### PR TITLE
Precompile MCP server and extend Fly start grace period

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .devcontainer
 node_modules
 dist
+dist-mcp
 .vade
 .env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-mcp/
 build/
 .DS_Store
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:20.19.1-bookworm-slim
 
-RUN npm install -g tsx@4.21.0 && npm cache clean --force
-
 # Ephemeral today; backed by a Fly volume once storage-abstraction lands.
 RUN mkdir -p /home/node/.vade/library/canvases \
              /home/node/.vade/library/entities \
@@ -11,10 +9,17 @@ USER node
 WORKDIR /app
 
 COPY --chown=node:node package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci
 
-COPY --chown=node:node tsconfig.json tsconfig.node.json ./
+COPY --chown=node:node tsconfig.json tsconfig.node.json tsconfig.mcp.build.json ./
 COPY --chown=node:node mcp ./mcp
+
+# Precompile the MCP server so boot doesn't pay tsx's JIT-transpile
+# cost — matters on Fly where the startup probe has a short grace
+# period.
+RUN npx tsc -p tsconfig.mcp.build.json \
+    && npm prune --omit=dev \
+    && npm cache clean --force
 
 ENV VADE_MCP_TRANSPORT=sse
 ENV VADE_MCP_HTTP_PORT=8080
@@ -24,4 +29,4 @@ ENV VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas
 
 EXPOSE 8080
 
-CMD ["tsx", "mcp/index.ts"]
+CMD ["node", "dist-mcp/index.js"]

--- a/fly.toml
+++ b/fly.toml
@@ -21,7 +21,7 @@ primary_region = 'fra'
   [[http_service.checks]]
     interval = '30s'
     timeout = '5s'
-    grace_period = '10s'
+    grace_period = '30s'
     method = 'GET'
     path = '/healthz'
 

--- a/tsconfig.mcp.build.json
+++ b/tsconfig.mcp.build.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist-mcp",
+    "rootDir": "mcp"
+  },
+  "include": ["mcp"]
+}


### PR DESCRIPTION
## Summary
- The image ran the MCP server with `tsx mcp/index.ts`, which JIT-transpiles on every boot. On Fly's shared-CPU 512MB VM this can exceed the 10s health-check grace period, causing the proxy to warn that nothing is listening on `:8080` and — worse — mark the machine unhealthy and cycle it. Cycled machines showed up as SSE sessions bouncing between instances in the logs.
- Precompile the `mcp/` tree to plain JS via a new `tsconfig.mcp.build.json`, and run `node dist-mcp/index.js` in the container instead. Dev deps are installed for the build step, then pruned so the runtime image doesn't ship `tsx`/`typescript`.
- Bump the Fly health check `grace_period` from `10s` to `30s` for cold-start headroom.

This is a follow-up to #35 — that PR keeps established SSE sessions alive past Fly's 60s idle close; this one keeps the machine itself from being considered unhealthy during startup.

## Observed evidence
From the previous deploy output:
```
WARNING The app is not listening on the expected address and will not be reachable by fly-proxy.
You can fix this by configuring your app to listen on the following addresses:
  - 0.0.0.0:8080
Found these processes inside the machine with open listening sockets:
 PROCESS        │ ADDRESSES
────────────────┼───────────────────────────────────────
 /.fly/hallpass │ [fdaa:…]:22
```
At probe time only Fly's SSH sidecar was listening; the Node process hadn't bound yet.

## Test plan
- [ ] `docker build . -t vade-mcp:test` completes without errors.
- [ ] `docker run -e VADE_MCP_TRANSPORT=sse -p 8080:8080 vade-mcp:test` — `curl localhost:8080/healthz` returns 200 within a second or two of boot.
- [ ] `flyctl deploy` completes without the "not listening on the expected address" warning.
- [ ] Post-deploy: machines stay healthy (no rolling restarts) and `fly logs` doesn't show unexpected session churn unrelated to client disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)