### PR TITLE
Scope MCP POST endpoint by Fly machine ID to fix session routing

### DIFF
--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -29,6 +29,12 @@ async function runSse() {
   const ssePath = '/sse'
   const canvasPath = '/canvas'
 
+  // On Fly.io, sessions live in per-machine memory. Advertise a
+  // machine-scoped endpoint so the client's POST can be replayed to
+  // the instance holding the SSE connection via `fly-replay`.
+  const machineId = process.env['FLY_MACHINE_ID'] ?? ''
+  const scopedMessagesPath = machineId ? `${messagesPath}/${machineId}` : messagesPath
+
   type Session = { server: McpServer; transport: SSEServerTransport }
   const sessions = new Map<string, Session>()
 
@@ -60,12 +66,14 @@ async function runSse() {
     }
 
     if (req.method === 'GET' && url.pathname === ssePath) {
-      const transport = new SSEServerTransport(messagesPath, res)
+      const transport = new SSEServerTransport(scopedMessagesPath, res)
       const server = buildServer(bridge)
 
       const sessionId = transport.sessionId
       sessions.set(sessionId, { server, transport })
-      console.error(`[vade-canvas] SSE session open ${sessionId} (total=${sessions.size})`)
+      console.error(
+        `[vade-canvas] SSE session open ${sessionId} on ${machineId || 'local'} (total=${sessions.size})`,
+      )
 
       const cleanup = () => {
         if (!sessions.has(sessionId)) return
@@ -85,7 +93,19 @@ async function runSse() {
       return
     }
 
-    if (req.method === 'POST' && url.pathname === messagesPath) {
+    if (req.method === 'POST' && url.pathname.startsWith(messagesPath)) {
+      // Path shape: `/messages` or `/messages/<machineId>`. If the
+      // client's target machine isn't us, hand off to Fly's proxy —
+      // it will replay the request (body included) to that instance.
+      const tail = url.pathname.slice(messagesPath.length)
+      const targetMachineId = tail.startsWith('/') ? tail.slice(1) : ''
+      if (targetMachineId && targetMachineId !== machineId) {
+        res.setHeader('fly-replay', `instance=${targetMachineId}`)
+        res.writeHead(204)
+        res.end()
+        return
+      }
+
       const sid = url.searchParams.get('sessionId')
       const session = sid ? sessions.get(sid) : undefined
       if (!session) {


### PR DESCRIPTION
## Summary

- Claude Code (and any SSE MCP client) couldn't connect to `vade-canvas` — `/mcp` reported "Failed to reconnect". Root cause: `vade-mcp` on Fly runs more than one machine, sessions live in per-process memory (`mcp/index.ts`), and nothing pinned the client's POST to `/messages` to the instance holding its SSE connection. When the POST landed on the wrong machine the server returned `404 Unknown sessionId`, which Claude Code then misinterpreted as an auth problem and fell into a broken OAuth fallback.
- Fix: advertise the endpoint as `/messages/$FLY_MACHINE_ID`. On POST, if the trailing segment doesn't match this machine, reply with a `fly-replay: instance=<id>` header so Fly's edge proxy re-routes the request (body included) to the owning instance.
- Backward compatible: when `FLY_MACHINE_ID` is unset (local dev / stdio), the path collapses back to `/messages` and behavior is unchanged.

## Test plan

- [x] `tsc -b` passes.
- [x] Local run with `FLY_MACHINE_ID=test-machine-a`: SSE handshake advertises `/messages/test-machine-a?sessionId=…`; same-machine `initialize` POST returns `202 Accepted` and the JSON-RPC response arrives on the SSE stream.
- [x] Local run with `FLY_MACHINE_ID=test-machine-a`: POST to `/messages/some-other-machine` returns `204` with `fly-replay: instance=some-other-machine`.
- [ ] Deploy to Fly (`flyctl deploy`), confirm both machines are up, then run `/mcp` in Claude Code and verify `vade-canvas` connects and tools are listed.
- [ ] Tail logs (`flyctl logs`) and confirm session-open lines include the machine ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)