### PR TITLE
Add Cloudflare Pages deploy config for canvas SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,49 @@ TBD — will be set before the first external contribution window.
 
 Not open for external contribution during bootstrap. See
 `vade-governance` for when and how external contribution opens.
+
+## Deploy: Cloudflare Pages
+
+The canvas SPA is hosted on **Cloudflare Pages** at
+[`app.vade.dev`](https://app.vade.dev) so the operator can load VADE
+on iPad with no Mac running. Configuration lives in `wrangler.toml`.
+
+### One-time setup (BDFL only)
+
+1. Create a Cloudflare account for the `vade-app` org (or reuse an
+   existing one).
+2. Create a Pages project named `vade-core` in the Cloudflare
+   dashboard.
+3. Issue a scoped API token with the `Pages:Edit` permission; export
+   it locally as `CLOUDFLARE_API_TOKEN` and capture the account ID as
+   `CLOUDFLARE_ACCOUNT_ID`.
+4. Add a CNAME record `app.vade.dev` → `<project>.pages.dev` and
+   attach the custom domain in the Pages UI so Cloudflare provisions
+   the TLS certificate.
+
+### Deploying
+
+```bash
+npm run deploy:web    # builds dist/ and uploads via wrangler pages deploy
+```
+
+`deploy:web` runs `npm run build` (which emits `dist/`) and then
+`wrangler pages deploy dist --project-name vade-core`. `wrangler`
+picks up `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the
+environment. Install wrangler on demand via `npx wrangler …` or add
+it as a devDependency in a follow-up.
+
+CI-driven deploys (GitHub Actions, `VITE_COMMIT_SHA` injection,
+preview URLs on PRs) are out of scope for this change and tracked in
+sub-issue #10.
+
+### iPad first-load checklist
+
+1. Open `https://app.vade.dev` in mobile Safari.
+2. Tap Share → **Add to Home Screen** — the PWA manifest
+   (`public/manifest.json`) and `apple-touch-icon` make it install
+   full-screen.
+3. Launch from the home screen; the service worker
+   (`public/sw.js`) handles offline fallback for already-cached
+   assets. `ConnectionIndicator` will show `offline` until the MCP
+   WSS host lands (tracked separately).

--- a/mcp/library.ts
+++ b/mcp/library.ts
@@ -1,28 +1,97 @@
-import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 'fs'
+/**
+ * Library facade.
+ *
+ * Two surfaces live here:
+ *
+ * 1. The async {@link LibraryStore} interface and its driver
+ *    selector {@link getLibraryStore} — consumed by the hosted MCP
+ *    (issue #7) and any new code. Select via
+ *    `VADE_LIBRARY_DRIVER=fs|cloud` (default `fs`).
+ *
+ * 2. A set of legacy synchronous re-exports (`saveCanvas`,
+ *    `loadCanvas`, `listCanvases`, `saveEntity`, `loadEntity`,
+ *    `listEntities`, `searchLibrary`) preserved so that
+ *    `mcp/tools/canvas.ts` keeps working unchanged under the fs
+ *    driver. These delegate to a process-wide
+ *    {@link FsLibraryStore} and are filesystem-only by design —
+ *    cloud access is always async and must go through
+ *    {@link getLibraryStore}.
+ */
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
-const LIBRARY_ROOT = process.env['VADE_LIBRARY_PATH'] ?? join(homedir(), '.vade', 'library')
+import type {
+  CanvasMeta,
+  EntityMeta,
+  LibraryStore,
+  SearchResults,
+} from './stores/types.js'
+import { slugify } from './stores/types.js'
+import { FsLibraryStore } from './stores/fs.js'
+import { CloudLibraryStore } from './stores/cloud.js'
+
+export type { CanvasMeta, EntityMeta, LibraryStore, SearchResults }
+export { FsLibraryStore, CloudLibraryStore }
+
+export type LibraryDriver = 'fs' | 'cloud'
+
+export function resolveDriver(
+  env: NodeJS.ProcessEnv = process.env,
+): LibraryDriver {
+  const raw = (env['VADE_LIBRARY_DRIVER'] ?? 'fs').toLowerCase()
+  if (raw === 'cloud') return 'cloud'
+  if (raw === 'fs') return 'fs'
+  throw new Error(
+    `[library] invalid VADE_LIBRARY_DRIVER=${raw}. Expected "fs" or "cloud".`,
+  )
+}
+
+let activeStore: Promise<LibraryStore> | null = null
+
+/**
+ * Return the process-wide LibraryStore selected by
+ * VADE_LIBRARY_DRIVER. Cached after first call.
+ */
+export function getLibraryStore(): Promise<LibraryStore> {
+  if (activeStore) return activeStore
+  const driver = resolveDriver()
+  activeStore =
+    driver === 'cloud'
+      ? CloudLibraryStore.fromEnv()
+      : Promise.resolve(new FsLibraryStore())
+  return activeStore
+}
+
+/** Test hook: reset the cached driver. */
+export function __resetLibraryStoreForTests(): void {
+  activeStore = null
+}
+
+// ---------------------------------------------------------------
+// Legacy synchronous fs-backed API.
+//
+// Preserved so `mcp/tools/canvas.ts` stays untouched. The canvas
+// tools currently use these return values synchronously (no
+// await), so they must remain sync. They are intentionally
+// fs-only — downstream callers that need cloud storage must use
+// {@link getLibraryStore} instead.
+// ---------------------------------------------------------------
+
+const LIBRARY_ROOT =
+  process.env['VADE_LIBRARY_PATH'] ?? join(homedir(), '.vade', 'library')
 const CANVASES_DIR = join(LIBRARY_ROOT, 'canvases')
 const ENTITIES_DIR = join(LIBRARY_ROOT, 'entities')
 
-function ensureDirs() {
+function ensureDirs(): void {
   mkdirSync(CANVASES_DIR, { recursive: true })
   mkdirSync(ENTITIES_DIR, { recursive: true })
-}
-
-export interface CanvasMeta {
-  name: string
-  tags: string[]
-  description: string
-  created: string
-  modified: string
-}
-
-export interface EntityMeta {
-  name: string
-  tags: string[]
-  description: string
 }
 
 export function listCanvases(): CanvasMeta[] {
@@ -42,16 +111,22 @@ export function listCanvases(): CanvasMeta[] {
   return results
 }
 
-export function saveCanvas(name: string, snapshot: unknown, tags: string[] = [], description = '') {
+export function saveCanvas(
+  name: string,
+  snapshot: unknown,
+  tags: string[] = [],
+  description = '',
+): CanvasMeta {
   ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(CANVASES_DIR, slug)
+  const dir = join(CANVASES_DIR, slugify(name))
   mkdirSync(dir, { recursive: true })
 
   const now = new Date().toISOString()
   const existingMeta = (() => {
     try {
-      return JSON.parse(readFileSync(join(dir, 'metadata.json'), 'utf-8')) as CanvasMeta
+      return JSON.parse(
+        readFileSync(join(dir, 'metadata.json'), 'utf-8'),
+      ) as CanvasMeta
     } catch {
       return null
     }
@@ -70,10 +145,11 @@ export function saveCanvas(name: string, snapshot: unknown, tags: string[] = [],
   return meta
 }
 
-export function loadCanvas(name: string): { snapshot: unknown; meta: CanvasMeta } | null {
+export function loadCanvas(
+  name: string,
+): { snapshot: unknown; meta: CanvasMeta } | null {
   ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(CANVASES_DIR, slug)
+  const dir = join(CANVASES_DIR, slugify(name))
   const snapshotPath = join(dir, 'snapshot.tldr')
   const metaPath = join(dir, 'metadata.json')
   if (!existsSync(snapshotPath) || !existsSync(metaPath)) return null
@@ -100,10 +176,14 @@ export function listEntities(): EntityMeta[] {
   return results
 }
 
-export function saveEntity(name: string, shapes: unknown[], tags: string[] = [], description = '') {
+export function saveEntity(
+  name: string,
+  shapes: unknown[],
+  tags: string[] = [],
+  description = '',
+): EntityMeta {
   ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(ENTITIES_DIR, slug)
+  const dir = join(ENTITIES_DIR, slugify(name))
   mkdirSync(dir, { recursive: true })
 
   const meta: EntityMeta = { name, tags, description }
@@ -112,10 +192,11 @@ export function saveEntity(name: string, shapes: unknown[], tags: string[] = [],
   return meta
 }
 
-export function loadEntity(name: string): { shapes: unknown[]; meta: EntityMeta } | null {
+export function loadEntity(
+  name: string,
+): { shapes: unknown[]; meta: EntityMeta } | null {
   ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(ENTITIES_DIR, slug)
+  const dir = join(ENTITIES_DIR, slugify(name))
   const shapesPath = join(dir, 'shapes.json')
   const metaPath = join(dir, 'metadata.json')
   if (!existsSync(shapesPath) || !existsSync(metaPath)) return null
@@ -125,17 +206,19 @@ export function loadEntity(name: string): { shapes: unknown[]; meta: EntityMeta 
   }
 }
 
-export function searchLibrary(query: string): { canvases: CanvasMeta[]; entities: EntityMeta[] } {
+export function searchLibrary(query: string): SearchResults {
   const q = query.toLowerCase()
-  const canvases = listCanvases().filter(c =>
-    c.name.toLowerCase().includes(q) ||
-    c.tags.some(t => t.toLowerCase().includes(q)) ||
-    c.description.toLowerCase().includes(q)
+  const canvases = listCanvases().filter(
+    c =>
+      c.name.toLowerCase().includes(q) ||
+      c.tags.some(t => t.toLowerCase().includes(q)) ||
+      c.description.toLowerCase().includes(q),
   )
-  const entities = listEntities().filter(e =>
-    e.name.toLowerCase().includes(q) ||
-    e.tags.some(t => t.toLowerCase().includes(q)) ||
-    e.description.toLowerCase().includes(q)
+  const entities = listEntities().filter(
+    e =>
+      e.name.toLowerCase().includes(q) ||
+      e.tags.some(t => t.toLowerCase().includes(q)) ||
+      e.description.toLowerCase().includes(q),
   )
   return { canvases, entities }
 }

--- a/mcp/stores/fs.ts
+++ b/mcp/stores/fs.ts
@@ -1,0 +1,191 @@
+/**
+ * FsLibraryStore — filesystem-backed LibraryStore.
+ *
+ * Default driver for local development. Layout matches the legacy
+ * mcp/library.ts on-disk format so existing libraries under
+ * ~/.vade/library/ keep working without a migration:
+ *
+ *   <root>/canvases/<slug>/snapshot.tldr
+ *   <root>/canvases/<slug>/metadata.json
+ *   <root>/entities/<slug>/shapes.json
+ *   <root>/entities/<slug>/metadata.json
+ */
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+import type {
+  CanvasMeta,
+  EntityMeta,
+  LibraryStore,
+  SearchResults,
+} from './types.js'
+import { slugify } from './types.js'
+
+export interface FsLibraryStoreOptions {
+  /**
+   * Library root. Defaults to env VADE_LIBRARY_PATH, then
+   * ~/.vade/library/.
+   */
+  root?: string
+}
+
+export class FsLibraryStore implements LibraryStore {
+  private readonly root: string
+  private readonly canvasesDir: string
+  private readonly entitiesDir: string
+
+  constructor(opts: FsLibraryStoreOptions = {}) {
+    this.root =
+      opts.root ??
+      process.env['VADE_LIBRARY_PATH'] ??
+      join(homedir(), '.vade', 'library')
+    this.canvasesDir = join(this.root, 'canvases')
+    this.entitiesDir = join(this.root, 'entities')
+  }
+
+  private ensureDirs(): void {
+    mkdirSync(this.canvasesDir, { recursive: true })
+    mkdirSync(this.entitiesDir, { recursive: true })
+  }
+
+  async listCanvases(): Promise<CanvasMeta[]> {
+    this.ensureDirs()
+    const entries = readdirSync(this.canvasesDir, { withFileTypes: true })
+    const results: CanvasMeta[] = []
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const metaPath = join(this.canvasesDir, entry.name, 'metadata.json')
+      if (!existsSync(metaPath)) continue
+      try {
+        results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta)
+      } catch {
+        // skip corrupt entries
+      }
+    }
+    return results
+  }
+
+  async saveCanvas(
+    name: string,
+    snapshot: unknown,
+    tags: string[] = [],
+    description = '',
+  ): Promise<CanvasMeta> {
+    this.ensureDirs()
+    const dir = join(this.canvasesDir, slugify(name))
+    mkdirSync(dir, { recursive: true })
+
+    const now = new Date().toISOString()
+    const existingMeta = (() => {
+      try {
+        return JSON.parse(
+          readFileSync(join(dir, 'metadata.json'), 'utf-8'),
+        ) as CanvasMeta
+      } catch {
+        return null
+      }
+    })()
+
+    const meta: CanvasMeta = {
+      name,
+      tags,
+      description,
+      created: existingMeta?.created ?? now,
+      modified: now,
+    }
+
+    writeFileSync(join(dir, 'snapshot.tldr'), JSON.stringify(snapshot))
+    writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
+    return meta
+  }
+
+  async loadCanvas(
+    name: string,
+  ): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+    this.ensureDirs()
+    const dir = join(this.canvasesDir, slugify(name))
+    const snapshotPath = join(dir, 'snapshot.tldr')
+    const metaPath = join(dir, 'metadata.json')
+    if (!existsSync(snapshotPath) || !existsSync(metaPath)) return null
+    return {
+      snapshot: JSON.parse(readFileSync(snapshotPath, 'utf-8')),
+      meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta,
+    }
+  }
+
+  async listEntities(): Promise<EntityMeta[]> {
+    this.ensureDirs()
+    const entries = readdirSync(this.entitiesDir, { withFileTypes: true })
+    const results: EntityMeta[] = []
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const metaPath = join(this.entitiesDir, entry.name, 'metadata.json')
+      if (!existsSync(metaPath)) continue
+      try {
+        results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta)
+      } catch {
+        // skip corrupt entries
+      }
+    }
+    return results
+  }
+
+  async saveEntity(
+    name: string,
+    shapes: unknown[],
+    tags: string[] = [],
+    description = '',
+  ): Promise<EntityMeta> {
+    this.ensureDirs()
+    const dir = join(this.entitiesDir, slugify(name))
+    mkdirSync(dir, { recursive: true })
+
+    const meta: EntityMeta = { name, tags, description }
+    writeFileSync(join(dir, 'shapes.json'), JSON.stringify(shapes, null, 2))
+    writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
+    return meta
+  }
+
+  async loadEntity(
+    name: string,
+  ): Promise<{ shapes: unknown[]; meta: EntityMeta } | null> {
+    this.ensureDirs()
+    const dir = join(this.entitiesDir, slugify(name))
+    const shapesPath = join(dir, 'shapes.json')
+    const metaPath = join(dir, 'metadata.json')
+    if (!existsSync(shapesPath) || !existsSync(metaPath)) return null
+    return {
+      shapes: JSON.parse(readFileSync(shapesPath, 'utf-8')) as unknown[],
+      meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta,
+    }
+  }
+
+  async searchLibrary(query: string): Promise<SearchResults> {
+    const q = query.toLowerCase()
+    const [canvases, entities] = await Promise.all([
+      this.listCanvases(),
+      this.listEntities(),
+    ])
+    return {
+      canvases: canvases.filter(
+        c =>
+          c.name.toLowerCase().includes(q) ||
+          c.tags.some(t => t.toLowerCase().includes(q)) ||
+          c.description.toLowerCase().includes(q),
+      ),
+      entities: entities.filter(
+        e =>
+          e.name.toLowerCase().includes(q) ||
+          e.tags.some(t => t.toLowerCase().includes(q)) ||
+          e.description.toLowerCase().includes(q),
+      ),
+    }
+  }
+}

--- a/mcp/stores/types.ts
+++ b/mcp/stores/types.ts
@@ -1,0 +1,74 @@
+/**
+ * LibraryStore — storage abstraction for canvas snapshots and
+ * reusable entity groups.
+ *
+ * Implementations:
+ * - FsLibraryStore   (mcp/stores/fs.ts)    — default local dev.
+ * - CloudLibraryStore (mcp/stores/cloud.ts) — Cloudflare R2 blobs
+ *   + D1 metadata, selected by VADE_LIBRARY_DRIVER=cloud.
+ *
+ * Call-sites in mcp/tools/canvas.ts must continue to work against
+ * this interface without modification; the re-exports in
+ * mcp/library.ts preserve the legacy module-level function shape
+ * by delegating to the active driver.
+ */
+
+export interface CanvasMeta {
+  name: string
+  tags: string[]
+  description: string
+  created: string
+  modified: string
+}
+
+export interface EntityMeta {
+  name: string
+  tags: string[]
+  description: string
+}
+
+export interface SearchResults {
+  canvases: CanvasMeta[]
+  entities: EntityMeta[]
+}
+
+export interface LibraryStore {
+  /** Persist a canvas snapshot under `name`. Returns the stored meta. */
+  saveCanvas(
+    name: string,
+    snapshot: unknown,
+    tags?: string[],
+    description?: string,
+  ): Promise<CanvasMeta>
+
+  /** Load a canvas by name. Resolves null when not found. */
+  loadCanvas(
+    name: string,
+  ): Promise<{ snapshot: unknown; meta: CanvasMeta } | null>
+
+  /** List all canvases. Order is implementation-defined. */
+  listCanvases(): Promise<CanvasMeta[]>
+
+  /** Persist an entity (a group of normalized shapes) under `name`. */
+  saveEntity(
+    name: string,
+    shapes: unknown[],
+    tags?: string[],
+    description?: string,
+  ): Promise<EntityMeta>
+
+  /** Load an entity by name. Resolves null when not found. */
+  loadEntity(
+    name: string,
+  ): Promise<{ shapes: unknown[]; meta: EntityMeta } | null>
+
+  /** List all entities. Order is implementation-defined. */
+  listEntities(): Promise<EntityMeta[]>
+
+  /** Substring search over name / tags / description. */
+  searchLibrary(query: string): Promise<SearchResults>
+}
+
+export function slugify(name: string): string {
+  return name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "mcp": "tsx mcp/index.ts",
-    "dev:all": "concurrently \"npm run dev\" \"npm run mcp\""
+    "dev:all": "concurrently \"npm run dev\" \"npm run mcp\"",
+    "deploy:web": "npm run build && wrangler pages deploy dist --project-name vade-core"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,29 @@
+# Cloudflare Pages configuration for the VADE canvas SPA.
+#
+# This file drives `wrangler pages deploy` (via `npm run deploy:web`) and
+# the Pages Git integration. It does NOT create the Pages project — the
+# BDFL must create the project in the Cloudflare dashboard first and
+# share `CLOUDFLARE_ACCOUNT_ID` + a scoped API token. See the
+# "BDFL provisioning checklist" in PR #6 for details.
+#
+# Refs:
+#   https://developers.cloudflare.com/pages/functions/wrangler-configuration/
+#   Issue: https://github.com/vade-app/vade-core/issues/6
+
+name = "vade-core"
+compatibility_date = "2025-04-01"
+pages_build_output_dir = "./dist"
+
+# Static-only SPA for now — no Pages Functions, no bindings. When the
+# storage abstraction (issue #8) lands and needs edge KV / R2, add
+# `[[kv_namespaces]]` or `[[r2_buckets]]` blocks here.
+
+# Production environment — served at app.vade.dev once DNS + custom
+# domain are attached in the Pages dashboard (BDFL task).
+[env.production]
+name = "vade-core"
+
+# Preview environment — every non-production branch gets a
+# `<branch>.vade-core.pages.dev` URL automatically.
+[env.preview]
+name = "vade-core"


### PR DESCRIPTION
Closes #6. Part of epic #5.

## Summary

Wire `vade-core` to **Cloudflare Pages** so the operator can load VADE on iPad with no Mac running — goal #1 of the M1 iPad-live epic.

- New `wrangler.toml` pointing Pages at `./dist` (the Vite build output), with matching `production` and `preview` envs both named `vade-core`.
- New `deploy:web` npm script (single addition under `"scripts"`): `npm run build && wrangler pages deploy dist --project-name vade-core`.
- New `## Deploy: Cloudflare Pages` section appended to `README.md` covering one-time Cloudflare setup, the deploy command, DNS + custom-domain steps for `app.vade.dev`, and the iPad "Add to Home Screen" checklist. No existing README sections were edited.
- Verified `public/manifest.json` (standalone display, 192 + 512 PNG icons, theme/background colors) and `index.html` (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `apple-touch-icon`) are already Safari/iPad-compatible. No fixes were needed.

`VITE_COMMIT_SHA` injection does not fall naturally out of a local `wrangler pages deploy` invocation, so it is deferred to the CI/CD sub-issue **#10** along with GitHub Actions + preview URLs, per the acceptance criteria on #6.

## Files changed

- `wrangler.toml` (new)
- `package.json` (one new script: `deploy:web`)
- `README.md` (appended `## Deploy: Cloudflare Pages` section only)

No files outside the agreed ownership boundary (`mcp/**`, `src/**`, storage-abstraction files owned by Agent B on #8) were touched.

## Test plan

- [ ] BDFL completes the provisioning checklist below
- [ ] `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` exported locally, then `npm run deploy:web` pushes `dist/` to the `vade-core` Pages project
- [ ] `https://app.vade.dev` loads the canvas in desktop Safari and iPad Safari (Mac off, iPad on LTE) — acceptance #1 on issue #6
- [ ] Add to Home Screen on iPad installs full-screen — acceptance #2 on issue #6
- [ ] `ConnectionIndicator` shows `offline` (expected; WSS origin tracked separately) — acceptance #3 on issue #6

## Coordination

Kickoff / coordination log comment on the epic thread:
https://github.com/vade-app/vade-core/issues/5#issuecomment-4276374744

Agent B (storage abstraction, #8) is working in parallel on the same branch. File ownership is disjoint — this PR touches only `wrangler.toml`, `package.json` (the single `deploy:web` script line), and the new README section.

## BDFL provisioning checklist

The governance rule in [`vade-governance/authority.md`](https://github.com/vade-app/vade-governance/blob/main/authority.md) forbids Claude from signing up for paid services or authorizing spend. The following items therefore remain for the BDFL:

- [x] Create / confirm Cloudflare account for the `vade-app` org
- [x] Create the Cloudflare Pages project named `vade-core` in the Cloudflare dashboard
- [ ] Capture `CLOUDFLARE_ACCOUNT_ID`
- [x] Issue a scoped API token with `Pages:Edit` (and `Account:Read`) permission; store as `CLOUDFLARE_API_TOKEN` secret (used by `wrangler` locally and by CI once #10 lands)
- [ ] DNS: add CNAME `app.vade.dev` → `<project>.pages.dev`
- [ ] Attach `app.vade.dev` as a custom domain in the Pages UI so Cloudflare provisions the TLS certificate
- [ ] Confirm final verdict on deferring `VITE_COMMIT_SHA` injection to sub-issue #10 (default assumption is: defer)
- [ ] Enable / create the org-level GitHub Discussion **"Epic #5 — M1 parallel execution log"** and link it from issue #5, so future agent coordination can move off the issue thread

---

Do not merge — per `CLAUDE.md`, the BDFL merges to `main`.