### PR TITLE
Downgrade tldraw from 4.5.8 to 3.15.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "tldraw": "^4.5.8",
+        "tldraw": "3.15.6",
         "ws": "^8.20.0",
         "zod": "^4.3.6"
       },
@@ -1566,6 +1566,16 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -3492,227 +3502,243 @@
       "license": "CC0-1.0"
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
-      "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.3.tgz",
-      "integrity": "sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.3.tgz",
-      "integrity": "sha512-tysipHla2zCWr8XNIWRaW9O+7i7/SoEqnRqSRUUi2ailcJjlia+RBy3RykhkgyThrQDStu5KGBS/UvrXwA+O1A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
-      "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.27.2.tgz",
+      "integrity": "sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "tippy.js": "^6.3.7"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.3.tgz",
-      "integrity": "sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.3.tgz",
-      "integrity": "sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.3.tgz",
-      "integrity": "sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.3.tgz",
-      "integrity": "sha512-MCSr1PFPtTd++lA3H1RNgqAczAE59XXJ5wUFIQf2F+/0DPY5q2SU4g5QsNJVxPPft5mrNT4C6ty8xBPrALFEdA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.3.tgz",
-      "integrity": "sha512-taXq9Tl5aybdFbptJtFRHX9LFJzbXphAbPp4/vutFyTrBu5meXDxuS+B9pEmE+Or0XcolTlW2nDZB0Tqnr18JQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
-      "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.27.2.tgz",
+      "integrity": "sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==",
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.3.tgz",
-      "integrity": "sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.3.tgz",
-      "integrity": "sha512-J0v8I99y9tbvVmgKYKzKP/JYNsWaZYS7avn4rzLft2OhnyTfwt3OoY8DtpHmmi6apSUaCtoWHWta/TmoEfK1nQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.3.tgz",
-      "integrity": "sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-highlight": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-3.22.3.tgz",
-      "integrity": "sha512-iGDzQ3IuVQpfQcWsMEQ0B8q3R83bZZH6l6O2MuCmWbzm/p7mMi5vQwRCMLAbM9xFELq8KjDMHOWeER4fozp/Sg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-2.27.2.tgz",
+      "integrity": "sha512-ZjlktDdMjruMJFAVz0TbQf0v92Jqkc7Ri1iZJqBXuLid+r+GxUzl2CVAV7qq5yagkGQgvAG+WGsMk880HgR3MA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.3.tgz",
-      "integrity": "sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.3.tgz",
-      "integrity": "sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.3.tgz",
-      "integrity": "sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.2.tgz",
+      "integrity": "sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.2"
@@ -3722,133 +3748,92 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
-      }
-    },
-    "node_modules/@tiptap/extension-list": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
-      "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.3.tgz",
-      "integrity": "sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.22.3"
-      }
-    },
-    "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.3.tgz",
-      "integrity": "sha512-pKuyj5llu35zd/s2u/H9aydKZjmPRAIK5P1q/YXULhhCNln2RnmuRfQ5NklAqTD3yGciQ2lxDwwf7J6iw3ergA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.3.tgz",
-      "integrity": "sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.3.tgz",
-      "integrity": "sha512-oO7rhfyhEuwm+50s9K3GZPjYyEEEvFAvm1wXopvZnhbkBLydIWImBfrZoC5IQh4/sRDlTIjosV2C+ji5y0tUSg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.3.tgz",
-      "integrity": "sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.3.tgz",
-      "integrity": "sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
-    "node_modules/@tiptap/extension-underline": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.3.tgz",
-      "integrity": "sha512-Ch6CBWRa5w90yYSPUW6x9Py9JdrXMqk3pZ9OIlMYD8A7BqyZGfiHerX7XDMYDS09KjyK3U9XH60/zxYOzXdDLA==",
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3"
-      }
-    },
-    "node_modules/@tiptap/extensions": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
-      "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
-      "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -3861,14 +3846,14 @@
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-markdown": "^1.13.1",
         "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
