### PR TITLE
docs: update CLAUDE.md with deployment, MCP, and config details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,9 @@ other `vade-app` repositories from sessions started here.
 - TypeScript (strict mode) + Node.js 20+ LTS
 - React 18 + tldraw ^4.5.x
 - Vite for dev server and bundling
-- @modelcontextprotocol/server for MCP
+- @modelcontextprotocol/sdk for MCP
 - ws (WebSocket) for MCP-to-canvas bridge
+- Cloudflare Workers + wrangler for hosted deployment
 - Tauri 2.x for desktop/mobile wrappers (later phase)
 
 ## Conventions
@@ -56,6 +57,18 @@ other `vade-app` repositories from sessions started here.
 - Prefer simplicity over premature abstraction.
 - Tests where they earn their keep. Prefer integration tests when
   the integration boundary is the risk.
+
+### Canonical config files
+
+- `.mcp.json` — project-scoped MCP server config (Mem0 + GitHub),
+  shared across surfaces. Committed.
+- `.claude/settings.local.json` — Claude Code permissions and
+  session settings for this repo. Committed where it encodes
+  repo-wide policy; user-local overrides stay out of git.
+- `.devcontainer/` — reproducible dev environment spec. Used by
+  VS Code devcontainers and by Codespaces.
+- `wrangler.jsonc` — Cloudflare Worker deploy config. See
+  Deployment below.
 
 ## What may be done autonomously in this repo
 
@@ -81,16 +94,75 @@ for the authoritative list.
 
 ## Current state
 
-Canvas shell scaffolded with tldraw SDK. Vite + React 18 +
-TypeScript strict. PWA manifest for iPad. MCP server and custom
-shapes in progress.
+**Pre-alpha MVP scaffold is in `main`.** The canvas is live at
+**https://vade-app.dev**, served from a Cloudflare Worker that
+auto-deploys on push to `main`. What ships today:
+
+- **Canvas shell** — tldraw-backed infinite canvas, pan/zoom,
+  gesture + touch support, IndexedDB persistence so the canvas
+  document survives reloads.
+- **PWA** — installable on iPad via Add to Home Screen; manifest
+  and icons are wired up.
+- **MCP server** — functional over stdio, with a WebSocket bridge
+  on `:7600` to push shape operations into the running canvas.
+- **Custom shapes** — `CodeShape` (syntax-highlighted code block)
+  and `DataShape` (structured JSON rendering).
+- **Library system** — file-based storage at `~/.vade/library/`
+  for canvas snapshots and reusable entity groups.
+- **Connection status indicator** — surfaces the WS bridge state
+  in the canvas UI.
+
+The bridge from a hosted MCP endpoint to the hosted canvas is
+the next MVP milestone (tracked under issue #7). CI/CD via
+GitHub Actions is tracked under issue #10.
 
 ## Running the project
 
 ```bash
 npm install           # install dependencies
-npm run dev           # start Vite dev server (LAN-accessible)
-npm run mcp           # start MCP server (when implemented)
-npm run dev:all       # start both (when MCP server exists)
-npm run build         # production build
+npm run dev           # start Vite dev server (LAN-accessible on :5173)
+npm run mcp           # start the MCP server (stdio + WebSocket :7600)
+npm run dev:all       # run Vite + MCP server concurrently
+npm run build         # production build (tsc -b && vite build)
+npm run preview       # build, then serve via `wrangler dev` locally
+npm run deploy        # build, then `wrangler deploy` to Cloudflare
 ```
+
+## Deployment
+
+The canvas SPA is deployed as a **Cloudflare Worker** that serves
+the Vite-built static assets (`dist/`). Config lives in
+`wrangler.jsonc`:
+
+- `assets.not_found_handling: "single-page-application"` — SPA
+  routing fallback to `index.html`.
+- `routes` — both `vade-app.dev` and `www.vade-app.dev` are
+  attached as `custom_domain` routes; DNS and TLS are managed
+  by Cloudflare.
+- `compatibility_flags: ["nodejs_compat"]`.
+
+Deploys are triggered by Cloudflare's Git integration on push to
+`main` (one build per push, auto-deploys to both custom domains).
+Manual deploy from a local clone: `npm run deploy`. A proper
+GitHub Actions CI/CD pipeline is tracked under issue #10.
+
+## MCP tools
+
+The MCP server exposes tools across three categories. See `mcp/`
+for the exact callable surface and argument schemas — that
+directory is the source of truth; do not treat this section as
+an enumeration.
+
+- **Shapes** (`mcp/tools/shapes.ts`) — create, update, delete,
+  and query tldraw shapes, including the custom `CodeShape` and
+  `DataShape`; batch operations; bindings between shapes.
+- **Canvas** (`mcp/tools/canvas.ts`) — query and navigate canvas
+  state (viewport, selection), persist snapshots into
+  `~/.vade/library/`, restore / search the library.
+- **Runtime** (`mcp/tools/runtime.ts`) — wire shapes into the
+  Control → State → Visualization loop: request code changes on
+  a shape, execute runtime hooks, move data between shapes.
+
+The server registers all three tool groups through
+`mcp/index.ts`; transport is stdio, and the canvas bridge is a
+separate WebSocket on `:7600` (`mcp/ws-server.ts`).


### PR DESCRIPTION
## Summary

Updated `CLAUDE.md` to reflect the current state of the project, including deployment infrastructure, MCP server implementation details, and canonical configuration files. This documentation now accurately describes the pre-alpha MVP that is live at https://vade-app.dev.

## Key Changes

- **Dependency updates**: Changed MCP dependency from `@modelcontextprotocol/server` to `@modelcontextprotocol/sdk` and added Cloudflare Workers + wrangler to the tech stack
- **New "Canonical config files" section**: Documented `.mcp.json`, `.claude/settings.local.json`, `.devcontainer/`, and `wrangler.jsonc` with their purposes
- **Expanded "Current state" section**: Replaced brief scaffold description with detailed breakdown of what's currently shipped:
  - Canvas shell with persistence
  - PWA capabilities
  - Functional MCP server with WebSocket bridge
  - Custom shapes (CodeShape, DataShape)
  - Library system for snapshots
  - Connection status indicator
- **Updated npm scripts**: Added descriptions for `npm run preview` and `npm run deploy`; clarified existing commands with port numbers and details
- **New "Deployment" section**: Documented Cloudflare Worker setup, SPA routing configuration, custom domain routing, and Git integration for auto-deploys
- **New "MCP tools" section**: Documented the three tool categories (Shapes, Canvas, Runtime) with references to source files in `mcp/`

## Notable Details

- Clarified that the canvas is live and auto-deploys on push to `main` via Cloudflare's Git integration
- Noted that the MCP-to-canvas bridge is the next MVP milestone (issue #7) and CI/CD pipeline is tracked under issue #10
- Emphasized that `mcp/` directory is the source of truth for MCP tool definitions

https://claude.ai/code/session_01DHfcswuyuemyZ2Ztiv1Z6N