### PR TITLE
Match page protocol when constructing bridge WebSocket URL

### DIFF
--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -1,7 +1,7 @@
 import type { Editor } from '@tldraw/editor'
 import type { ServerMessage, ClientMessage } from './protocol'
 
-const WS_URL = `ws://${window.location.hostname}:7600`
+const WS_URL = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:7600`
 
 export type BridgeStatus = 'disconnected' | 'connecting' | 'connected'
 type StatusListener = (status: BridgeStatus) => void


### PR DESCRIPTION
## Summary
- The bridge WebSocket URL was hardcoded to `ws://`, so on `https://vade-app.dev` the browser blocked it as mixed content and `new WebSocket(...)` threw `SecurityError`, triggering the canvas error boundary ("Something went wrong").
- Pick `wss://` when the page is served over HTTPS so the constructor succeeds. When no bridge server is listening (the normal production case) the connection just fails silently through the existing `onerror` → reconnect loop, which is the pre-existing behavior on localhost too.

## Test plan
- [ ] `npm run build` succeeds.
- [ ] On `https://vade-app.dev` the canvas loads instead of showing the error screen.
- [ ] On local dev (`http://localhost:5173`) the bridge still connects to `ws://localhost:7600` when the MCP server is running.
- [ ] DevTools no longer shows the `SecurityError: Failed to construct 'WebSocket'` exception.

## Follow-up (not in this PR)
The bridge still attempts to connect forever in production where no server exists. Consider gating `VadeBridge.connect()` on `import.meta.env.DEV` or on a localhost hostname check.

https://claude.ai/code/session_01PZzkbg7F4SJtyP1PDEKnHu