### PR TITLE
Unwrap tldraw snapshot in saveCanvas before persisting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,10 @@
       "Bash(python3 -c \"import sys,json;d=json.load\\(sys.stdin\\);[print\\(i['content']['number'],i['id'],i.get\\('status','?'\\),i['content']['title']\\) for i in d['items'] if i.get\\('content',{}\\).get\\('number'\\) in \\(5,7,8,9,10,11\\)]\")",
       "mcp__claude_ai_Customgithub__issue_read",
       "WebFetch(domain:github.com)",
-      "Bash(gh api *)"
+      "Bash(gh api *)",
+      "Bash(flyctl scale *)",
+      "mcp__claude_ai_tldraw__exec",
+      "mcp__vade-canvas__loadCanvas"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/mcp/tools/canvas.ts
+++ b/mcp/tools/canvas.ts
@@ -13,9 +13,9 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
       description: z.string().optional().describe('What this canvas contains'),
     },
   }, async ({ name, tags, description }) => {
-    const snapshot = await bridge.send({ type: 'getSnapshot', id: makeId() })
+    const summary = await bridge.send({ type: 'getSnapshot', id: makeId() }) as { snapshot: unknown }
     const store = await getStore()
-    const meta = await store.saveCanvas(name, snapshot, tags ?? [], description ?? '')
+    const meta = await store.saveCanvas(name, summary.snapshot, tags ?? [], description ?? '')
     return { content: [{ type: 'text' as const, text: `Saved canvas "${name}"\n${JSON.stringify(meta, null, 2)}` }] }
   })
 


### PR DESCRIPTION
## Summary
- Fixes `loadCanvas` crashing with `undefined is not an object (evaluating 'n.schemaVersion')` on every canvas saved through the hosted MCP.
- Root cause: the browser's `getSnapshot` handler wraps the raw tldraw snapshot inside `{shapeCount, types, pageId, snapshot}`. `saveCanvas` stored that wrapper instead of the inner snapshot, so `loadCanvas` handed the wrapper to `editor.store.loadStoreSnapshot()` and tldraw read `.schema` off the wrapper (undefined) and threw.
- Fix: extract `summary.snapshot` at save time so the library stores only the raw tldraw snapshot.

## Migration
Canvases saved before this change are stored with the wrong shape and are not loadable. After deploy, delete and re-save any existing library entries (e.g. the `heart-demo` entry created while reproducing the bug). No code-level compatibility shim is included — pre-alpha, not worth carrying the dual-shape branch.

## Test plan
- [ ] Deploy to `vade-app.dev`.
- [ ] `deleteCanvas("heart-demo")`, then re-run `saveCanvas("heart-demo")` on a populated tab.
- [ ] From a different tab (after refreshing so it becomes the active bridge), run `loadCanvas("heart-demo")` and confirm shapes appear without a tldraw error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)