### PR TITLE
Add Authorization header to vade-canvas MCP SSE config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "vade-canvas": {
       "type": "sse",
-      "url": "https://mcp.vade-app.dev/sse"
+      "url": "https://mcp.vade-app.dev/sse",
+      "headers": {
+        "Authorization": "Bearer ${VADE_AUTH_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
Follow-up to #41. The hosted MCP now rejects unauthenticated SSE, so Claude Code needs to send \`Authorization: Bearer\` when it opens the transport.

Uses \`\${VADE_AUTH_TOKEN}\` env-var substitution so the secret lives in each operator's shell env — nothing sensitive is committed.

## Operator setup

Add to \`~/.zshrc\` (or equivalent) on every machine running Claude Code:

\`\`\`sh
export VADE_AUTH_TOKEN='<operator-token>'
\`\`\`

Then reload the shell and restart Claude Code. Verify via \`/mcp\` that \`vade-canvas\` shows connected.

## Test plan

- [ ] With \`VADE_AUTH_TOKEN\` unset → Claude Code surfaces a 401 from the SSE endpoint (config substitutes the literal string \`Bearer \` with nothing after it, or \`Bearer \${VADE_AUTH_TOKEN}\` depending on substitution semantics — either way the server rejects).
- [ ] With \`VADE_AUTH_TOKEN\` set to the Fly-configured token → \`/mcp\` shows vade-canvas connected; an MCP tool call round-trips to the iPad canvas.
- [ ] With \`VADE_AUTH_TOKEN\` set to a wrong token → server returns 401; \`/mcp\` shows error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)