### PR TITLE
Gate MCP bridge to dev-only and pass through VITE_BRIDGE_URL for hosted bridge

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,0 @@
-VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,14 @@ function ConnectionIndicator() {
     connected: '#a6e3a1',
     connecting: '#f9e2af',
     disconnected: '#f38ba8',
+    'no-bridge': '#6c7086',
+  }
+
+  const labels: Record<BridgeStatus, string> = {
+    connected: 'MCP',
+    connecting: 'connecting...',
+    disconnected: 'offline',
+    'no-bridge': 'no bridge',
   }
 
   return (
@@ -47,7 +55,7 @@ function ConnectionIndicator() {
           background: colors[status],
         }}
       />
-      {status === 'connected' ? 'MCP' : status === 'connecting' ? 'connecting...' : 'offline'}
+      {labels[status]}
     </div>
   )
 }

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -5,7 +5,22 @@ const WS_URL =
   (import.meta.env.VITE_BRIDGE_URL as string | undefined) ??
   `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:7600`
 
-export type BridgeStatus = 'disconnected' | 'connecting' | 'connected'
+const isLocalHostname = (hostname: string): boolean => {
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true
+  if (hostname.endsWith('.local')) return true
+  if (/^10\./.test(hostname)) return true
+  if (/^192\.168\./.test(hostname)) return true
+  if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)) return true
+  return false
+}
+
+const shouldAttemptBridge = (): boolean => {
+  if (import.meta.env.VITE_BRIDGE_URL) return true
+  if (import.meta.env.DEV) return true
+  return isLocalHostname(window.location.hostname)
+}
+
+export type BridgeStatus = 'disconnected' | 'connecting' | 'connected' | 'no-bridge'
 type StatusListener = (status: BridgeStatus) => void
 
 export class VadeBridge {
@@ -18,6 +33,10 @@ export class VadeBridge {
 
   connect(editor: Editor) {
     this.editor = editor
+    if (!shouldAttemptBridge()) {
+      this.setStatus('no-bridge')
+      return
+    }
     this.tryConnect()
   }
 


### PR DESCRIPTION
## Summary

Closes #24.

Production at `https://vade-app.dev` was hammering `wss://vade-app.dev:7600` forever (nothing listens on `:7600` at the edge), surfacing as a permanently blinking "Connecting…" indicator and DevTools network noise.

**Gate `VadeBridge.connect()`** — short-circuit unless `import.meta.env.DEV`, `import.meta.env.VITE_BRIDGE_URL` is set, or the hostname looks local (`localhost`, `127.0.0.1`, `::1`, `*.local`, RFC1918). When gated, the bridge emits a new terminal `'no-bridge'` status and never schedules a reconnect — no timer, no backoff.

`ConnectionIndicator` gains a fourth muted-gray state (`'no bridge'`, `#6c7086`) distinct from yellow `'connecting...'` and red `'offline'`. The existing ternary label selector was replaced with a `labels` record to keep types exhaustive.

## Production bridge wiring (out of tree)

The gate's `VITE_BRIDGE_URL` passthrough lets the hosted MCP + WSS bridge from #26 (`wss://mcp.vade-app.dev/canvas`) work as soon as that value is available at build time. An earlier attempt in this PR committed a `.env.production` for that, but wrangler 4.83.0 auto-loads committed `.env*` files and treats the vars as Worker bindings — the resulting binding-set change triggered an interactive confirmation prompt that crashes in Cloudflare's non-interactive build runner (`✘ [ERROR] TTY initialization failed: uv_tty_init returned EINVAL`).

Resolution: set `VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas` in **Cloudflare → Workers → vade-core → Settings → Builds → Variables** (build-time env, not Worker bindings). Vite reads it via `process.env` during `npm run build` and inlines it.

## Files

- `src/bridge/ws-client.ts` — `isLocalHostname` + `shouldAttemptBridge` helpers; early-exit in `connect()`; `BridgeStatus` extended with `'no-bridge'`.
- `src/App.tsx` — fourth entry in `colors`; new `labels` map; renders `labels[status]`.

## Test plan

- [x] `npm run build` passes (TS + Vite).
- [x] Local gate-only build (commit 68d93a3) deployed to Cloudflare cleanly.
- [x] With `VITE_BRIDGE_URL` set in Cloudflare dashboard: production hostname passes the gate and connects to `wss://mcp.vade-app.dev/canvas`.
- [ ] Local dev with MCP server (`npm run dev:all`): indicator transitions `disconnected → connecting → connected`. Unchanged.
- [ ] Local dev, no MCP: indicator flips `connecting → disconnected` with existing backoff. Unchanged.
- [ ] Deployed to `https://vade-app.dev` without `VITE_BRIDGE_URL`: indicator settles on `'no bridge'` (gray); no reconnect loop, no `wss://vade-app.dev:7600` noise.

## Notes

- `fly.toml` has a stray `VITE_BRIDGE_URL` under the MCP server's `[env]` block — harmless but dead (server runtime, not SPA build). Worth cleaning up in a small follow-up.

https://claude.ai/code/session_01Kx8Qpj7Xws2RhVLAMpD9KM