+        "prosemirror-model": "^1.23.0",
         "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-schema-list": "^1.4.1",
         "prosemirror-state": "^1.4.3",
         "prosemirror-tables": "^1.6.4",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "prosemirror-view": "^1.37.0"
       },
       "funding": {
         "type": "github",
@@ -3876,62 +3861,55 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.3.tgz",
-      "integrity": "sha512-6MNr6z0PxwfJFs+BKhHcvPNvY+UV1PXgqzTiTM4Z9guml84iVZxv7ZOCSj1dFYTr3Bf1MiOs4hT1yvBFlTfIaQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.27.2.tgz",
+      "integrity": "sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==",
       "license": "MIT",
       "dependencies": {
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-floating-menu": "^2.27.2",
         "@types/use-sync-external-store": "^0.0.6",
-        "fast-equals": "^5.3.3",
-        "use-sync-external-store": "^1.4.0"
+        "fast-deep-equal": "^3",
+        "use-sync-external-store": "^1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
-      "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.22.3",
-        "@tiptap/extension-floating-menu": "^3.22.3"
-      },
       "peerDependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/pm": "^3.22.3",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.3.tgz",
-      "integrity": "sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.22.3",
-        "@tiptap/extension-blockquote": "^3.22.3",
-        "@tiptap/extension-bold": "^3.22.3",
-        "@tiptap/extension-bullet-list": "^3.22.3",
-        "@tiptap/extension-code": "^3.22.3",
-        "@tiptap/extension-code-block": "^3.22.3",
-        "@tiptap/extension-document": "^3.22.3",
-        "@tiptap/extension-dropcursor": "^3.22.3",
-        "@tiptap/extension-gapcursor": "^3.22.3",
-        "@tiptap/extension-hard-break": "^3.22.3",
-        "@tiptap/extension-heading": "^3.22.3",
-        "@tiptap/extension-horizontal-rule": "^3.22.3",
-        "@tiptap/extension-italic": "^3.22.3",
-        "@tiptap/extension-link": "^3.22.3",
-        "@tiptap/extension-list": "^3.22.3",
-        "@tiptap/extension-list-item": "^3.22.3",
-        "@tiptap/extension-list-keymap": "^3.22.3",
-        "@tiptap/extension-ordered-list": "^3.22.3",
-        "@tiptap/extension-paragraph": "^3.22.3",
-        "@tiptap/extension-strike": "^3.22.3",
-        "@tiptap/extension-text": "^3.22.3",
-        "@tiptap/extension-underline": "^3.22.3",
-        "@tiptap/extensions": "^3.22.3",
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
       },
       "funding": {
         "type": "github",
@@ -3939,91 +3917,92 @@
       }
     },
     "node_modules/@tldraw/editor": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/editor/-/editor-4.5.9.tgz",
-      "integrity": "sha512-XahQla6Rs6JBv2yNYtROgbsGw6jRHdaSTrxTKe2fvc+oZqiDMd4IUE6s/MqWUeOA0M3gfvLc21EEosRA6mApKg==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/editor/-/editor-3.15.6.tgz",
+      "integrity": "sha512-avchuWHkX4zR/tkuzwgefr3bkATf/BZYyAJtp3OA+tqWkmqd5+AQkJi9jfEbauvy3ZIjljuejHGUUPWt3kS7yA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@tiptap/core": "^3.12.1",
-        "@tiptap/pm": "^3.12.1",
-        "@tiptap/react": "^3.12.1",
-        "@tldraw/state": "4.5.9",
-        "@tldraw/state-react": "4.5.9",
-        "@tldraw/store": "4.5.9",
-        "@tldraw/tlschema": "4.5.9",
-        "@tldraw/utils": "4.5.9",
-        "@tldraw/validate": "4.5.9",
+        "@tiptap/core": "^2.9.1",
+        "@tiptap/pm": "^2.9.1",
+        "@tiptap/react": "^2.9.1",
+        "@tldraw/state": "3.15.6",
+        "@tldraw/state-react": "3.15.6",
+        "@tldraw/store": "3.15.6",
+        "@tldraw/tlschema": "3.15.6",
+        "@tldraw/utils": "3.15.6",
+        "@tldraw/validate": "3.15.6",
+        "@types/core-js": "^2.5.8",
         "@use-gesture/react": "^10.3.1",
         "classnames": "^2.5.1",
+        "core-js": "^3.40.0",
         "eventemitter3": "^4.0.7",
         "idb": "^7.1.1",
-        "is-plain-object": "^5.0.0",
-        "rbush": "^3.0.1"
+        "is-plain-object": "^5.0.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0 || ^19.2.1",
-        "react-dom": "^18.2.0 || ^19.2.1"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@tldraw/state": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/state/-/state-4.5.9.tgz",
-      "integrity": "sha512-HhesDh5MnxgwSpkYEP9bFK5Bxc1nO5oAfykGcjtir7QYi3WuBGH7o7V4mey94Vha7lPLstHITH9d2gFHceBT+A==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/state/-/state-3.15.6.tgz",
+      "integrity": "sha512-ZBwlNMUPwtxd++x8kzPEfXna/C7o+7qiiIejpI34hkC927trlr22MNajtYSEAmyO8Q8cP3nC0Q68Eh4Mx2NTHA==",
       "license": "MIT",
       "dependencies": {
-        "@tldraw/utils": "4.5.9"
+        "@tldraw/utils": "3.15.6"
       }
     },
     "node_modules/@tldraw/state-react": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/state-react/-/state-react-4.5.9.tgz",
