### PR TITLE
Trim .mcp.json to vade-canvas and add local permissions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//Users/venpopov/.claude/**)",
+      "Bash(python3 -c \"import json; d=json.load\\(open\\('/Users/venpopov/.claude.json'\\)\\); print\\(d['projects']['/Users/venpopov/GitHub/vade-app/vade-core']['enabledMcpjsonServers']\\)\")",
+      "Bash(lsof -iTCP:7600 -sTCP:LISTEN)",
+      "Bash(grep -E \"claude$|tsx.*mcp\")",
+      "Bash(claude mcp *)",
+      "Bash(python3 -c ' *)",
+      "mcp__vade-canvas__getCanvasState",
+      "mcp__vade-canvas__listCanvases",
+      "mcp__vade-canvas__createShape",
+      "Bash(git commit -m ' *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git branch *)",
+      "Bash(git reset *)",
+      "Bash(git checkout *)",
+      "Bash(git push *)",
+      "Bash(gh pr *)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "vade-canvas"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,17 +5,6 @@
       "command": "npx",
       "args": ["tsx", "mcp/index.ts"],
       "cwd": "."
-    },
-    "mem0": {
-      "type": "http",
-      "url": "https://mcp.mem0.ai/mcp"
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_MCP_PAT}"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Drop `mem0` and `github` HTTP MCP entries from the shared `.mcp.json` so the repo only advertises the in-tree `vade-canvas` server.
- Add `.claude/settings.local.json` pre-allowing common `vade-canvas` MCP tools and the bash/read probes used to verify the server is up.

## Test plan
- [ ] `npm run dev` still boots cleanly
- [ ] `vade-canvas` MCP server starts and is reachable on the expected port
- [ ] Fresh Claude Code session in this repo sees only `vade-canvas` in its MCP server list

🤖 Generated with [Claude Code](https://claude.com/claude-code)