### PR TITLE
Hosted MCP server with HTTP/SSE + public WSS bridge (Fly.io)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,15 @@
       "mcp__vade-canvas__createBindings",
       "mcp__vade-canvas__deleteShapes",
       "mcp__vade-canvas__queryShapes",
-      "mcp__vade-canvas__updateShape"
+      "mcp__vade-canvas__updateShape",
+      "Bash(git *)",
+      "Bash(curl -sI https://mcp.vade.dev/healthz)",
+      "Bash(curl -sIv https://mcp.vade.dev/healthz)",
+      "Bash(curl -sI https://vade-mcp.fly.dev/healthz)",
+      "Bash(host mcp.vade.dev)",
+      "Bash(host vade-mcp.fly.dev)",
+      "Bash(curl -s https://vade-mcp.fly.dev/healthz)",
+      "Bash(curl -sI -X GET --max-time 3 https://vade-mcp.fly.dev/sse)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,5 +28,8 @@
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "vade-canvas"
-  ]
+  ],
+  "remote": {
+    "defaultEnvironmentId": "env_01PfLi963eMBv5LgFZuc1HNZ"
+  }
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.claude
+.devcontainer
+node_modules
+dist
+.vade
+.env
+.env.*
+*.md
+src
+public
+index.html
+vite.config.ts
+wrangler.jsonc
+.mcp.json
+.gitignore

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "vade-canvas": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["tsx", "mcp/index.ts"],
-      "cwd": "."
+      "type": "sse",
+      "url": "https://mcp.vade.dev/sse"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "vade-canvas": {
       "type": "sse",
-      "url": "https://mcp.vade.dev/sse"
+      "url": "https://mcp.vade-app.dev/sse"
     }
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV VADE_MCP_TRANSPORT=sse
 ENV VADE_MCP_HTTP_PORT=8080
 ENV VADE_LIBRARY_PATH=/home/node/.vade/library
 ENV NODE_ENV=production
+ENV VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM ghcr.io/vade-app/vade-runtime:latest
+FROM node:20.19.1-bookworm-slim
+
+RUN npm install -g tsx@4.21.0 && npm cache clean --force
+
+# Ephemeral today; backed by a Fly volume once storage-abstraction lands.
+RUN mkdir -p /home/node/.vade/library/canvases \
+             /home/node/.vade/library/entities \
+    && chown -R node:node /home/node/.vade
 
 USER node
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/vade-app/vade-runtime:latest
+
+USER node
+WORKDIR /app
+
+COPY --chown=node:node package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --chown=node:node tsconfig.json tsconfig.node.json ./
+COPY --chown=node:node mcp ./mcp
+
+ENV VADE_MCP_TRANSPORT=sse
+ENV VADE_MCP_HTTP_PORT=8080
+ENV VADE_LIBRARY_PATH=/home/node/.vade/library
+ENV NODE_ENV=production
+
+EXPOSE 8080
+
+CMD ["tsx", "mcp/index.ts"]

--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,7 @@ primary_region = 'fra'
   VADE_MCP_TRANSPORT = 'sse'
   VADE_MCP_HTTP_PORT = '8080'
   VADE_LIBRARY_PATH = '/home/node/.vade/library'
-  VITE_BRIDGE_URL=''wss://mcp.vade-app.dev/canvas''
+  VITE_BRIDGE_URL = 'wss://mcp.vade-app.dev/canvas'
 
 [http_service]
   internal_port = 8080

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = 'vade-mcp'
-primary_region = 'sea'
+primary_region = 'fra'
 
 [build]
   dockerfile = 'Dockerfile'

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,7 @@ primary_region = 'fra'
   VADE_MCP_TRANSPORT = 'sse'
   VADE_MCP_HTTP_PORT = '8080'
   VADE_LIBRARY_PATH = '/home/node/.vade/library'
+  VITE_BRIDGE_URL=''wss://mcp.vade-app.dev/canvas''
 
 [http_service]
   internal_port = 8080

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,36 @@
+app = 'vade-mcp'
+primary_region = 'sea'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[env]
+  VADE_MCP_TRANSPORT = 'sse'
+  VADE_MCP_HTTP_PORT = '8080'
+  VADE_LIBRARY_PATH = '/home/node/.vade/library'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/healthz'
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 512
+
+# Enable once the storage-abstraction sub-issue lands and a
+# `vade_library` volume has been created via `flyctl volumes create`.
+# [[mounts]]
+#   source = 'vade_library'
+#   destination = '/home/node/.vade'

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -1,22 +1,139 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { CanvasBridge } from './ws-server.js'
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
+import { CanvasBridge, DEFAULT_WS_PORT } from './ws-server.js'
 import { registerShapeTools } from './tools/shapes.js'
 import { registerCanvasTools } from './tools/canvas.js'
 import { registerRuntimeTools } from './tools/runtime.js'
 