-      "integrity": "sha512-6dGi5lYnJZk9ynzvaTp+d4LXuXaN2EVmNYHLIbXfPHM77P9WgHVe+ew/l4FyELYZkdcNzvxaUnI3+anCOTYZ1g==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/state-react/-/state-react-3.15.6.tgz",
+      "integrity": "sha512-LWQGBv0Qtss8/grtPzHlfXYq2ge+TbZDM4hiV2oconp3x8LjiCzmVQDq9mIvcFSpZaD6ECj86k/lYX6GMsXBOQ==",
       "license": "MIT",
       "dependencies": {
-        "@tldraw/state": "4.5.9",
-        "@tldraw/utils": "4.5.9"
+        "@tldraw/state": "3.15.6",
+        "@tldraw/utils": "3.15.6"
       },
       "peerDependencies": {
-        "react": "^18.2.0 || ^19.2.1",
-        "react-dom": "^18.2.0 || ^19.2.1"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@tldraw/store": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/store/-/store-4.5.9.tgz",
-      "integrity": "sha512-0FU/8fmkpX4lwGv4SQQqvUki+7JaUrx7VLwl99mOOvq+wGeWDt7H7EvkAtcNGtsCrHe5U3nvjYOiCr/sEs+QJw==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/store/-/store-3.15.6.tgz",
+      "integrity": "sha512-v2VGW+kvcwccehSjQKriDGhG2C7703wxGzW/dZqNtxpuoqm51qZL2fStUsrSRQb1Mh1zbHu+IJDhTQqmnZzEiQ==",
       "license": "MIT",
       "dependencies": {
-        "@tldraw/state": "4.5.9",
-        "@tldraw/utils": "4.5.9"
+        "@tldraw/state": "3.15.6",
+        "@tldraw/utils": "3.15.6"
       },
       "peerDependencies": {
-        "react": "^18.2.0 || ^19.2.1"
+        "react": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@tldraw/tlschema": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/tlschema/-/tlschema-4.5.9.tgz",
-      "integrity": "sha512-Zz8WiwO3YG5keNeAhmsBYGhV3ORPW+FXATcJSbQdvIUhTyIkAfvq6ghy7AcjlEgf9Accoq6Hzc/Kz16Q89E2Xg==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/tlschema/-/tlschema-3.15.6.tgz",
+      "integrity": "sha512-7rlgTADifvNd5hXZynuKV/I7SIHKszw1XOYKxx/BcVeLmy5SYFBjofFIYPfrDJo9luZPt23MfXvy2iW2p8kIvw==",
       "license": "MIT",
       "dependencies": {
-        "@tldraw/state": "4.5.9",
-        "@tldraw/store": "4.5.9",
-        "@tldraw/utils": "4.5.9",
-        "@tldraw/validate": "4.5.9"
+        "@tldraw/state": "3.15.6",
+        "@tldraw/store": "3.15.6",
+        "@tldraw/utils": "3.15.6",
+        "@tldraw/validate": "3.15.6"
       },
       "peerDependencies": {
-        "react": "^18.2.0 || ^19.2.1",
-        "react-dom": "^18.2.0 || ^19.2.1"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@tldraw/utils": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/utils/-/utils-4.5.9.tgz",
-      "integrity": "sha512-UjJXlPkfFdnRlwV7TI++XTYsGN1nFGsoA825pXek3O1ZgsJyuHz18oP42dGRAaXomG/O9qtudO/Y/vQyYNnWIg==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/utils/-/utils-3.15.6.tgz",
+      "integrity": "sha512-GDvMJvw7Y4UPR8IU7/thPDMtuBkXqoyzjSlOslKzHIZAdF3hfQDLqmC7ugJ/xc7KtfC8WKeuiYhBf2Oo0Bv5HQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "jittered-fractional-indexing": "^1.0.0",
+        "fractional-indexing-jittered": "^1.0.0",
         "lodash.isequal": "^4.5.0",
         "lodash.isequalwith": "^4.4.0",
         "lodash.throttle": "^4.1.1",
@@ -4031,12 +4010,12 @@
       }
     },
     "node_modules/@tldraw/validate": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@tldraw/validate/-/validate-4.5.9.tgz",
-      "integrity": "sha512-/uy5UBYMKHq2TiCTXCVkCxL6XucLEOOhqtJRQ/Hr4UgWTN8pkBbN9gKGNgIZQnOHWU4Ea0A3GUVKtS+sUdUHbQ==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@tldraw/validate/-/validate-3.15.6.tgz",
+      "integrity": "sha512-lYUbe36HmmJWFlg2wM5SCEGPB0n4HHALcxvfibEu351uGSwlemznr/tN3WCvQLshTXe1vMDNtyO+jJwrPprp5w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@tldraw/utils": "4.5.9"
+        "@tldraw/utils": "3.15.6"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4084,6 +4063,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/core-js": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.8.tgz",
+      "integrity": "sha512-VgnAj6tIAhJhZdJ8/IpxdatM8G4OD3VWGlp6xIxUGENZlpbob9Ty4VVdC1FIEp0aK6DBscDDjyzy5FB60TuNqg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4127,12 +4112,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4143,6 +4130,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4573,6 +4561,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -4614,6 +4613,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4926,15 +4926,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -4999,14 +4990,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fractional-indexing": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz",
-      "integrity": "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==",
-      "license": "CC0-1.0",
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
+    "node_modules/fractional-indexing-jittered": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing-jittered/-/fractional-indexing-jittered-1.0.0.tgz",
+      "integrity": "sha512-0tLU0FOedVY7lrvN4LK0DVj6FTuYM0pWDpN97/8UTZE2lx1+OwX8+2uL7IOWc2PmktYTHQjMT6FvZZ3SGCdZdg==",
+      "license": "CC0-1.0"
     },
     "node_modules/fresh": {
       "version": "2.0.0",
@@ -5280,18 +5268,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/jittered-fractional-indexing": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jittered-fractional-indexing/-/jittered-fractional-indexing-1.0.1.tgz",
-      "integrity": "sha512-OpKFkVr4hU5ivd1ZCjZfHvVpWekraJvcePcMusBmgBmCVQK5JiRCA+4TT1vAUTLqGD9MkhqFwO0l3QspvlZgzw==",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "fractional-indexing": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -5826,9 +5802,9 @@
       }
     },
     "node_modules/prosemirror-menu": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.1.tgz",
