### PR TITLE
Canvas UI for cloud save/load of named canvases

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -5,6 +5,7 @@ export interface Env {
   LIBRARY_R2: R2Bucket
   vade_library: D1Database
   LIBRARY_BEARER: string
+  OPERATOR_TOKENS?: string
 }
 
 export default {

--- a/worker/library.ts
+++ b/worker/library.ts
@@ -65,10 +65,26 @@ function entityKey(slug: string): string {
   return `entities/${slug}/shapes.json`
 }
 
+function isAuthorized(auth: string, env: Env): boolean {
+  if (!auth.startsWith('Bearer ')) return false
+  const token = auth.slice('Bearer '.length)
+  if (!token) return false
+  if (env.LIBRARY_BEARER && token === env.LIBRARY_BEARER) return true
+  if (env.OPERATOR_TOKENS) {
+    try {
+      const parsed = JSON.parse(env.OPERATOR_TOKENS) as { operator?: unknown; agents?: unknown }
+      const operator = Array.isArray(parsed.operator) ? (parsed.operator as string[]) : []
+      const agents = Array.isArray(parsed.agents) ? (parsed.agents as string[]) : []
+      if (operator.includes(token) || agents.includes(token)) return true
+    } catch {
+      // malformed secret — treat as no extra tokens
+    }
+  }
+  return false
+}
+
 export async function handleLibrary(req: Request, env: Env, url: URL): Promise<Response> {
-  const auth = req.headers.get('Authorization') ?? ''
-  const expected = `Bearer ${env.LIBRARY_BEARER}`
-  if (!env.LIBRARY_BEARER || auth !== expected) {
+  if (!isAuthorized(req.headers.get('Authorization') ?? '', env)) {
     return text('Unauthorized', 401)
   }
 


### PR DESCRIPTION
Tracking PR for #44 — canvas UI for cloud save/load of named canvases.

## Status

First slice landed:

- [x] Worker `/library/*` accepts the operator token (via new `OPERATOR_TOKENS` secret) in addition to the service-to-service `LIBRARY_BEARER`.
- [ ] `src/lib/library.ts` — client fetch wrapper.
- [ ] `src/components/CanvasSwitcher.tsx` — save / load / list / rename / duplicate / delete UI.
- [ ] `src/App.tsx` — mount switcher, active-canvas state, dirty tracking.
- [ ] `docs/auth.md` — document the new Worker secret.
- [ ] `README.md` — one-line mention.

## Blocker / known caveat

The hosted canvas at vade-app.dev is currently subject to the tldraw v4 license gate tracked in #32. The save/load UI here will build and typecheck cleanly, but end-to-end verification on the hosted origin is gated on #32's resolution. Local dev (`npm run dev`) is unaffected.

## What this first commit does

`worker/library.ts` previously gated on a single service-to-service bearer (`LIBRARY_BEARER`), which the SPA can't hold safely. This commit adds a second accepted credential — any token in a new `OPERATOR_TOKENS` secret (same JSON shape as Fly's `VADE_AUTH_TOKENS`), so the operator's `vade-auth-token` from `localStorage` can call `/library/*` directly, same-origin, without leaking the cross-service secret to the browser.

No behavior change until `OPERATOR_TOKENS` is set via `wrangler secret put`.

## Verification so far

- [x] `npm run typecheck:worker` clean.
- [ ] `curl -H "Authorization: Bearer $LIBRARY_BEARER" /library/canvases` → still 200 (unchanged path).
- [ ] `curl -H "Authorization: Bearer $OPERATOR_TOKEN" /library/canvases` → 200 once secret is set.
- [ ] Wrong / missing token → 401.

Closes #44 when merged (after remaining slices land).

https://claude.ai/code/session_01YSLfNUAP8Fvg86NQXeYmnA