### PR TITLE
Gate hosted canvas + MCP with operator bearer tokens

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a2d7a553-34d9-4614-bae3-02f7708fab3d","pid":77540,"acquiredAt":1776660717042}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,9 @@
       "mcp__vade-canvas__saveCanvas",
       "Bash(gh run *)",
       "Bash(gh project *)",
-      "Bash(python3 -c \"import sys,json;d=json.load\\(sys.stdin\\);[print\\(i['content']['number'],i['id'],i.get\\('status','?'\\),i['content']['title']\\) for i in d['items'] if i.get\\('content',{}\\).get\\('number'\\) in \\(5,7,8,9,10,11\\)]\")"
+      "Bash(python3 -c \"import sys,json;d=json.load\\(sys.stdin\\);[print\\(i['content']['number'],i['id'],i.get\\('status','?'\\),i['content']['title']\\) for i in d['items'] if i.get\\('content',{}\\).get\\('number'\\) in \\(5,7,8,9,10,11\\)]\")",
+      "mcp__claude_ai_Customgithub__issue_read",
+      "WebFetch(domain:github.com)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -47,7 +47,8 @@
       "Bash(gh project *)",
       "Bash(python3 -c \"import sys,json;d=json.load\\(sys.stdin\\);[print\\(i['content']['number'],i['id'],i.get\\('status','?'\\),i['content']['title']\\) for i in d['items'] if i.get\\('content',{}\\).get\\('number'\\) in \\(5,7,8,9,10,11\\)]\")",
       "mcp__claude_ai_Customgithub__issue_read",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(gh api *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,118 @@
+# Authentication
+
+Single-operator bearer-token auth for the hosted canvas and MCP
+service. Three client-facing surfaces are gated:
+
+| Surface | Endpoint | How the token travels |
+|---|---|---|
+| Canvas SPA bootstrap | `https://vade-app.dev` | Prompt on first load, persisted in `localStorage` |
+| MCP SSE transport | `https://mcp.vade-app.dev/sse` + `/messages/<machine-id>` | `Authorization: Bearer <token>` |
+| Canvas↔MCP WebSocket | `wss://mcp.vade-app.dev/canvas` | `Sec-WebSocket-Protocol: vade-canvas, vade-auth.<token>` |
+
+`LIBRARY_BEARER` (Worker) ↔ `VADE_LIBRARY_BEARER` (Fly) is a separate
+service-to-service secret. Client tokens do not grant direct access
+to the Worker's `/library/*` route — that keeps the blast radius of a
+leaked client token to the MCP surface only.
+
+## Config shape
+
+The MCP service reads a single JSON env var:
+
+```json
+{
+  "operator": ["<operator-token-1>"],
+  "agents": []
+}
+```
+
+`operator` is the operator's tokens (iPad PWA, personal Claude Code
+instances). `agents` reserves space for a future second principal
+(autonomous agent identities); M1 ships with it empty. Validation
+accepts any token from either list; the role is logged but not yet
+used for capability separation.
+
+## Mint a token
+
+```sh
+openssl rand -hex 32
+```
+
+Store in 1Password / Keychain. Never commit.
+
+## Set on Fly
+
+```sh
+TOKEN=$(openssl rand -hex 32)
+flyctl secrets set \
+  VADE_AUTH_TOKENS="$(jq -cn --arg t "$TOKEN" '{operator:[$t],agents:[]}')" \
+  --app vade-mcp
+```
+
+The Fly machine restarts automatically on secret change. If
+`VADE_AUTH_TOKENS` is unset when `VADE_MCP_TRANSPORT=sse`, the
+process exits at startup — **fail closed**.
+
+## iPad PWA first load
+
+1. Open `https://vade-app.dev`.
+2. Paste the token into the prompt, tap **Connect**.
+3. The token is stored in `localStorage` under `vade-auth-token`.
+4. Add to Home Screen for PWA mode.
+
+If the MCP indicator shows `bad token`, tap it to clear and re-enter.
+
+## Claude Code (remote MCP client)
+
+Add to your Claude Code MCP config:
+
+```json
+{
+  "mcpServers": {
+    "vade-canvas": {
+      "type": "sse",
+      "url": "https://mcp.vade-app.dev/sse",
+      "headers": {
+        "Authorization": "Bearer <paste-token-here>"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Code so it picks up the new config. A full remote-MCP
+setup walkthrough lives under issue #11.
+
+## Rotation
+
+1. Mint a new token.
+2. `flyctl secrets set VADE_AUTH_TOKENS='{"operator":["<new>"],"agents":[]}' --app vade-mcp`
+3. Wait for the Fly machine to restart (~15s).
+4. On the iPad: tap the `bad token` indicator, paste the new token.
+5. Update the Claude Code MCP config, restart Claude Code.
+
+To support zero-downtime rotation, include both old and new tokens
+in the operator array during a cutover window:
+
+```json
+{ "operator": ["<new>", "<old>"], "agents": [] }
+```
+
+Then remove `<old>` after every client has moved over.
+
+## Threat model (M1)
+
+In-scope:
+
+- Anonymous internet traffic hitting the hosted endpoints.
+- Accidental exposure of the canvas URL.
+
+Out-of-scope (M1 is single-operator):
+
+- Per-principal capability separation (role is logged, not enforced).
+- Token leakage via browser XSS — mitigated operationally (we run one
+  trusted SPA). Future hardening: move the token to an httpOnly
+  cookie with a same-origin proxy.
+- WebSocket subprotocol logging — Fly's edge does not routinely log
+  `Sec-*` headers, but they can appear in verbose access logs. For
+  M1 this is acceptable; if it becomes load-bearing, switch to a
+  short-lived signed subprotocol token derived from the bearer.

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,10 @@ primary_region = 'fra'
 
 # VADE_LIBRARY_BEARER is set via `flyctl secrets set` — must match the
 # Worker's LIBRARY_BEARER (`wrangler secret put LIBRARY_BEARER`).
+#
+# VADE_AUTH_TOKENS is set via `flyctl secrets set` — JSON of shape
+# `{"operator":["..."],"agents":["..."]}`. Required in SSE mode; the
+# process exits at startup if unset. See docs/auth.md.
 
 [http_service]
   internal_port = 8080

--- a/mcp/auth.ts
+++ b/mcp/auth.ts
@@ -1,0 +1,108 @@
+import { Buffer } from 'node:buffer'
+import { timingSafeEqual } from 'node:crypto'
+
+export type Role = 'operator' | 'agent'
+
+export type Principal = {
+  role: Role
+  tokenId: string
+}
+
+export type AuthConfig = {
+  operator: string[]
+  agents: string[]
+}
+
+const CLIENT_SUBPROTOCOL = 'vade-canvas'
+const TOKEN_SUBPROTOCOL_PREFIX = 'vade-auth.'
+
+export function loadAuthConfig(raw: string | undefined | null): AuthConfig {
+  if (!raw || !raw.trim()) {
+    throw new Error('VADE_AUTH_TOKENS is required (set via `flyctl secrets set`)')
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`VADE_AUTH_TOKENS is not valid JSON: ${msg}`)
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('VADE_AUTH_TOKENS must be an object { operator: [...], agents: [...] }')
+  }
+  const obj = parsed as Record<string, unknown>
+  const operator = normalizeList(obj['operator'], 'operator')
+  const agents = normalizeList(obj['agents'], 'agents')
+  if (operator.length === 0 && agents.length === 0) {
+    throw new Error('VADE_AUTH_TOKENS must contain at least one token')
+  }
+  return { operator, agents }
+}
+
+function normalizeList(value: unknown, name: string): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) {
+    throw new Error(`VADE_AUTH_TOKENS.${name} must be an array of strings`)
+  }
+  const tokens: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      throw new Error(`VADE_AUTH_TOKENS.${name} contains an empty or non-string token`)
+    }
+    tokens.push(entry.trim())
+  }
+  return tokens
+}
+
+function matchToken(presented: string, cfg: AuthConfig): Principal | null {
+  if (!presented) return null
+  const presentedBuf = Buffer.from(presented)
+  for (const role of ['operator', 'agents'] as const) {
+    for (const candidate of cfg[role]) {
+      const candidateBuf = Buffer.from(candidate)
+      if (candidateBuf.length !== presentedBuf.length) continue
+      if (timingSafeEqual(candidateBuf, presentedBuf)) {
+        return {
+          role: role === 'operator' ? 'operator' : 'agent',
+          tokenId: candidate.slice(0, 8),
+        }
+      }
+    }
+  }
+  return null
+}
+
+export function verifyBearer(header: string | undefined | null, cfg: AuthConfig): Principal | null {
+  if (!header) return null
+  const m = /^Bearer\s+(.+)$/i.exec(header.trim())
+  if (!m) return null
+  return matchToken(m[1]!.trim(), cfg)
+}
+
+export type SubprotocolResult = {
+  principal: Principal
+  chosenSubprotocol: string
+}
+
+export function verifySubprotocols(
+  header: string | undefined | null,
+  cfg: AuthConfig,
+): SubprotocolResult | null {
+  if (!header) return null
+  const offered = header.split(',').map((p) => p.trim()).filter(Boolean)
+  let tokenValue: string | null = null
+  let hasClientProtocol = false
+  for (const entry of offered) {
+    if (entry === CLIENT_SUBPROTOCOL) {
+      hasClientProtocol = true
+    } else if (entry.startsWith(TOKEN_SUBPROTOCOL_PREFIX)) {
+      tokenValue = entry.slice(TOKEN_SUBPROTOCOL_PREFIX.length)
+    }
+  }
+  if (!hasClientProtocol || !tokenValue) return null
+  const principal = matchToken(tokenValue, cfg)
+  if (!principal) return null
+  return { principal, chosenSubprotocol: CLIENT_SUBPROTOCOL }
+}
+
+export { CLIENT_SUBPROTOCOL, TOKEN_SUBPROTOCOL_PREFIX }

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -3,6 +3,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
 import { CanvasBridge, DEFAULT_WS_PORT } from './ws-server.js'
+import {
+  loadAuthConfig,
+  verifyBearer,
+  verifySubprotocols,
+  type AuthConfig,
+  type Principal,
+} from './auth.js'
 import { registerShapeTools } from './tools/shapes.js'
 import { registerCanvasTools } from './tools/canvas.js'
 import { registerRuntimeTools } from './tools/runtime.js'
@@ -23,11 +30,33 @@ async function runStdio() {
   console.error(`[vade-canvas] MCP server running on stdio, WebSocket bridge on :${DEFAULT_WS_PORT}`)
 }
 
+function requireBearer(
+  req: IncomingMessage,
+  res: ServerResponse,
+  cfg: AuthConfig,
+): Principal | null {
+  const principal = verifyBearer(req.headers['authorization'], cfg)
+  if (!principal) {
+    res.writeHead(401, {
+      'Content-Type': 'text/plain',
+      'WWW-Authenticate': 'Bearer realm="vade-canvas"',
+    })
+    res.end('Unauthorized')
+    return null
+  }
+  return principal
+}
+
 async function runSse() {
   const port = Number(process.env['VADE_MCP_HTTP_PORT'] ?? 8080)
   const messagesPath = '/messages'
   const ssePath = '/sse'
   const canvasPath = '/canvas'
+
+  const auth = loadAuthConfig(process.env['VADE_AUTH_TOKENS'])
+  console.error(
+    `[vade-canvas] auth loaded: ${auth.operator.length} operator, ${auth.agents.length} agent token(s)`,
+  )
 
   // On Fly.io, sessions live in per-machine memory. Advertise a
   // machine-scoped endpoint so the client's POST can be replayed to
@@ -41,12 +70,23 @@ async function runSse() {
   const setCors = (res: ServerResponse) => {
     res.setHeader('Access-Control-Allow-Origin', '*')
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id')
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Mcp-Session-Id')
     res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id')
   }
 
   const httpServer = createServer()
-  const bridge = new CanvasBridge({ mode: 'attached', server: httpServer, path: canvasPath })
+  const bridge = new CanvasBridge({
+    mode: 'attached',
+    server: httpServer,
+    path: canvasPath,
+    verify: (req) => {
+      const header = req.headers['sec-websocket-protocol']
+      const value = Array.isArray(header) ? header.join(',') : header
+      const result = verifySubprotocols(value, auth)
+      if (!result) return { ok: false, reason: 'Unauthorized' }
+      return { ok: true, principal: result.principal }
+    },
+  })
 
   httpServer.on('request', async (req: IncomingMessage, res: ServerResponse) => {
     setCors(res)
@@ -66,13 +106,16 @@ async function runSse() {
     }
 
     if (req.method === 'GET' && url.pathname === ssePath) {
+      const principal = requireBearer(req, res, auth)
+      if (!principal) return
+
       const transport = new SSEServerTransport(scopedMessagesPath, res)
       const server = buildServer(bridge)
 
       const sessionId = transport.sessionId
       sessions.set(sessionId, { server, transport })
       console.error(
-        `[vade-canvas] SSE session open ${sessionId} on ${machineId || 'local'} (total=${sessions.size})`,
+        `[vade-canvas] SSE session open ${sessionId} (${principal.role} ${principal.tokenId}) on ${machineId || 'local'} (total=${sessions.size})`,
       )
 
       // Fly-proxy closes idle HTTP connections at 60s. Send an SSE
@@ -103,6 +146,8 @@ async function runSse() {
     }
 
     if (req.method === 'POST' && url.pathname.startsWith(messagesPath)) {
+      if (!requireBearer(req, res, auth)) return
+
       // Path shape: `/messages` or `/messages/<machineId>`. If the
       // client's target machine isn't us, hand off to Fly's proxy —
       // it will replay the request (body included) to that instance.

--- a/mcp/ws-server.ts
+++ b/mcp/ws-server.ts
@@ -13,7 +13,7 @@ export type VerifyUpgradeResult =
 export type VerifyUpgrade = (req: IncomingMessage) => VerifyUpgradeResult
 
 export type CanvasBridgeOptions =
-  | { mode: 'standalone'; port?: number; host?: string; verify?: VerifyUpgrade }
+  | { mode: 'standalone'; port?: number; host?: string }
   | { mode: 'attached'; server: HttpServer; path: string; verify?: VerifyUpgrade }
 
 type PendingRequest = {

--- a/mcp/ws-server.ts
+++ b/mcp/ws-server.ts
@@ -2,17 +2,40 @@ import type { IncomingMessage, Server as HttpServer } from 'node:http'
 import type { Duplex } from 'node:stream'
 import { WebSocketServer, WebSocket } from 'ws'
 import type { ServerMessage, ClientMessage } from './protocol.js'
+import { CLIENT_SUBPROTOCOL, type Principal } from './auth.js'
 
 export const DEFAULT_WS_PORT = 7600
 
+export type VerifyUpgradeResult =
+  | { ok: true; principal: Principal }
+  | { ok: false; reason?: string }
+
+export type VerifyUpgrade = (req: IncomingMessage) => VerifyUpgradeResult
+
 export type CanvasBridgeOptions =
-  | { mode: 'standalone'; port?: number; host?: string }
-  | { mode: 'attached'; server: HttpServer; path: string }
+  | { mode: 'standalone'; port?: number; host?: string; verify?: VerifyUpgrade }
+  | { mode: 'attached'; server: HttpServer; path: string; verify?: VerifyUpgrade }
 
 type PendingRequest = {
   resolve: (data: unknown) => void
   reject: (err: Error) => void
   timer: ReturnType<typeof setTimeout>
+}
+
+function handleProtocols(protocols: Set<string>): string | false {
+  return protocols.has(CLIENT_SUBPROTOCOL) ? CLIENT_SUBPROTOCOL : false
+}
+
+function rejectUnauthorized(socket: Duplex, reason?: string): void {
+  const body = reason ?? 'Unauthorized'
+  socket.write(
+    `HTTP/1.1 401 Unauthorized\r\n` +
+      `Content-Type: text/plain\r\n` +
+      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      `Connection: close\r\n\r\n` +
+      body,
+  )
+  socket.destroy()
 }
 
 export class CanvasBridge {
@@ -25,14 +48,15 @@ export class CanvasBridge {
 
   constructor(options: CanvasBridgeOptions = { mode: 'standalone' }) {
     this.mode = options.mode
+    const verify = options.verify
 
     if (options.mode === 'standalone') {
       const port = options.port ?? DEFAULT_WS_PORT
       const host = options.host ?? '0.0.0.0'
-      this.wss = new WebSocketServer({ port, host })
+      this.wss = new WebSocketServer({ port, host, handleProtocols })
       console.error(`[bridge] WebSocket server listening on ${host}:${port}`)
     } else {
-      this.wss = new WebSocketServer({ noServer: true })
+      this.wss = new WebSocketServer({ noServer: true, handleProtocols })
       this.attachedServer = options.server
       const path = options.path
       this.upgradeHandler = (req, socket, head) => {
@@ -42,12 +66,24 @@ export class CanvasBridge {
         }
         const url = new URL(req.url, 'http://localhost')
         if (url.pathname !== path) return
+        if (verify) {
+          const result = verify(req)
+          if (!result.ok) {
+            rejectUnauthorized(socket, result.reason)
+            return
+          }
+          console.error(
+            `[bridge] auth ok: ${result.principal.role} ${result.principal.tokenId}`,
+          )
+        }
         this.wss.handleUpgrade(req, socket, head, (ws) => {
           this.wss.emit('connection', ws, req)
         })
       }
       options.server.on('upgrade', this.upgradeHandler)
-      console.error(`[bridge] WebSocket upgrade handler attached on path ${path}`)
+      console.error(
+        `[bridge] WebSocket upgrade handler attached on path ${path}${verify ? ' (auth required)' : ''}`,
+      )
     }
 
     this.wss.on('connection', (ws) => {

--- a/mcp/ws-server.ts
+++ b/mcp/ws-server.ts
@@ -26,17 +26,12 @@ function handleProtocols(protocols: Set<string>): string | false {
   return protocols.has(CLIENT_SUBPROTOCOL) ? CLIENT_SUBPROTOCOL : false
 }
 
-function rejectUnauthorized(socket: Duplex, reason?: string): void {
-  const body = reason ?? 'Unauthorized'
-  socket.write(
-    `HTTP/1.1 401 Unauthorized\r\n` +
-      `Content-Type: text/plain\r\n` +
-      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
-      `Connection: close\r\n\r\n` +
-      body,
-  )
-  socket.destroy()
-}
+// 4000–4999 is reserved for application-specific close codes; 4401
+// mirrors HTTP 401 so the client can distinguish auth failure from a
+// transient network disconnect. Writing a raw HTTP/1.1 401 here would
+// surface in the browser as code 1006 (abnormal close) with no way
+// to tell it apart from a dropped connection.
+const CLOSE_CODE_UNAUTHORIZED = 4401
 
 export class CanvasBridge {
   private wss: WebSocketServer
@@ -48,7 +43,6 @@ export class CanvasBridge {
 
   constructor(options: CanvasBridgeOptions = { mode: 'standalone' }) {
     this.mode = options.mode
-    const verify = options.verify
 
     if (options.mode === 'standalone') {
       const port = options.port ?? DEFAULT_WS_PORT
@@ -56,6 +50,7 @@ export class CanvasBridge {
       this.wss = new WebSocketServer({ port, host, handleProtocols })
       console.error(`[bridge] WebSocket server listening on ${host}:${port}`)
     } else {
+      const verify = options.verify
       this.wss = new WebSocketServer({ noServer: true, handleProtocols })
       this.attachedServer = options.server
       const path = options.path
@@ -66,12 +61,17 @@ export class CanvasBridge {
         }
         const url = new URL(req.url, 'http://localhost')
         if (url.pathname !== path) return
-        if (verify) {
-          const result = verify(req)
-          if (!result.ok) {
-            rejectUnauthorized(socket, result.reason)
-            return
-          }
+        const result = verify?.(req)
+        if (result && !result.ok) {
+          // Accept the handshake so we can send a WS close frame with a
+          // readable code instead of dropping the socket (which browsers
+          // report as 1006 and can't distinguish from a network blip).
+          this.wss.handleUpgrade(req, socket, head, (ws) => {
+            ws.close(CLOSE_CODE_UNAUTHORIZED, result.reason ?? 'Unauthorized')
+          })
+          return
+        }
+        if (result) {
           console.error(
             `[bridge] auth ok: ${result.principal.role} ${result.principal.tokenId}`,
           )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,36 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { customShapeUtils } from './shapes'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
 
-const bridge = new VadeBridge()
+const TOKEN_STORAGE_KEY = 'vade-auth-token'
 
-function ConnectionIndicator() {
+const requiresAuth = !import.meta.env.DEV
+
+function readStoredToken(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const v = window.localStorage.getItem(TOKEN_STORAGE_KEY)
+    return v && v.trim() ? v.trim() : null
+  } catch {
+    return null
+  }
+}
+
+function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onClearToken: () => void }) {
   const [status, setStatus] = useState<BridgeStatus>('disconnected')
 
   useEffect(() => {
     return bridge.onStatusChange(setStatus)
-  }, [])
+  }, [bridge])
 
   const colors: Record<BridgeStatus, string> = {
     connected: '#a6e3a1',
     connecting: '#f9e2af',
     disconnected: '#f38ba8',
     'no-bridge': '#6c7086',
+    unauthorized: '#f38ba8',
   }
 
   const labels: Record<BridgeStatus, string> = {
@@ -25,10 +38,14 @@ function ConnectionIndicator() {
     connecting: 'connecting...',
     disconnected: 'offline',
     'no-bridge': 'no bridge',
+    unauthorized: 'bad token',
   }
+
+  const interactive = status === 'unauthorized'
 
   return (
     <div
+      onClick={interactive ? onClearToken : undefined}
       style={{
         position: 'fixed',
         bottom: 12,
@@ -43,9 +60,11 @@ function ConnectionIndicator() {
         color: colors[status],
         fontSize: 11,
         fontFamily: 'ui-monospace, monospace',
-        pointerEvents: 'none',
+        pointerEvents: interactive ? 'auto' : 'none',
+        cursor: interactive ? 'pointer' : 'default',
         backdropFilter: 'blur(8px)',
       }}
+      title={interactive ? 'Click to re-enter token' : undefined}
     >
       <div
         style={{
@@ -60,8 +79,112 @@ function ConnectionIndicator() {
   )
 }
 
+function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
+  const [value, setValue] = useState('')
+  const trimmed = value.trim()
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#1e1e2e',
+        color: '#cdd6f4',
+        fontFamily: 'ui-monospace, monospace',
+        padding: 24,
+      }}
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (trimmed) onSubmit(trimmed)
+        }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          width: '100%',
+          maxWidth: 420,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600 }}>VADE</div>
+        <label htmlFor="vade-token" style={{ fontSize: 12, color: '#a6adc8' }}>
+          Paste your operator token to continue
+        </label>
+        <input
+          id="vade-token"
+          type="password"
+          autoFocus
+          autoComplete="off"
+          spellCheck={false}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          style={{
+            padding: '10px 12px',
+            borderRadius: 8,
+            border: '1px solid #45475a',
+            background: '#181825',
+            color: '#cdd6f4',
+            fontFamily: 'ui-monospace, monospace',
+            fontSize: 13,
+          }}
+        />
+        <button
+          type="submit"
+          disabled={!trimmed}
+          style={{
+            padding: '10px 12px',
+            borderRadius: 8,
+            border: 'none',
+            background: trimmed ? '#89b4fa' : '#45475a',
+            color: '#11111b',
+            fontFamily: 'inherit',
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: trimmed ? 'pointer' : 'not-allowed',
+          }}
+        >
+          Connect
+        </button>
+      </form>
+    </div>
+  )
+}
+
 export default function App() {
+  const [token, setToken] = useState<string | null>(() => (requiresAuth ? readStoredToken() : null))
+
+  const bridge = useMemo(() => new VadeBridge(token), [token])
   const bridgeRef = useRef(bridge)
+  bridgeRef.current = bridge
+
+  if (requiresAuth && !token) {
+    return (
+      <TokenGate
+        onSubmit={(t) => {
+          try {
+            window.localStorage.setItem(TOKEN_STORAGE_KEY, t)
+          } catch {
+            // ignore — session-only use still works
+          }
+          setToken(t)
+        }}
+      />
+    )
+  }
+
+  const clearToken = () => {
+    try {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+    bridge.disconnect()
+    setToken(null)
+  }
 
   return (
     <div style={{ position: 'fixed', inset: 0 }}>
@@ -72,7 +195,7 @@ export default function App() {
           bridgeRef.current.connect(editor)
         }}
       />
-      <ConnectionIndicator />
+      <ConnectionIndicator bridge={bridge} onClearToken={clearToken} />
     </div>
   )
 }

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -95,9 +95,14 @@ export class VadeBridge {
 
     ws.onclose = (event) => {
       this.ws = null
+      // Happy path: the server accepts the WS upgrade and then closes
+      // with 4401 on auth failure. Fallback: if the handshake itself
+      // never completed (didOpen === false) but we had a token and
+      // the browser is online, treat code 1006 as auth failure too —
+      // a dropped/proxied upgrade can leave us without the 4401 frame.
       const failedHandshakeWithToken =
         !!this.token && !didOpen && event.code === 1006 && navigator.onLine
-      if (event.code === 1008 || event.code === 4401 || failedHandshakeWithToken) {
+      if (event.code === 4401 || event.code === 1008 || failedHandshakeWithToken) {
         this.setStatus('unauthorized')
         return
       }

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -5,6 +5,9 @@ const WS_URL =
   (import.meta.env.VITE_BRIDGE_URL as string | undefined) ??
   `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.hostname}:7600`
 
+const CLIENT_SUBPROTOCOL = 'vade-canvas'
+const TOKEN_SUBPROTOCOL_PREFIX = 'vade-auth.'
+
 const isLocalHostname = (hostname: string): boolean => {
   if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true
   if (hostname.endsWith('.local')) return true
@@ -20,7 +23,7 @@ const shouldAttemptBridge = (): boolean => {
   return isLocalHostname(window.location.hostname)
 }
 
-export type BridgeStatus = 'disconnected' | 'connecting' | 'connected' | 'no-bridge'
+export type BridgeStatus = 'disconnected' | 'connecting' | 'connected' | 'no-bridge' | 'unauthorized'
 type StatusListener = (status: BridgeStatus) => void
 
 export class VadeBridge {
@@ -30,6 +33,11 @@ export class VadeBridge {
   private listeners: StatusListener[] = []
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectDelay = 1000
+  private token: string | null
+
+  constructor(token: string | null = null) {
+    this.token = token && token.trim() ? token.trim() : null
+  }
 
   connect(editor: Editor) {
     this.editor = editor
@@ -60,7 +68,10 @@ export class VadeBridge {
     }
 
     this.setStatus('connecting')
-    const ws = new WebSocket(WS_URL)
+    const protocols = this.token
+      ? [CLIENT_SUBPROTOCOL, `${TOKEN_SUBPROTOCOL_PREFIX}${this.token}`]
+      : undefined
+    const ws = protocols ? new WebSocket(WS_URL, protocols) : new WebSocket(WS_URL)
 
     ws.onopen = () => {
       this.ws = ws
@@ -80,8 +91,14 @@ export class VadeBridge {
       }
     }
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
       this.ws = null
+      // 1008 (policy violation) is what browsers surface for a 401 on
+      // the upgrade response — treat as unauthorized and stop retrying.
+      if (event.code === 1008 || event.code === 4401) {
+        this.setStatus('unauthorized')
+        return
+      }
       this.setStatus('disconnected')
       this.scheduleReconnect()
     }

--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -72,8 +72,10 @@ export class VadeBridge {
       ? [CLIENT_SUBPROTOCOL, `${TOKEN_SUBPROTOCOL_PREFIX}${this.token}`]
       : undefined
     const ws = protocols ? new WebSocket(WS_URL, protocols) : new WebSocket(WS_URL)
+    let didOpen = false
 
     ws.onopen = () => {
+      didOpen = true
       this.ws = ws
       this.reconnectDelay = 1000
       this.setStatus('connected')
@@ -93,9 +95,9 @@ export class VadeBridge {
 
     ws.onclose = (event) => {
       this.ws = null
-      // 1008 (policy violation) is what browsers surface for a 401 on
-      // the upgrade response — treat as unauthorized and stop retrying.
-      if (event.code === 1008 || event.code === 4401) {
+      const failedHandshakeWithToken =
+        !!this.token && !didOpen && event.code === 1006 && navigator.onLine
+      if (event.code === 1008 || event.code === 4401 || failedHandshakeWithToken) {
         this.setStatus('unauthorized')
         return
       }


### PR DESCRIPTION
Closes #9 (part of #5).

## Summary

- Adds a **client-facing bearer** distinct from the existing Fly↔Worker `LIBRARY_BEARER`, so a leaked SPA/Claude-Code token cannot hit the Worker's `/library/*` route directly.
- MCP reads `VADE_AUTH_TOKENS` as JSON of shape `{ operator: [...], agents: [...] }` — `agents` is the hook for a future second principal; M1 ships with it empty and validation treats both lists equivalently.
- Three surfaces enforce, all fail-closed in SSE mode:
  - `GET /sse` and `POST /messages[/<machine-id>]` require `Authorization: Bearer <token>`.
  - `wss://.../canvas` verifies `Sec-WebSocket-Protocol` carries `vade-canvas` plus `vade-auth.<token>`, Kubernetes-style — browsers can send it without setting arbitrary WS headers. Invalid upgrades get a raw `HTTP/1.1 401` + socket close.
  - Prod SPA (`!import.meta.env.DEV`) prompts for the token on first load, persists in `localStorage`, and refuses to mount `<Tldraw />` until it's entered. Invalid-token close codes surface as \`bad token\` in the indicator; tapping clears + re-prompts.
- `stdio` mode and local standalone WSS remain unauthenticated — dev loop is unchanged.

## AC mapping (issue #9)

| AC | How |
|---|---|
| Hit SPA without token → rejected | Editor is not mounted; token-prompt overlay is all the user sees |
| Hit WSS without token → rejected | 401 written to raw socket, `socket.destroy()` |
| Hit SSE without token → rejected | 401 + `WWW-Authenticate: Bearer` |
| With token, iPad PWA connects | Token persisted in `localStorage`, sent via subprotocol |
| With token, Claude Code calls tools | `Authorization: Bearer` in MCP SSE client config |
| Rotation under 2 minutes | `flyctl secrets set VADE_AUTH_TOKENS='…'` → machine restart → re-paste |

Interpretation note on AC#1: the Worker keeps serving `index.html` unauthenticated (no in-page prompt is possible otherwise). Enforcement happens on the surfaces that grant capability (WSS + SSE). Flagged in \`docs/auth.md\` and in the open design thread — happy to also gate `index.html` at the Worker if you'd rather.

## Test plan

Before merge, operator verifies against the hosted stack:

- [x] Set `VADE_AUTH_TOKENS` via `flyctl secrets set`, watch Fly log show \`auth loaded: 1 operator, 0 agent token(s)\`.
- [x] `curl -sI https://mcp.vade-app.dev/sse` → 401.
- [x] `curl -H "Authorization: Bearer $VADE_AUTH_TOKEN" https://mcp.vade-app.dev/sse` → 200, SSE stream opens.
- [x] `curl -sI https://mcp.vade-app.dev/healthz` → 200 (still open).
- [ ] WSS w/o subprotocol (e.g. `websocat wss://mcp.vade-app.dev/canvas`) → 401 close.
- [ ] WSS w/ `vade-canvas, vade-auth.<token>` subprotocol → upgrade succeeds.
- [ ] Fresh browser on `https://vade-app.dev` → token prompt, paste token → canvas mounts, indicator turns `MCP` green.
- [ ] Bad token via prompt → indicator shows `bad token`; tap clears localStorage and re-prompts.
- [ ] Claude Code MCP config with `Authorization: Bearer <token>` → \`mcp__vade-canvas__*\` tools work.
- [ ] Remove secret → Fly machine refuses to start (log: `VADE_AUTH_TOKENS is required`).

What I did **not** test locally (no hosted stack from this session): the three hosted `curl` probes and the end-to-end Claude-Code-over-SSE flow. Typecheck + prod build pass.

## Open design questions still worth a call

1. Should the Worker 401 unauthenticated `index.html` requests as well (stricter AC#1 read)? Currently it doesn't.
2. Is the subprotocol-as-token pattern acceptable for M1, or do we want to move to a signed short-lived derivative now? Discussed in `docs/auth.md` threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)