-      "integrity": "sha512-2OSIKBFyLo2iqDpjQHEC7tKt3lluhY7L44pcRai8EpoU9R7cZDj/dklEsOOIubNKWUXab6dL7y4JtAWnrlR4lA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
       "license": "MIT",
       "dependencies": {
         "crelt": "^1.0.0",
@@ -5962,12 +5938,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "license": "ISC"
-    },
     "node_modules/radix-ui": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
@@ -6067,15 +6037,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "license": "MIT",
-      "dependencies": {
-        "quickselect": "^2.0.0"
       }
     },
     "node_modules/react": {
@@ -6608,30 +6569,39 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tldraw": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/tldraw/-/tldraw-4.5.9.tgz",
-      "integrity": "sha512-IiJF5AKvGzI1Lqdr9II1U2TZs/RTA8sMsKGHjdLURcHajYJMXgM19GBTqHw5K8d5zVfH67WdEUt96/M++n6HEg==",
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/tldraw/-/tldraw-3.15.6.tgz",
+      "integrity": "sha512-DGFYaKexMrk7POFLyIUU5mzlOqBw3cR3xk2S25zauvhSPlQ64EAsR1fIMwXX4rJVmuV/4zg0jh6mqK0E0KfGHg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@tiptap/core": "^3.12.1",
-        "@tiptap/extension-code": "^3.12.1",
-        "@tiptap/extension-highlight": "^3.12.1",
-        "@tiptap/extension-list": "^3.12.1",
-        "@tiptap/pm": "^3.12.1",
-        "@tiptap/react": "^3.12.1",
-        "@tiptap/starter-kit": "^3.12.1",
-        "@tldraw/editor": "4.5.9",
-        "@tldraw/store": "4.5.9",
+        "@tiptap/core": "^2.9.1",
+        "@tiptap/extension-code": "^2.9.1",
+        "@tiptap/extension-highlight": "^2.9.1",
+        "@tiptap/extension-link": "^2.9.1",
+        "@tiptap/pm": "^2.9.1",
+        "@tiptap/react": "^2.9.1",
+        "@tiptap/starter-kit": "^2.9.1",
+        "@tldraw/editor": "3.15.6",
+        "@tldraw/store": "3.15.6",
         "classnames": "^2.5.1",
         "hotkeys-js": "^3.13.9",
         "idb": "^7.1.1",
         "lz-string": "^1.5.0",
-        "radix-ui": "^1.4.2"
+        "radix-ui": "^1.3.4"
       },
       "peerDependencies": {
-        "react": "^18.2.0 || ^19.2.1",
-        "react-dom": "^18.2.0 || ^19.2.1"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tldraw": "^4.5.8",
+    "tldraw": "3.15.6",
     "ws": "^8.20.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary
Downgrade the tldraw dependency to version 3.15.6, moving from the latest 4.5.8 release to an earlier stable version.

## Changes
- Updated tldraw dependency from `^4.5.8` to `3.15.6` (pinned version)

## Notes
- This change pins tldraw to a specific version rather than using a caret range, which may indicate compatibility requirements or stability concerns with the newer major version
- Package lock file has been updated with transitive dependency changes

https://claude.ai/code/session_016BCUuHidaPB6K7DxSi1MRW