-const server = new McpServer({
-  name: 'vade-canvas',
-  version: '0.1.0',
-})
+function buildServer(bridge: CanvasBridge): McpServer {
+  const server = new McpServer({ name: 'vade-canvas', version: '0.1.0' })
+  registerShapeTools(server, bridge)
+  registerCanvasTools(server, bridge)
+  registerRuntimeTools(server, bridge)
+  return server
+}
 
-const bridge = new CanvasBridge()
+async function runStdio() {
+  const bridge = new CanvasBridge({ mode: 'standalone', port: DEFAULT_WS_PORT, host: '0.0.0.0' })
+  const server = buildServer(bridge)
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  console.error(`[vade-canvas] MCP server running on stdio, WebSocket bridge on :${DEFAULT_WS_PORT}`)
+}
 
-registerShapeTools(server, bridge)
-registerCanvasTools(server, bridge)
-registerRuntimeTools(server, bridge)
+async function runSse() {
+  const port = Number(process.env['VADE_MCP_HTTP_PORT'] ?? 8080)
+  const messagesPath = '/messages'
+  const ssePath = '/sse'
+  const canvasPath = '/canvas'
 
-const transport = new StdioServerTransport()
-await server.connect(transport)
+  type Session = { server: McpServer; transport: SSEServerTransport }
+  const sessions = new Map<string, Session>()
 
-console.error('[vade-canvas] MCP server running on stdio, WebSocket bridge on :7600')
+  const setCors = (res: ServerResponse) => {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id')
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id')
+  }
+
+  const httpServer = createServer()
+  const bridge = new CanvasBridge({ mode: 'attached', server: httpServer, path: canvasPath })
+
+  httpServer.on('request', async (req: IncomingMessage, res: ServerResponse) => {
+    setCors(res)
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`)
+
+    if (req.method === 'GET' && url.pathname === '/healthz') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('ok')
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === ssePath) {
+      const transport = new SSEServerTransport(messagesPath, res)
+      const server = buildServer(bridge)
+
+      const sessionId = transport.sessionId
+      sessions.set(sessionId, { server, transport })
+      console.error(`[vade-canvas] SSE session open ${sessionId} (total=${sessions.size})`)
+
+      const cleanup = () => {
+        if (!sessions.has(sessionId)) return
+        sessions.delete(sessionId)
+        console.error(`[vade-canvas] SSE session close ${sessionId} (total=${sessions.size})`)
+        void server.close().catch(() => {})
+      }
+      transport.onclose = cleanup
+      res.on('close', cleanup)
+
+      try {
+        await server.connect(transport)
+      } catch (err) {
+        console.error('[vade-canvas] Failed to start SSE session:', err)
+        cleanup()
+      }
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === messagesPath) {
+      const sid = url.searchParams.get('sessionId')
+      const session = sid ? sessions.get(sid) : undefined
+      if (!session) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' })
+        res.end('Unknown sessionId')
+        return
+      }
+      try {
+        await session.transport.handlePostMessage(req, res)
+      } catch (err) {
+        console.error('[vade-canvas] handlePostMessage error:', err)
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'text/plain' })
+          res.end('Internal error')
+        }
+      }
+      return
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('Not found')
+  })
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(port, '0.0.0.0', () => resolve())
+  })
+  console.error(`[vade-canvas] SSE + WSS on :${port} (sse=${ssePath}, canvas=${canvasPath})`)
+
+  const shutdown = async () => {
+    console.error('[vade-canvas] Shutting down…')
+    for (const [id, s] of sessions) {
+      sessions.delete(id)
+      await s.server.close().catch(() => {})
+    }
+    await bridge.close()
+    httpServer.close()
+    process.exit(0)
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+}
+
+const mode = process.env['VADE_MCP_TRANSPORT'] ?? 'stdio'
+if (mode === 'stdio') {
+  await runStdio()
+} else if (mode === 'sse') {
+  await runSse()
+} else {
+  console.error(`[vade-canvas] Unknown VADE_MCP_TRANSPORT=${mode}; expected 'stdio' or 'sse'`)
+  process.exit(1)
+}

--- a/mcp/ws-server.ts
+++ b/mcp/ws-server.ts
@@ -1,7 +1,13 @@
+import type { IncomingMessage, Server as HttpServer } from 'node:http'
+import type { Duplex } from 'node:stream'
 import { WebSocketServer, WebSocket } from 'ws'
 import type { ServerMessage, ClientMessage } from './protocol.js'
 
-const WS_PORT = 7600
+export const DEFAULT_WS_PORT = 7600
+
+export type CanvasBridgeOptions =
+  | { mode: 'standalone'; port?: number; host?: string }
+  | { mode: 'attached'; server: HttpServer; path: string }
 
 type PendingRequest = {
   resolve: (data: unknown) => void
@@ -11,11 +17,39 @@ type PendingRequest = {
 
 export class CanvasBridge {
   private wss: WebSocketServer
+  private mode: CanvasBridgeOptions['mode']
   private canvas: WebSocket | null = null
   private pending = new Map<string, PendingRequest>()
+  private upgradeHandler?: (req: IncomingMessage, socket: Duplex, head: Buffer) => void
+  private attachedServer?: HttpServer
 
-  constructor() {
-    this.wss = new WebSocketServer({ port: WS_PORT, host: '0.0.0.0' })
+  constructor(options: CanvasBridgeOptions = { mode: 'standalone' }) {
+    this.mode = options.mode
+
+    if (options.mode === 'standalone') {
+      const port = options.port ?? DEFAULT_WS_PORT
+      const host = options.host ?? '0.0.0.0'
+      this.wss = new WebSocketServer({ port, host })
+      console.error(`[bridge] WebSocket server listening on ${host}:${port}`)
+    } else {
+      this.wss = new WebSocketServer({ noServer: true })
+      this.attachedServer = options.server
+      const path = options.path
+      this.upgradeHandler = (req, socket, head) => {
+        if (!req.url) {
+          socket.destroy()
+          return
+        }
+        const url = new URL(req.url, 'http://localhost')
+        if (url.pathname !== path) return
+        this.wss.handleUpgrade(req, socket, head, (ws) => {
+          this.wss.emit('connection', ws, req)
+        })
+      }
+      options.server.on('upgrade', this.upgradeHandler)
+      console.error(`[bridge] WebSocket upgrade handler attached on path ${path}`)
+    }
+
     this.wss.on('connection', (ws) => {
       this.canvas = ws
       console.error(`[bridge] Canvas connected`)
@@ -39,8 +73,6 @@ export class CanvasBridge {
         }
       })
     })
-
-    console.error(`[bridge] WebSocket server listening on :${WS_PORT}`)
   }
 
   get isConnected(): boolean {
@@ -85,6 +117,9 @@ export class CanvasBridge {
   }
 
   async close() {
+    if (this.mode === 'attached' && this.attachedServer && this.upgradeHandler) {
+      this.attachedServer.off('upgrade', this.upgradeHandler)
+    }
     this.wss.close()
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "npm run build && wrangler dev",
     "mcp": "tsx mcp/index.ts",
+    "mcp:stdio": "tsx mcp/index.ts",
+    "mcp:sse": "VADE_MCP_TRANSPORT=sse VADE_MCP_HTTP_PORT=8080 tsx mcp/index.ts",
     "dev:all": "concurrently \"npm run dev\" \"npm run mcp\"",
     "deploy": "npm run build && wrangler deploy"
   },

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -1,7 +1,9 @@
 import type { Editor } from '@tldraw/editor'
 import type { ServerMessage, ClientMessage } from './protocol'
 
-const WS_URL = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:7600`
+const WS_URL =
+  (import.meta.env.VITE_BRIDGE_URL as string | undefined) ??
+  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:7600`
 
 export type BridgeStatus = 'disconnected' | 'connecting' | 'connected'
 type StatusListener = (status: BridgeStatus) => void


### PR DESCRIPTION
Closes #7.

## Summary

- Add HTTP/SSE transport to the MCP server, selected by `VADE_MCP_TRANSPORT=stdio|sse` (default stdio so `npm run dev:all` keeps working).
- Refactor `CanvasBridge` to run in `standalone` mode (current local WS on :7600) or `attached` mode sharing a single HTTP server with the MCP SSE endpoints on `/canvas`.
- Parametrize the PWA's ws-client via `VITE_BRIDGE_URL` (defaults to the existing localhost behavior).
- Add `Dockerfile` (reusing `ghcr.io/vade-app/vade-runtime:latest`), `.dockerignore`, and `fly.toml` for Fly.io deploy. Fly volume mount is commented out pending the storage-abstraction sub-issue.

## Endpoints (once deployed)

- `https://mcp.vade.dev/sse` — MCP HTTP/SSE (Claude Code)
- `https://mcp.vade.dev/messages?sessionId=…` — POST sink (handled by the SSE transport)
- `wss://mcp.vade.dev/canvas` — WebSocket for the PWA
- `https://mcp.vade.dev/healthz` — liveness

## Setup tasks (for you to run locally)

These require `flyctl` + DNS control and are intentionally out of this PR. Do them in order on a machine with `flyctl` logged in.

### 1. Create the Fly app
```bash
cd vade-core
flyctl launch --no-deploy --copy-config --name vade-mcp --region sea
```
- Use `--copy-config` so Fly keeps the committed `fly.toml`.
- If the name `vade-mcp` is taken, pick another and update `app = '…'` in `fly.toml` before committing.
- Adjust `primary_region` if `sea` is wrong for you.

### 2. First deploy
```bash
flyctl deploy
flyctl status
curl https://vade-mcp.fly.dev/healthz   # expect "ok"
```
The default `*.fly.dev` hostname should respond before you bother with DNS.

### 3. Add the custom domain + cert
```bash
flyctl certs add mcp.vade.dev
flyctl certs show mcp.vade.dev          # prints DNS records to add
```
`flyctl certs show` prints the exact CNAME (and acme-challenge) records. Add them in your DNS provider:

- `CNAME mcp → vade-mcp.fly.dev`
- `CNAME _acme-challenge.mcp → …` (whatever Fly shows)

Wait for LetsEncrypt issuance (`flyctl certs show mcp.vade.dev` flips to `Issued`).

### 4. Verify the hosted endpoints
```bash
curl https://mcp.vade.dev/healthz                 # "ok"
wscat -c wss://mcp.vade.dev/canvas                # opens; close with Ctrl-C
```
Register `https://mcp.vade.dev/sse` in a remote Claude Code MCP config and confirm the `vade-canvas` tools list.

### 5. Point the PWA at the hosted bridge
Cloudflare build needs `VITE_BRIDGE_URL=wss://mcp.vade.dev/canvas` baked in. In `wrangler.jsonc` or the Cloudflare Pages UI, add the build-time var and redeploy the PWA. Local dev keeps the default `ws://localhost:7600` when the var is unset.

### 6. End-to-end acceptance test (matches issue #7 criteria)
1. PWA on `https://vade-app.dev` connects to `wss://mcp.vade.dev/canvas` — visible in `flyctl logs` as `[bridge] Canvas connected`.
2. From a remote machine, Claude Code with `https://mcp.vade.dev/sse` calls `createShape` → shape appears on the PWA in ~1s.
3. `npm run dev:all` locally still works unchanged.

## Deferred / follow-up issues to file

- **Auth** — `/sse` and `/canvas` are currently unauthenticated. Add a shared-secret header gate (`VADE_MCP_AUTH_TOKEN`) before announcing the URL widely.
- **Fly volume for library data** — uncomment the `[[mounts]]` block in `fly.toml` once the storage-abstraction sub-issue lands. Create the volume with `flyctl volumes create vade_library --size 1 --region sea` before redeploying.
- **Multi-canvas support** — `CanvasBridge` still has one `canvas` slot (last-wins). M1-acceptable; revisit if multiple PWAs need to share the hosted bridge.

## Test plan

- [x] `npx tsc -b` passes (full project)
- [x] `npx tsc -p tsconfig.node.json --noEmit` passes (MCP only)
- [x] `npx tsx mcp/index.ts` (stdio) boots — logs `[bridge] WebSocket server listening on 0.0.0.0:7600` and `[vade-canvas] MCP server running on stdio…`
- [x] `VADE_MCP_TRANSPORT=sse VADE_MCP_HTTP_PORT=18085 npx tsx mcp/index.ts` boots — `/healthz` returns `ok`; logs `SSE + WSS on :18085 (sse=/sse, canvas=/canvas)`
- [ ] Local SSE e2e: `VITE_BRIDGE_URL=ws://localhost:8080/canvas npm run dev` + `npm run mcp:sse` + remote Claude Code → shape on canvas
- [ ] Hosted: `flyctl deploy` + DNS + remote Claude Code → `mcp.vade.dev`/sse → shape on PWA
- [ ] `npm run dev:all` regression — stdio + localhost:7600 still works

https://claude.ai/code/session_01WBp8LS2vC3iS2P5adTfZxA