### PR TITLE
Cloud-backed library storage (R2 + D1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,8 @@
       "Bash(npm install *)",
       "mcp__vade-canvas__createBatch",
       "Bash(flyctl releases *)",
-      "Bash(npm run *)"
+      "Bash(npm run *)",
+      "Bash(gh issue *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM node:20.19.1-bookworm-slim
 
-# Ephemeral today; backed by a Fly volume once storage-abstraction lands.
-RUN mkdir -p /home/node/.vade/library/canvases \
-             /home/node/.vade/library/entities \
-    && chown -R node:node /home/node/.vade
-
 USER node
 WORKDIR /app
 
@@ -23,7 +18,8 @@ RUN npx tsc -p tsconfig.mcp.build.json \
 
 ENV VADE_MCP_TRANSPORT=sse
 ENV VADE_MCP_HTTP_PORT=8080
-ENV VADE_LIBRARY_PATH=/home/node/.vade/library
+ENV VADE_LIBRARY_DRIVER=cloud
+ENV VADE_LIBRARY_API_URL=https://vade-app.dev/library
 ENV NODE_ENV=production
 ENV VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas
 

--- a/fly.toml
+++ b/fly.toml
@@ -7,8 +7,12 @@ primary_region = 'fra'
 [env]
   VADE_MCP_TRANSPORT = 'sse'
   VADE_MCP_HTTP_PORT = '8080'
-  VADE_LIBRARY_PATH = '/home/node/.vade/library'
+  VADE_LIBRARY_DRIVER = 'cloud'
+  VADE_LIBRARY_API_URL = 'https://vade-app.dev/library'
   VITE_BRIDGE_URL = 'wss://mcp.vade-app.dev/canvas'
+
+# VADE_LIBRARY_BEARER is set via `flyctl secrets set` — must match the
+# Worker's LIBRARY_BEARER (`wrangler secret put LIBRARY_BEARER`).
 
 [http_service]
   internal_port = 8080
@@ -29,9 +33,3 @@ primary_region = 'fra'
   cpu_kind = 'shared'
   cpus = 1
   memory_mb = 512
-
-# Enable once the storage-abstraction sub-issue lands and a
-# `vade_library` volume has been created via `flyctl volumes create`.
-# [[mounts]]
-#   source = 'vade_library'
-#   destination = '/home/node/.vade'

--- a/mcp/library.ts
+++ b/mcp/library.ts
@@ -1,16 +1,3 @@
-import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 'fs'
-import { join } from 'path'
-import { homedir } from 'os'
-
-const LIBRARY_ROOT = process.env['VADE_LIBRARY_PATH'] ?? join(homedir(), '.vade', 'library')
-const CANVASES_DIR = join(LIBRARY_ROOT, 'canvases')
-const ENTITIES_DIR = join(LIBRARY_ROOT, 'entities')
-
-function ensureDirs() {
-  mkdirSync(CANVASES_DIR, { recursive: true })
-  mkdirSync(ENTITIES_DIR, { recursive: true })
-}
-
 export interface CanvasMeta {
   name: string
   tags: string[]
@@ -25,117 +12,33 @@ export interface EntityMeta {
   description: string
 }
 
-export function listCanvases(): CanvasMeta[] {
-  ensureDirs()
-  const entries = readdirSync(CANVASES_DIR, { withFileTypes: true })
-  const results: CanvasMeta[] = []
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-    const metaPath = join(CANVASES_DIR, entry.name, 'metadata.json')
-    if (!existsSync(metaPath)) continue
-    try {
-      results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta)
-    } catch {
-      // skip corrupt entries
-    }
+export interface LibraryStore {
+  saveCanvas(name: string, snapshot: unknown, tags: string[], description: string): Promise<CanvasMeta>
+  loadCanvas(name: string): Promise<{ snapshot: unknown; meta: CanvasMeta } | null>
+  listCanvases(): Promise<CanvasMeta[]>
+  saveEntity(name: string, shapes: unknown[], tags: string[], description: string): Promise<EntityMeta>
+  loadEntity(name: string): Promise<{ shapes: unknown[]; meta: EntityMeta } | null>
+  listEntities(): Promise<EntityMeta[]>
+  searchLibrary(query: string): Promise<{ canvases: CanvasMeta[]; entities: EntityMeta[] }>
+}
+
+export function slugify(name: string): string {
+  return name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
+}
+
+let cached: LibraryStore | null = null
+
+export async function getStore(): Promise<LibraryStore> {
+  if (cached) return cached
+  const driver = process.env['VADE_LIBRARY_DRIVER'] ?? 'fs'
+  if (driver === 'cloud') {
+    const { CloudLibraryStore } = await import('./stores/cloud.js')
+    cached = new CloudLibraryStore()
+  } else if (driver === 'fs') {
+    const { FsLibraryStore } = await import('./stores/fs.js')
+    cached = new FsLibraryStore()
+  } else {
+    throw new Error(`Unknown VADE_LIBRARY_DRIVER=${driver}; expected 'fs' or 'cloud'`)
   }
-  return results
-}
-
-export function saveCanvas(name: string, snapshot: unknown, tags: string[] = [], description = '') {
-  ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(CANVASES_DIR, slug)
-  mkdirSync(dir, { recursive: true })
-
-  const now = new Date().toISOString()
-  const existingMeta = (() => {
-    try {
-      return JSON.parse(readFileSync(join(dir, 'metadata.json'), 'utf-8')) as CanvasMeta
-    } catch {
-      return null
-    }
-  })()
-
-  const meta: CanvasMeta = {
-    name,
-    tags,
-    description,
-    created: existingMeta?.created ?? now,
-    modified: now,
-  }
-
-  writeFileSync(join(dir, 'snapshot.tldr'), JSON.stringify(snapshot))
-  writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
-  return meta
-}
-
-export function loadCanvas(name: string): { snapshot: unknown; meta: CanvasMeta } | null {
-  ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(CANVASES_DIR, slug)
-  const snapshotPath = join(dir, 'snapshot.tldr')
-  const metaPath = join(dir, 'metadata.json')
-  if (!existsSync(snapshotPath) || !existsSync(metaPath)) return null
-  return {
-    snapshot: JSON.parse(readFileSync(snapshotPath, 'utf-8')),
-    meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta,
-  }
-}
-
-export function listEntities(): EntityMeta[] {
-  ensureDirs()
-  const entries = readdirSync(ENTITIES_DIR, { withFileTypes: true })
-  const results: EntityMeta[] = []
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-    const metaPath = join(ENTITIES_DIR, entry.name, 'metadata.json')
-    if (!existsSync(metaPath)) continue
-    try {
-      results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta)
-    } catch {
-      // skip corrupt entries
-    }
-  }
-  return results
-}
-
-export function saveEntity(name: string, shapes: unknown[], tags: string[] = [], description = '') {
-  ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(ENTITIES_DIR, slug)
-  mkdirSync(dir, { recursive: true })
-
-  const meta: EntityMeta = { name, tags, description }
-  writeFileSync(join(dir, 'shapes.json'), JSON.stringify(shapes, null, 2))
-  writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
-  return meta
-}
-
-export function loadEntity(name: string): { shapes: unknown[]; meta: EntityMeta } | null {
-  ensureDirs()
-  const slug = name.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
-  const dir = join(ENTITIES_DIR, slug)
-  const shapesPath = join(dir, 'shapes.json')
-  const metaPath = join(dir, 'metadata.json')
-  if (!existsSync(shapesPath) || !existsSync(metaPath)) return null
-  return {
-    shapes: JSON.parse(readFileSync(shapesPath, 'utf-8')) as unknown[],
-    meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta,
-  }
-}
-
-export function searchLibrary(query: string): { canvases: CanvasMeta[]; entities: EntityMeta[] } {
-  const q = query.toLowerCase()
-  const canvases = listCanvases().filter(c =>
-    c.name.toLowerCase().includes(q) ||
-    c.tags.some(t => t.toLowerCase().includes(q)) ||
-    c.description.toLowerCase().includes(q)
-  )
-  const entities = listEntities().filter(e =>
-    e.name.toLowerCase().includes(q) ||
-    e.tags.some(t => t.toLowerCase().includes(q)) ||
-    e.description.toLowerCase().includes(q)
-  )
-  return { canvases, entities }
+  return cached
 }

