### PR TITLE
Add createBindings MCP tool and fix empty-response errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,12 @@
       "Bash(git reset *)",
       "Bash(git checkout *)",
       "Bash(git push *)",
-      "Bash(gh pr *)"
+      "Bash(gh pr *)",
+      "Bash(npx tsc *)",
+      "mcp__vade-canvas__createBindings",
+      "mcp__vade-canvas__deleteShapes",
+      "mcp__vade-canvas__queryShapes",
+      "mcp__vade-canvas__updateShape"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/mcp/protocol.ts
+++ b/mcp/protocol.ts
@@ -3,6 +3,7 @@ export type ServerMessage =
   | { type: 'updateShapes'; id: string; shapes: ShapeUpdate[] }
   | { type: 'deleteShapes'; id: string; ids: string[] }
   | { type: 'queryShapes'; id: string; filter?: { type?: string } }
+  | { type: 'createBindings'; id: string; bindings: BindingPartial[] }
   | { type: 'getSnapshot'; id: string }
   | { type: 'loadSnapshot'; id: string; snapshot: unknown }
 
@@ -25,6 +26,14 @@ export interface ShapeUpdate {
   x?: number
   y?: number
   props?: Record<string, unknown>
+}
+
+export interface BindingPartial {
+  type: string
+  fromId: string
+  toId: string
+  props?: Record<string, unknown>
+  meta?: Record<string, unknown>
 }
 
 let counter = 0

--- a/mcp/tools/shapes.ts
+++ b/mcp/tools/shapes.ts
@@ -36,7 +36,7 @@ export function registerShapeTools(server: McpServer, bridge: CanvasBridge) {
       id: makeId(),
       shapes: [{ id, type, x, y, props }],
     })
-    return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] }
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result ?? { ok: true }) }] }
   })
 
   server.registerTool('deleteShapes', {
@@ -49,6 +49,26 @@ export function registerShapeTools(server: McpServer, bridge: CanvasBridge) {
       type: 'deleteShapes',
       id: makeId(),
       ids,
+    })
+    return { content: [{ type: 'text' as const, text: JSON.stringify(result ?? { ok: true }) }] }
+  })
+
+  server.registerTool('createBindings', {
+    description: 'Create bindings between shapes (e.g. bind arrow terminals to shapes). For an arrow binding, set type="arrow", fromId=arrow shape id, toId=target shape id, and props={ terminal: "start"|"end", normalizedAnchor: {x,y}, isPrecise, isExact, snap }.',
+    inputSchema: {
+      bindings: z.array(z.object({
+        type: z.string().describe('Binding type (e.g. "arrow")'),
+        fromId: z.string().describe('Source shape ID (e.g. the arrow)'),
+        toId: z.string().describe('Target shape ID (e.g. the shape the arrow terminal attaches to)'),
+        props: z.record(z.string(), z.unknown()).optional().describe('Binding-type-specific properties'),
+        meta: z.record(z.string(), z.unknown()).optional(),
+      })).describe('Array of bindings to create'),
+    },
+  }, async ({ bindings }) => {
+    const result = await bridge.send({
+      type: 'createBindings',
+      id: makeId(),
+      bindings,
     })
     return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] }
   })

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -3,6 +3,7 @@ export type ServerMessage =
   | { type: 'updateShapes'; id: string; shapes: ShapeUpdate[] }
   | { type: 'deleteShapes'; id: string; ids: string[] }
   | { type: 'queryShapes'; id: string; filter?: { type?: string } }
+  | { type: 'createBindings'; id: string; bindings: BindingPartial[] }
   | { type: 'getSnapshot'; id: string }
   | { type: 'loadSnapshot'; id: string; snapshot: unknown }
 
@@ -25,4 +26,12 @@ export interface ShapeUpdate {
   x?: number
   y?: number
   props?: Record<string, unknown>
+}
+
+export interface BindingPartial {
+  type: string
+  fromId: string
+  toId: string
+  props?: Record<string, unknown>
+  meta?: Record<string, unknown>
 }

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -135,6 +135,21 @@ export class VadeBridge {
           break
         }
 
+        case 'createBindings': {
+          const beforeIds = new Set(
+            editor.store.allRecords()
+              .filter(r => r.typeName === 'binding')
+              .map(r => r.id)
+          )
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          editor.createBindings(msg.bindings as any)
+          const created = editor.store.allRecords()
+            .filter(r => r.typeName === 'binding' && !beforeIds.has(r.id))
+            .map(r => r.id)
+          this.reply(msg.id, true, created)
+          break
+        }
+
         case 'queryShapes': {
           let shapes = editor.getCurrentPageShapes()
           if (msg.filter?.type) {


### PR DESCRIPTION
## Summary
- Adds a `createBindings` message on the canvas bridge and an MCP tool so agents can bind arrow terminals (and other binding kinds) to shapes — arrows created over MCP were previously freestanding and didn't track their endpoint shapes.
- Handler diffs binding IDs before/after the call to return actual created IDs (`editor.createBinding` returns the editor itself, not the binding).
- Fixes `updateShape` and `deleteShapes` tool handlers: bridge reply carries no data for these, and `JSON.stringify(undefined)` produced content the MCP SDK rejected. Coalesces to `{ ok: true }`.

## Test plan
- [x] Typecheck passes (`npx tsc -b`)
- [x] Smoke test: created 8 circles + 8 arrows, bound all 16 arrow terminals via `createBindings` — returned IDs match `binding:*` records in the store, dragging a circle moves its arrows.
- [x] Smoke test: `updateShape` / `deleteShapes` now return `{"ok":true}` instead of erroring on invalid content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)