### PR TITLE
Declare apex and www as custom domains in wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,10 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "vade-core",
   "compatibility_date": "2026-04-19",
+  "routes": [
+    { "pattern": "vade-app.dev", "custom_domain": true },
+    { "pattern": "www.vade-app.dev", "custom_domain": true }
+  ],
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- Cloudflare dashboard warns that `www.vade-app.dev` does not resolve (only the apex `vade-app.dev` has a Worker DNS record).
- Declare both `vade-app.dev` and `www.vade-app.dev` as `custom_domain` routes in `wrangler.jsonc` so `wrangler deploy` creates and manages the Worker DNS record for `www` alongside the apex.

## Test plan
- [ ] `wrangler deploy` from `vade-core` completes without route conflicts (may prompt to adopt the existing apex custom domain on first run).
- [ ] Cloudflare DNS tab shows a second "Worker / Proxied" row for `www.vade-app.dev`.
- [ ] `curl -I https://www.vade-app.dev` returns a response from the Worker.
- [ ] The "Add an A, AAAA, or CNAME record for www" recommendation clears in the Cloudflare dashboard.

https://claude.ai/code/session_01PZzkbg7F4SJtyP1PDEKnHu