--- a/mcp/stores/cloud.ts
+++ b/mcp/stores/cloud.ts
@@ -1,0 +1,71 @@
+import type { CanvasMeta, EntityMeta, LibraryStore } from '../library.js'
+import { slugify } from '../library.js'
+
+export class CloudLibraryStore implements LibraryStore {
+  private readonly apiUrl: string
+  private readonly bearer: string
+
+  constructor() {
+    const apiUrl = process.env['VADE_LIBRARY_API_URL']
+    const bearer = process.env['VADE_LIBRARY_BEARER']
+    if (!apiUrl) throw new Error('VADE_LIBRARY_API_URL must be set when VADE_LIBRARY_DRIVER=cloud')
+    if (!bearer) throw new Error('VADE_LIBRARY_BEARER must be set when VADE_LIBRARY_DRIVER=cloud')
+    this.apiUrl = apiUrl.replace(/\/$/, '')
+    this.bearer = bearer
+  }
+
+  private async req(method: string, path: string, body?: unknown): Promise<Response> {
+    const res = await fetch(`${this.apiUrl}${path}`, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${this.bearer}`,
+        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+    return res
+  }
+
+  private async json<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await this.req(method, path, body)
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`Cloud library ${method} ${path} failed: ${res.status} ${text}`)
+    }
+    return (await res.json()) as T
+  }
+
+  async saveCanvas(name: string, snapshot: unknown, tags: string[], description: string): Promise<CanvasMeta> {
+    return this.json<CanvasMeta>('PUT', `/canvases/${slugify(name)}`, { name, snapshot, tags, description })
+  }
+
+  async loadCanvas(name: string): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+    const res = await this.req('GET', `/canvases/${slugify(name)}`)
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`Cloud library GET canvas failed: ${res.status}`)
+    return (await res.json()) as { snapshot: unknown; meta: CanvasMeta }
+  }
+
+  async listCanvases(): Promise<CanvasMeta[]> {
+    return this.json<CanvasMeta[]>('GET', `/canvases`)
+  }
+
+  async saveEntity(name: string, shapes: unknown[], tags: string[], description: string): Promise<EntityMeta> {
+    return this.json<EntityMeta>('PUT', `/entities/${slugify(name)}`, { name, shapes, tags, description })
+  }
+
+  async loadEntity(name: string): Promise<{ shapes: unknown[]; meta: EntityMeta } | null> {
+    const res = await this.req('GET', `/entities/${slugify(name)}`)
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`Cloud library GET entity failed: ${res.status}`)
+    return (await res.json()) as { shapes: unknown[]; meta: EntityMeta }
+  }
+
+  async listEntities(): Promise<EntityMeta[]> {
+    return this.json<EntityMeta[]>('GET', `/entities`)
+  }
+
+  async searchLibrary(query: string): Promise<{ canvases: CanvasMeta[]; entities: EntityMeta[] }> {
+    return this.json('GET', `/search?q=${encodeURIComponent(query)}`)
+  }
+}

--- a/mcp/stores/fs.ts
+++ b/mcp/stores/fs.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import type { CanvasMeta, EntityMeta, LibraryStore } from '../library.js'
+import { slugify } from '../library.js'
+
+export class FsLibraryStore implements LibraryStore {
+  private readonly root: string
+  private readonly canvasesDir: string
+  private readonly entitiesDir: string
+
+  constructor(root?: string) {
+    this.root = root ?? process.env['VADE_LIBRARY_PATH'] ?? join(homedir(), '.vade', 'library')
+    this.canvasesDir = join(this.root, 'canvases')
+    this.entitiesDir = join(this.root, 'entities')
+  }
+
+  private ensureDirs() {
+    mkdirSync(this.canvasesDir, { recursive: true })
+    mkdirSync(this.entitiesDir, { recursive: true })
+  }
+
+  async listCanvases(): Promise<CanvasMeta[]> {
+    this.ensureDirs()
+    const entries = readdirSync(this.canvasesDir, { withFileTypes: true })
+    const results: CanvasMeta[] = []
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const metaPath = join(this.canvasesDir, entry.name, 'metadata.json')
+      if (!existsSync(metaPath)) continue
+      try {
+        results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta)
+      } catch {
+        // skip corrupt entries
+      }
+    }
+    return results
+  }
+
+  async saveCanvas(name: string, snapshot: unknown, tags: string[], description: string): Promise<CanvasMeta> {
+    this.ensureDirs()
+    const dir = join(this.canvasesDir, slugify(name))
+    mkdirSync(dir, { recursive: true })
+
+    const now = new Date().toISOString()
+    const existingMeta = (() => {
+      try {
+        return JSON.parse(readFileSync(join(dir, 'metadata.json'), 'utf-8')) as CanvasMeta
+      } catch {
+        return null
+      }
+    })()
+
+    const meta: CanvasMeta = {
+      name,
+      tags,
+      description,
+      created: existingMeta?.created ?? now,
+      modified: now,
+    }
+
+    writeFileSync(join(dir, 'snapshot.tldr'), JSON.stringify(snapshot))
+    writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
+    return meta
+  }
+
+  async loadCanvas(name: string): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+    this.ensureDirs()
+    const dir = join(this.canvasesDir, slugify(name))
+    const snapshotPath = join(dir, 'snapshot.tldr')
+    const metaPath = join(dir, 'metadata.json')
+    if (!existsSync(snapshotPath) || !existsSync(metaPath)) return null
+    return {
+      snapshot: JSON.parse(readFileSync(snapshotPath, 'utf-8')),
+      meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta,
+    }
+  }
+
+  async listEntities(): Promise<EntityMeta[]> {
+    this.ensureDirs()
+    const entries = readdirSync(this.entitiesDir, { withFileTypes: true })
+    const results: EntityMeta[] = []
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const metaPath = join(this.entitiesDir, entry.name, 'metadata.json')
+      if (!existsSync(metaPath)) continue
+      try {
+        results.push(JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta)
+      } catch {
+        // skip corrupt entries
+      }
+    }
+    return results
+  }
+
+  async saveEntity(name: string, shapes: unknown[], tags: string[], description: string): Promise<EntityMeta> {
+    this.ensureDirs()
+    const dir = join(this.entitiesDir, slugify(name))
+    mkdirSync(dir, { recursive: true })
+
+    const meta: EntityMeta = { name, tags, description }
+    writeFileSync(join(dir, 'shapes.json'), JSON.stringify(shapes, null, 2))
+    writeFileSync(join(dir, 'metadata.json'), JSON.stringify(meta, null, 2))
+    return meta
+  }
+
+  async loadEntity(name: string): Promise<{ shapes: unknown[]; meta: EntityMeta } | null> {
+    this.ensureDirs()
+    const dir = join(this.entitiesDir, slugify(name))
+    const shapesPath = join(dir, 'shapes.json')
+    const metaPath = join(dir, 'metadata.json')
+    if (!existsSync(shapesPath) || !existsSync(metaPath)) return null
+    return {
+      shapes: JSON.parse(readFileSync(shapesPath, 'utf-8')) as unknown[],
+      meta: JSON.parse(readFileSync(metaPath, 'utf-8')) as EntityMeta,
+    }
+  }
+
+  async searchLibrary(query: string): Promise<{ canvases: CanvasMeta[]; entities: EntityMeta[] }> {
+    const q = query.toLowerCase()
+    const [allC, allE] = await Promise.all([this.listCanvases(), this.listEntities()])
+    const canvases = allC.filter(c =>
+      c.name.toLowerCase().includes(q) ||
+      c.tags.some(t => t.toLowerCase().includes(q)) ||
+      c.description.toLowerCase().includes(q),
+    )
+    const entities = allE.filter(e =>
+      e.name.toLowerCase().includes(q) ||
+      e.tags.some(t => t.toLowerCase().includes(q)) ||
+      e.description.toLowerCase().includes(q),
+    )
+    return { canvases, entities }
+  }
+}

--- a/mcp/tools/canvas.ts
+++ b/mcp/tools/canvas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CanvasBridge } from '../ws-server.js'
 import { makeId } from '../protocol.js'
-import * as lib from '../library.js'
+import { getStore } from '../library.js'
 
 export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
   server.registerTool('saveCanvas', {
@@ -14,7 +14,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
     },
   }, async ({ name, tags, description }) => {
     const snapshot = await bridge.send({ type: 'getSnapshot', id: makeId() })
-    const meta = lib.saveCanvas(name, snapshot, tags ?? [], description ?? '')
+    const store = await getStore()
+    const meta = await store.saveCanvas(name, snapshot, tags ?? [], description ?? '')
     return { content: [{ type: 'text' as const, text: `Saved canvas "${name}"\n${JSON.stringify(meta, null, 2)}` }] }
   })
 
@@ -24,7 +25,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
       name: z.string().describe('Name of the canvas to load'),
     },
   }, async ({ name }) => {
-    const result = lib.loadCanvas(name)
+    const store = await getStore()
+    const result = await store.loadCanvas(name)
     if (!result) {
       return { content: [{ type: 'text' as const, text: `Canvas "${name}" not found in library.` }] }
     }
@@ -35,7 +37,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
   server.registerTool('listCanvases', {
     description: 'List all saved canvases in the library.',
   }, async () => {
-    const canvases = lib.listCanvases()
+    const store = await getStore()
+    const canvases = await store.listCanvases()
     if (canvases.length === 0) {
       return { content: [{ type: 'text' as const, text: 'No canvases saved yet.' }] }
     }
@@ -48,7 +51,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
       query: z.string().describe('Search query'),
     },
   }, async ({ query }) => {
-    const results = lib.searchLibrary(query)
+    const store = await getStore()
+    const results = await store.searchLibrary(query)
     return { content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }] }
   })
 
@@ -80,7 +84,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
       id: undefined,
     }))
 
-    const meta = lib.saveEntity(name, normalized, tags ?? [], description ?? '')
+    const store = await getStore()
+    const meta = await store.saveEntity(name, normalized, tags ?? [], description ?? '')
     return { content: [{ type: 'text' as const, text: `Saved entity "${name}" (${selected.length} shapes)\n${JSON.stringify(meta, null, 2)}` }] }
   })
 
@@ -92,7 +97,8 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
       y: z.number().optional().describe('Y position to place entity (default: 0)'),
     },
   }, async ({ name, x, y }) => {
-    const result = lib.loadEntity(name)
+    const store = await getStore()
+    const result = await store.loadEntity(name)
     if (!result) {
       return { content: [{ type: 'text' as const, text: `Entity "${name}" not found.` }] }
     }

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS canvases (
+  slug        TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  tags        TEXT NOT NULL DEFAULT '[]',
+  description TEXT NOT NULL DEFAULT '',
+  created     TEXT NOT NULL,
+  modified    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS canvases_modified_idx ON canvases (modified DESC);
+
+CREATE TABLE IF NOT EXISTS entities (
+  slug        TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  tags        TEXT NOT NULL DEFAULT '[]',
+  description TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS entities_name_idx ON entities (name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.32.3",
+        "@cloudflare/workers-types": "^4.20260420.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@types/ws": "^8.18.1",
@@ -460,6 +461,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260420.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260420.1.tgz",
+      "integrity": "sha512-DHT9JnSn9cIiCSdL76OxW+Xvc1+ml1CWzWvgVwreoHQ+E604aeFxPPHp9X7nE+XRWm2NH4l0OgtxUI5T/nuI3g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "mcp:stdio": "tsx mcp/index.ts",
     "mcp:sse": "VADE_MCP_TRANSPORT=sse VADE_MCP_HTTP_PORT=8080 tsx mcp/index.ts",
     "dev:all": "concurrently \"npm run dev\" \"npm run mcp\"",
-    "deploy": "npm run build && wrangler deploy"
+    "deploy": "npm run build && wrangler deploy",
+    "migrate-library": "tsx scripts/migrate-library.ts",
+    "typecheck:worker": "tsc -p tsconfig.worker.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.32.3",
+    "@cloudflare/workers-types": "^4.20260420.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/ws": "^8.18.1",

--- a/scripts/migrate-library.ts
+++ b/scripts/migrate-library.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot migration: copy a populated local `~/.vade/library/` up to
+ * the cloud-backed library behind the Worker.
+ *
+ * Usage:
+ *   VADE_LIBRARY_API_URL=https://vade-app.dev/library \
+ *   VADE_LIBRARY_BEARER=<secret> \
+ *   VADE_LIBRARY_PATH=~/.vade/library \   # optional; defaults to this
+ *   tsx scripts/migrate-library.ts
+ */
+import { FsLibraryStore } from '../mcp/stores/fs.js'
+import { CloudLibraryStore } from '../mcp/stores/cloud.js'
+
+async function main() {
+  const fs = new FsLibraryStore()
+  const cloud = new CloudLibraryStore()
+
+  const canvases = await fs.listCanvases()
+  console.log(`[migrate] ${canvases.length} canvases found locally`)
+  for (const meta of canvases) {
+    const loaded = await fs.loadCanvas(meta.name)
+    if (!loaded) {
+      console.warn(`[migrate] skip "${meta.name}" — could not read snapshot`)
+      continue
+    }
+    await cloud.saveCanvas(meta.name, loaded.snapshot, meta.tags, meta.description)
+    console.log(`[migrate] canvas "${meta.name}" → cloud`)
+  }
+
+  const entities = await fs.listEntities()
+  console.log(`[migrate] ${entities.length} entities found locally`)
+  for (const meta of entities) {
+    const loaded = await fs.loadEntity(meta.name)
+    if (!loaded) {
+      console.warn(`[migrate] skip entity "${meta.name}" — could not read shapes`)
+      continue
+    }
+    await cloud.saveEntity(meta.name, loaded.shapes, meta.tags, meta.description)
+    console.log(`[migrate] entity "${meta.name}" → cloud`)
+  }
+
+  console.log('[migrate] done')
+}
+
+main().catch(err => {
+  console.error('[migrate] failed:', err)
+  process.exit(1)
+})

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022"]
+  },
+  "include": ["worker"]
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,18 @@
+import { handleLibrary } from './library.js'
+
+export interface Env {
+  ASSETS: Fetcher
+  LIBRARY_R2: R2Bucket
+  LIBRARY_D1: D1Database
+  LIBRARY_BEARER: string
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    if (url.pathname === '/library' || url.pathname.startsWith('/library/')) {
+      return handleLibrary(request, env, url)
+    }
+    return env.ASSETS.fetch(request)
+  },
+}

--- a/worker/library.ts
+++ b/worker/library.ts
@@ -1,0 +1,230 @@
+import type { Env } from './index.js'
+
+type CanvasMeta = {
+  name: string
+  tags: string[]
+  description: string
+  created: string
+  modified: string
+}
+
+type EntityMeta = {
+  name: string
+  tags: string[]
+  description: string
+}
+
+type CanvasRow = {
+  slug: string
+  name: string
+  tags: string
+  description: string
+  created: string
+  modified: string
+}
+
+type EntityRow = {
+  slug: string
+  name: string
+  tags: string
+  description: string
+}
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const text = (body: string, status: number): Response =>
+  new Response(body, { status, headers: { 'Content-Type': 'text/plain' } })
+
+function canvasMetaFromRow(row: CanvasRow): CanvasMeta {
+  return {
+    name: row.name,
+    tags: JSON.parse(row.tags) as string[],
+    description: row.description,
+    created: row.created,
+    modified: row.modified,
+  }
+}
+
+function entityMetaFromRow(row: EntityRow): EntityMeta {
+  return {
+    name: row.name,
+    tags: JSON.parse(row.tags) as string[],
+    description: row.description,
+  }
+}
+
+function canvasKey(slug: string): string {
+  return `canvases/${slug}/snapshot.tldr`
+}
+
+function entityKey(slug: string): string {
+  return `entities/${slug}/shapes.json`
+}
+
+export async function handleLibrary(req: Request, env: Env, url: URL): Promise<Response> {
+  const auth = req.headers.get('Authorization') ?? ''
+  const expected = `Bearer ${env.LIBRARY_BEARER}`
+  if (!env.LIBRARY_BEARER || auth !== expected) {
+    return text('Unauthorized', 401)
+  }
+
+  const parts = url.pathname.split('/').filter(Boolean)
+  // [ 'library', <resource>, <slug?> ]
+  const resource = parts[1]
+  const slug = parts[2]
+
+  try {
+    if (resource === 'canvases') {
+      if (!slug) {
+        if (req.method === 'GET') return listCanvases(env)
+        return text('Method not allowed', 405)
+      }
+      if (req.method === 'GET') return getCanvas(env, slug)
+      if (req.method === 'PUT') return putCanvas(env, slug, await req.json())
+      return text('Method not allowed', 405)
+    }
+
+    if (resource === 'entities') {
+      if (!slug) {
+        if (req.method === 'GET') return listEntities(env)
+        return text('Method not allowed', 405)
+      }
+      if (req.method === 'GET') return getEntity(env, slug)
+      if (req.method === 'PUT') return putEntity(env, slug, await req.json())
+      return text('Method not allowed', 405)
+    }
+
+    if (resource === 'search' && req.method === 'GET') {
+      return search(env, url.searchParams.get('q') ?? '')
+    }
+
+    return text('Not found', 404)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return text(`Library error: ${msg}`, 500)
+  }
+}
+
+async function listCanvases(env: Env): Promise<Response> {
+  const { results } = await env.LIBRARY_D1
+    .prepare('SELECT slug, name, tags, description, created, modified FROM canvases ORDER BY modified DESC')
+    .all<CanvasRow>()
+  return json(results.map(canvasMetaFromRow))
+}
+
+async function getCanvas(env: Env, slug: string): Promise<Response> {
+  const row = await env.LIBRARY_D1
+    .prepare('SELECT slug, name, tags, description, created, modified FROM canvases WHERE slug = ?')
+    .bind(slug)
+    .first<CanvasRow>()
+  if (!row) return text('Not found', 404)
+  const obj = await env.LIBRARY_R2.get(canvasKey(slug))
+  if (!obj) return text('Not found', 404)
+  const snapshot = JSON.parse(await obj.text())
+  return json({ snapshot, meta: canvasMetaFromRow(row) })
+}
+
+async function putCanvas(env: Env, slug: string, body: unknown): Promise<Response> {
+  const b = body as { name?: unknown; snapshot?: unknown; tags?: unknown; description?: unknown }
+  if (typeof b.name !== 'string') return text('name required', 400)
+  if (b.snapshot === undefined) return text('snapshot required', 400)
+  const tags = Array.isArray(b.tags) ? (b.tags as string[]) : []
+  const description = typeof b.description === 'string' ? b.description : ''
+  const now = new Date().toISOString()
+
+  const existing = await env.LIBRARY_D1
+    .prepare('SELECT created FROM canvases WHERE slug = ?')
+    .bind(slug)
+    .first<{ created: string }>()
+  const created = existing?.created ?? now
+
+  await env.LIBRARY_R2.put(canvasKey(slug), JSON.stringify(b.snapshot))
+  await env.LIBRARY_D1
+    .prepare(
+      `INSERT INTO canvases (slug, name, tags, description, created, modified)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(slug) DO UPDATE SET
+         name = excluded.name,
+         tags = excluded.tags,
+         description = excluded.description,
+         modified = excluded.modified`,
+    )
+    .bind(slug, b.name, JSON.stringify(tags), description, created, now)
+    .run()
+
+  return json({ name: b.name, tags, description, created, modified: now } satisfies CanvasMeta)
+}
+
+async function listEntities(env: Env): Promise<Response> {
+  const { results } = await env.LIBRARY_D1
+    .prepare('SELECT slug, name, tags, description FROM entities ORDER BY name')
+    .all<EntityRow>()
+  return json(results.map(entityMetaFromRow))
+}
+
+async function getEntity(env: Env, slug: string): Promise<Response> {
+  const row = await env.LIBRARY_D1
+    .prepare('SELECT slug, name, tags, description FROM entities WHERE slug = ?')
+    .bind(slug)
+    .first<EntityRow>()
+  if (!row) return text('Not found', 404)
+  const obj = await env.LIBRARY_R2.get(entityKey(slug))
+  if (!obj) return text('Not found', 404)
+  const shapes = JSON.parse(await obj.text()) as unknown[]
+  return json({ shapes, meta: entityMetaFromRow(row) })
+}
+
+async function putEntity(env: Env, slug: string, body: unknown): Promise<Response> {
+  const b = body as { name?: unknown; shapes?: unknown; tags?: unknown; description?: unknown }
+  if (typeof b.name !== 'string') return text('name required', 400)
+  if (!Array.isArray(b.shapes)) return text('shapes must be array', 400)
+  const tags = Array.isArray(b.tags) ? (b.tags as string[]) : []
+  const description = typeof b.description === 'string' ? b.description : ''
+
+  await env.LIBRARY_R2.put(entityKey(slug), JSON.stringify(b.shapes))
+  await env.LIBRARY_D1
+    .prepare(
+      `INSERT INTO entities (slug, name, tags, description)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(slug) DO UPDATE SET
+         name = excluded.name,
+         tags = excluded.tags,
+         description = excluded.description`,
+    )
+    .bind(slug, b.name, JSON.stringify(tags), description)
+    .run()
+
+  return json({ name: b.name, tags, description } satisfies EntityMeta)
+}
+
+async function search(env: Env, query: string): Promise<Response> {
+  // D1 doesn't have a great fuzzy search primitive; fall back to
+  // LIKE on name/description/tags (tags are JSON-encoded, so
+  // substring hits the raw JSON which is fine for single-user scale).
+  const q = `%${query.toLowerCase()}%`
+  const canvasQ = env.LIBRARY_D1
+    .prepare(
+      `SELECT slug, name, tags, description, created, modified FROM canvases
+       WHERE lower(name) LIKE ? OR lower(description) LIKE ? OR lower(tags) LIKE ?
+       ORDER BY modified DESC`,
+    )
+    .bind(q, q, q)
+    .all<CanvasRow>()
+  const entityQ = env.LIBRARY_D1
+    .prepare(
+      `SELECT slug, name, tags, description FROM entities
+       WHERE lower(name) LIKE ? OR lower(description) LIKE ? OR lower(tags) LIKE ?
+       ORDER BY name`,
+    )
+    .bind(q, q, q)
+    .all<EntityRow>()
+  const [c, e] = await Promise.all([canvasQ, entityQ])
+  return json({
+    canvases: c.results.map(canvasMetaFromRow),
+    entities: e.results.map(entityMetaFromRow),
+  })
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "vade-core",
+  "main": "worker/index.ts",
   "compatibility_date": "2026-04-19",
   "routes": [
     { "pattern": "vade-app.dev", "custom_domain": true },
@@ -10,9 +11,26 @@
     "enabled": true
   },
   "assets": {
-    "not_found_handling": "single-page-application"
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
   },
   "compatibility_flags": [
     "nodejs_compat"
+  ],
+  "r2_buckets": [
+    {
+      "binding": "LIBRARY_R2",
+      "bucket_name": "vade-library"
+    }
+  ],
+  "d1_databases": [
+    {
+      "binding": "LIBRARY_D1",
+      "database_name": "vade-library",
+      "database_id": "REPLACE_WITH_D1_ID",
+      "migrations_dir": "migrations"
+    }
   ]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,36 +1,42 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "vade-core",
-  "main": "worker/index.ts",
-  "compatibility_date": "2026-04-19",
-  "routes": [
-    { "pattern": "vade-app.dev", "custom_domain": true },
-    { "pattern": "www.vade-app.dev", "custom_domain": true }
-  ],
-  "observability": {
-    "enabled": true
-  },
-  "assets": {
-    "directory": "./dist",
-    "binding": "ASSETS",
-    "not_found_handling": "single-page-application",
-    "run_worker_first": true
-  },
-  "compatibility_flags": [
-    "nodejs_compat"
-  ],
-  "r2_buckets": [
-    {
-      "binding": "LIBRARY_R2",
-      "bucket_name": "vade-library"
-    }
-  ],
-  "d1_databases": [
-    {
-      "binding": "LIBRARY_D1",
-      "database_name": "vade-library",
-      "database_id": "REPLACE_WITH_D1_ID",
-      "migrations_dir": "migrations"
-    }
-  ]
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "vade-core",
+	"main": "worker/index.ts",
+	"compatibility_date": "2026-04-19",
+	"routes": [
+		{
+			"pattern": "vade-app.dev",
+			"custom_domain": true
+		},
+		{
+			"pattern": "www.vade-app.dev",
+			"custom_domain": true
+		}
+	],
+	"observability": {
+		"enabled": true
+	},
+	"assets": {
+		"directory": "./dist",
+		"binding": "ASSETS",
+		"not_found_handling": "single-page-application",
+		"run_worker_first": true
+	},
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"r2_buckets": [
+		{
+			"binding": "LIBRARY_R2",
+			"bucket_name": "vade-library"
+		}
+	],
+	"d1_databases": [
+		{
+			"binding": "vade_library",
+			"database_name": "vade-library",
+			"database_id": "9a3ff295-d190-40a5-be3b-1f2af0111d1d",
+			"remote": true
+		}
+	]
 }


### PR DESCRIPTION
## Summary

- Extracts `LibraryStore` interface in `mcp/library.ts`; keeps FS impl as `FsLibraryStore` (default) and adds `CloudLibraryStore` that speaks HTTPS to a `/library/*` route on the `vade-core` Worker.
- Worker bearer-gates the route and persists snapshots to R2 with metadata + substring search in D1.
- Driver selected by `VADE_LIBRARY_DRIVER=fs|cloud` (default `fs`). MCP container now defaults to `cloud`, targeting `https://vade-app.dev/library`.
- One-shot migration script (`scripts/migrate-library.ts`) copies a populated local `~/.vade/library/` up to the cloud.

Closes #8. Part of #5.

## Files

- `mcp/library.ts` — interface + `getStore()` selector
- `mcp/stores/{fs,cloud}.ts` — impls
- `mcp/tools/canvas.ts` — tool handlers now `await store.*`
- `worker/{index,library}.ts` — Worker entry + library routes
- `migrations/0001_init.sql` — D1 schema (`canvases`, `entities`)
- `wrangler.jsonc` — `main`, R2 + D1 bindings, `run_worker_first`
- `tsconfig.worker.json`, `@cloudflare/workers-types` devDep
- `scripts/migrate-library.ts`, `package.json` script
- `Dockerfile` + `fly.toml` — default `VADE_LIBRARY_DRIVER=cloud`; dropped commented Fly volume stub
- `.claude/settings.local.json` — allow `gh issue *`

## One-time setup before the cloud driver works

Run on the Cloudflare side:

```bash
wrangler r2 bucket create vade-library
wrangler d1 create vade-library              # copy the database_id into wrangler.jsonc
wrangler d1 migrations apply vade-library    # applies migrations/0001_init.sql
wrangler secret put LIBRARY_BEARER           # generate a secret, paste when prompted
```

Then mirror the same secret to Fly so the MCP container can call the Worker:

```bash
flyctl secrets set VADE_LIBRARY_BEARER=<same-secret> --app vade-mcp
```

After that, `npm run deploy` (Worker) and a Fly redeploy pick up the new routes. Migration: `VADE_LIBRARY_API_URL=https://vade-app.dev/library VADE_LIBRARY_BEARER=<secret> npm run migrate-library`.

## Test plan

- [ ] Local dev with `VADE_LIBRARY_DRIVER=fs` (default) — `npm run dev:all`, save/load canvas, behaviour unchanged
- [ ] `npm run typecheck:worker` passes
- [ ] `npm run build` passes (Worker + SPA)
- [ ] After Cloudflare setup: `curl -H "Authorization: Bearer $LIBRARY_BEARER" https://vade-app.dev/library/canvases` returns `[]`
- [ ] Save a canvas from the iPad with Fly MCP pointed at cloud driver; force-redeploy Fly; reload iPad — canvas survives
- [ ] `npm run migrate-library` on a populated local library round-trips to the cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)