### PR TITLE
Keep MCP SSE sessions alive past Fly-proxy idle timeout

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,8 @@
       "Bash(./node_modules/.bin/tsc -b)",
       "Bash(npm install *)",
       "mcp__vade-canvas__createBatch",
-      "Bash(flyctl releases *)"
+      "Bash(flyctl releases *)",
+      "Bash(npm run *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -75,9 +75,18 @@ async function runSse() {
         `[vade-canvas] SSE session open ${sessionId} on ${machineId || 'local'} (total=${sessions.size})`,
       )
 
+      // Fly-proxy closes idle HTTP connections at 60s. Send an SSE
+      // comment frame periodically so the stream has traffic and the
+      // edge keeps it alive.
+      const heartbeat = setInterval(() => {
+        if (res.writableEnded) return
+        res.write(':\n\n')
+      }, 25_000)
+
       const cleanup = () => {
         if (!sessions.has(sessionId)) return
         sessions.delete(sessionId)
+        clearInterval(heartbeat)
         console.error(`[vade-canvas] SSE session close ${sessionId} (total=${sessions.size})`)
         void server.close().catch(() => {})
       }


### PR DESCRIPTION
## Summary
- Fly-proxy closes idle HTTP connections at ~60s. MCP SSE sessions on `vade-canvas` carry no traffic between messages, so the edge was silently killing them and forcing Claude Code to reconnect — bouncing across Fly machines as the proxy load-balanced each fresh SSE GET.
- Emit an SSE comment frame (`:\n\n`) every 25s while the session is open, and clear the interval in the existing cleanup path so we don't leak a timer or write to a closed response.

## Repro / evidence
The machine-ID scoping from #30 made the churn observable in the server logs — sessions consistently opened on one `FLY_MACHINE_ID` and closed ~60–70s later, then reopened on a different machine:

```
02:13:42 SSE session open a7bb894a on 7841e0ea213678
02:14:54 SSE session close a7bb894a
02:14:54 SSE session open f917b76b on 2869e6ea9d4968
```

From the client side this looked like `Canvas not connected` on every other MCP tool call.

## Test plan
- [x] Deploy to Fly, open an MCP SSE session, leave it idle for ≥2 minutes, confirm it stays open (no close log until the client disconnects).
- [x] Issue MCP tool calls back-to-back across the 60s mark — no `Unknown sessionId` / `Canvas not connected` errors.
- [x] Local `VADE_MCP_TRANSPORT=sse npm run mcp` still works; cleanup clears the interval on client disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)