### PR TITLE
Document live vade-app.dev hosting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ build interactive tools on an infinite canvas.
 
 ## Status
 
-**Pre-alpha.** Canvas shell scaffolded with tldraw SDK. MCP server
-and custom shapes in progress.
+**Pre-alpha.** Canvas is live at **https://vade-app.dev** (served
+from a Cloudflare Worker). MCP server and custom shapes still in
+progress — the hosted app currently runs canvas-only; the bridge
+to a hosted MCP endpoint is tracked under issue #7.
 
 ## What this repo contains
 
@@ -34,8 +36,26 @@ npm run dev           # start Vite dev server (LAN-accessible on :5173)
 npm run build         # production build
 ```
 
-Access from iPad: open `http://<your-mac-ip>:5173` in Safari, then
-Add to Home Screen for full-screen PWA mode.
+Access the local dev server from iPad by opening
+`http://<your-mac-ip>:5173` in Safari, then Add to Home Screen for
+full-screen PWA mode. For the hosted app, open
+[https://vade-app.dev](https://vade-app.dev) and Add to Home Screen.
+
+## Deploy
+
+The canvas SPA is deployed as a **Cloudflare Worker** that serves
+the Vite-built static assets (`dist/`). Configuration lives in
+`wrangler.jsonc`:
+
+- `assets.not_found_handling: "single-page-application"` — SPA
+  routing fallback to `index.html`.
+- `routes` — both `vade-app.dev` and `www.vade-app.dev` are
+  attached as `custom_domain` routes; DNS and TLS are managed by
+  Cloudflare.
+
+Deploys are triggered by Cloudflare's Git integration on push to
+`main` (one build per push, auto-deploys to the custom domains).
+CI/CD via GitHub Actions is tracked under issue #10.
 
 ## Governance
 


### PR DESCRIPTION
## Summary
- Update `Status` to reflect that the canvas is now live at **https://vade-app.dev** via a Cloudflare Worker.
- Extend `Getting started` with both the local dev instructions (unchanged) and the hosted URL for iPad Add to Home Screen.
- Add a short `Deploy` section documenting `wrangler.jsonc`, the `custom_domain` routes for apex + `www`, and the current Cloudflare Git-push deploy flow, with a pointer to #10 for future GitHub Actions CI.

## Context
The SPA hosting path (originally issue #6 / PR #19) landed as a Cloudflare **Worker** rather than Pages, at `vade-app.dev` rather than `app.vade.dev`. See the status update on epic #5 for the full picture.

## Test plan
- [x] README renders correctly on GitHub.
- [x] No stale references to Pages or `app.vade.dev` in the doc.

https://claude.ai/code/session_01PZzkbg7F4SJtyP1PDEKnHu