### PR TITLE
Refresh docs to reflect tldraw 3.15.6 pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,11 @@ other `vade-app` repositories from sessions started here.
 
 ## Architecture (target)
 
-- Canvas-based UI built on **tldraw SDK** (v4.5.x). tldraw provides
-  the infinite canvas, pan/zoom, gestures, touch/tablet support,
-  shape system, and persistence. React 18 + TypeScript.
+- Canvas-based UI built on **tldraw SDK** (currently pinned to
+  3.15.6; target v4.5.x once the v4 license gate is resolved —
+  see #32). tldraw provides the infinite canvas, pan/zoom,
+  gestures, touch/tablet support, shape system, and persistence.
+  React 18 + TypeScript.
 - **MCP server** (`mcp/`) bridges Claude agents to the canvas via
   WebSocket. Agents can create, update, delete, and query shapes
   programmatically through MCP tools.
@@ -39,10 +41,11 @@ other `vade-app` repositories from sessions started here.
 ## Tech stack
 
 - TypeScript (strict mode) + Node.js 20+ LTS
-- React 18 + tldraw ^4.5.x
+- React 18 + tldraw 3.15.6 (pinned; target ^4.5.x — see #32)
 - Vite for dev server and bundling
-- @modelcontextprotocol/server for MCP
+- @modelcontextprotocol/sdk for MCP
 - ws (WebSocket) for MCP-to-canvas bridge
+- Cloudflare Workers + wrangler for hosted deployment
 - Tauri 2.x for desktop/mobile wrappers (later phase)
 
 ## Conventions
@@ -56,6 +59,18 @@ other `vade-app` repositories from sessions started here.
 - Prefer simplicity over premature abstraction.
 - Tests where they earn their keep. Prefer integration tests when
   the integration boundary is the risk.
+
+### Canonical config files
+
+- `.mcp.json` — project-scoped MCP server config (Mem0 + GitHub),
+  shared across surfaces. Committed.
+- `.claude/settings.local.json` — Claude Code permissions and
+  session settings for this repo. Committed where it encodes
+  repo-wide policy; user-local overrides stay out of git.
+- `.devcontainer/` — reproducible dev environment spec. Used by
+  VS Code devcontainers and by Codespaces.
+- `wrangler.jsonc` — Cloudflare Worker deploy config. See
+  Deployment below.
 
 ## What may be done autonomously in this repo
 
@@ -81,16 +96,75 @@ for the authoritative list.
 
 ## Current state
 
-Canvas shell scaffolded with tldraw SDK. Vite + React 18 +
-TypeScript strict. PWA manifest for iPad. MCP server and custom
-shapes in progress.
+**Pre-alpha MVP scaffold is in `main`.** The canvas is live at
+**https://vade-app.dev**, served from a Cloudflare Worker that
+auto-deploys on push to `main`. What ships today:
+
+- **Canvas shell** — tldraw-backed infinite canvas, pan/zoom,
+  gesture + touch support, IndexedDB persistence so the canvas
+  document survives reloads.
+- **PWA** — installable on iPad via Add to Home Screen; manifest
+  and icons are wired up.
+- **MCP server** — functional over stdio, with a WebSocket bridge
+  on `:7600` to push shape operations into the running canvas.
+- **Custom shapes** — `CodeShape` (syntax-highlighted code block)
+  and `DataShape` (structured JSON rendering).
+- **Library system** — file-based storage at `~/.vade/library/`
+  for canvas snapshots and reusable entity groups.
+- **Connection status indicator** — surfaces the WS bridge state
+  in the canvas UI.
+
+The bridge from a hosted MCP endpoint to the hosted canvas is
+the next MVP milestone (tracked under issue #7). CI/CD via
+GitHub Actions is tracked under issue #10.
 
 ## Running the project
 
 ```bash
 npm install           # install dependencies
-npm run dev           # start Vite dev server (LAN-accessible)
-npm run mcp           # start MCP server (when implemented)
-npm run dev:all       # start both (when MCP server exists)
-npm run build         # production build
+npm run dev           # start Vite dev server (LAN-accessible on :5173)
+npm run mcp           # start the MCP server (stdio + WebSocket :7600)
+npm run dev:all       # run Vite + MCP server concurrently
+npm run build         # production build (tsc -b && vite build)
+npm run preview       # build, then serve via `wrangler dev` locally
+npm run deploy        # build, then `wrangler deploy` to Cloudflare
 ```
+
+## Deployment
+
+The canvas SPA is deployed as a **Cloudflare Worker** that serves
+the Vite-built static assets (`dist/`). Config lives in
+`wrangler.jsonc`:
+
+- `assets.not_found_handling: "single-page-application"` — SPA
+  routing fallback to `index.html`.
+- `routes` — both `vade-app.dev` and `www.vade-app.dev` are
+  attached as `custom_domain` routes; DNS and TLS are managed
+  by Cloudflare.
+- `compatibility_flags: ["nodejs_compat"]`.
+
+Deploys are triggered by Cloudflare's Git integration on push to
+`main` (one build per push, auto-deploys to both custom domains).
+Manual deploy from a local clone: `npm run deploy`. A proper
+GitHub Actions CI/CD pipeline is tracked under issue #10.
+
+## MCP tools
+
+The MCP server exposes tools across three categories. See `mcp/`
+for the exact callable surface and argument schemas — that
+directory is the source of truth; do not treat this section as
+an enumeration.
+
+- **Shapes** (`mcp/tools/shapes.ts`) — create, update, delete,
+  and query tldraw shapes, including the custom `CodeShape` and
+  `DataShape`; batch operations; bindings between shapes.
+- **Canvas** (`mcp/tools/canvas.ts`) — query and navigate canvas
+  state (viewport, selection), persist snapshots into
+  `~/.vade/library/`, restore / search the library.
+- **Runtime** (`mcp/tools/runtime.ts`) — wire shapes into the
+  Control → State → Visualization loop: request code changes on
+  a shape, execute runtime hooks, move data between shapes.
+
+The server registers all three tool groups through
+`mcp/index.ts`; transport is stdio, and the canvas bridge is a
+separate WebSocket on `:7600` (`mcp/ws-server.ts`).

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ build interactive tools on an infinite canvas.
 
 ## Status
 
-**Pre-alpha.** Canvas shell scaffolded with tldraw SDK. MCP server
-and custom shapes in progress.
+**Pre-alpha.** The canvas is live at **https://vade-app.dev** (served
+from a Cloudflare Worker), and the MCP server is live at
+**https://mcp.vade-app.dev** (served from Fly.io). Canvas snapshots
+and reusable entity groups persist to Cloudflare R2 + D1 via a
+`/library/*` route on the Worker, so Fly redeploys no longer wipe
+saved work. Remaining milestone-1 work is tracked under issues
+#9 (auth), #10 (CI/CD), and #11 (remote-MCP client docs).
 
 ## What this repo contains
 
@@ -17,12 +22,15 @@ and custom shapes in progress.
 - **MCP server** (`mcp/`) — bridges Claude agents to the running
   canvas via WebSocket, enabling real-time shape creation and
   manipulation through MCP tools
+- **Cloud library** (`worker/library.ts` + `migrations/`) — bearer-
+  gated `/library/*` route on the Worker, snapshots to R2, metadata
+  to D1; selected from the MCP side via `VADE_LIBRARY_DRIVER=fs|cloud`
 - **PWA support** — installable on iPad via Add to Home Screen
 
 ## Tech stack
 
 - React 18 + TypeScript (strict) + Vite
-- tldraw ^4.5.x (infinite canvas SDK)
+- tldraw 3.15.6 (infinite canvas SDK; temporarily pinned — see #32)
 - @modelcontextprotocol/server (MCP bridge)
 - WebSocket (real-time MCP-to-canvas communication)
 
@@ -34,8 +42,33 @@ npm run dev           # start Vite dev server (LAN-accessible on :5173)
 npm run build         # production build
 ```
 
-Access from iPad: open `http://<your-mac-ip>:5173` in Safari, then
-Add to Home Screen for full-screen PWA mode.
+Access the local dev server from iPad by opening
+`http://<your-mac-ip>:5173` in Safari, then Add to Home Screen for
+full-screen PWA mode. For the hosted app, open
+[https://vade-app.dev](https://vade-app.dev) and Add to Home Screen.
+
+## Deploy
+
+Two independent deploy targets, both driven off `main`:
+
+**Canvas SPA + library API** — Cloudflare Worker (`wrangler.jsonc`).
+The Worker serves Vite-built assets from `dist/client/` and owns the
+bearer-gated `/library/*` route, which reads/writes R2 (`LIBRARY_R2`)
+and D1 (`vade_library`). Deploys are triggered by Cloudflare's Git
+integration on push to `main`. `routes` attaches both `vade-app.dev`
+and `www.vade-app.dev` as `custom_domain` routes.
+
+**MCP server** — Fly.io app `vade-mcp` at `mcp.vade-app.dev`
+(`Dockerfile` + `fly.toml`). The container runs the SSE MCP transport
+on `:8080` with a WebSocket bridge at `/canvas`, and defaults
+`VADE_LIBRARY_DRIVER=cloud` so canvas state round-trips through the
+Worker's library routes instead of a local filesystem. Redeploy with
+`flyctl deploy --app vade-mcp`.
+
+The two services share a bearer: the Worker holds it as
+`LIBRARY_BEARER` (`wrangler secret put`), the Fly container holds it
+as `VADE_LIBRARY_BEARER` (`flyctl secrets set`). CI/CD via GitHub
+Actions is tracked under issue #10.
 
 ## Governance
 


### PR DESCRIPTION
## Why

`CLAUDE.md` (Architecture, Tech stack) and `README.md` (Tech
stack) claim the repo is on `tldraw ^4.5.x`, but commit 3495afd
pinned tldraw to exact `3.15.6` to avoid v4's license-
enforcement gate (#32). The stale strings have been misleading
agents into reaching for v4-only APIs and examples when reading
those files at session start.

## What changed

Three bullets in two files. No code, no config, no test touches.

- `CLAUDE.md` → Architecture bullet: `(v4.5.x)` → `(currently
  pinned to 3.15.6; target v4.5.x once the v4 license gate is
  resolved — see #32)`.
- `CLAUDE.md` → Tech stack bullet: `tldraw ^4.5.x` →
  `tldraw 3.15.6 (pinned; target ^4.5.x — see #32)`.
- `README.md` → Tech stack bullet: `tldraw ^4.5.x (infinite
  canvas SDK)` → `tldraw 3.15.6 (infinite canvas SDK;
  temporarily pinned — see #32)`.

## Notes for the reviewer

- Keeps the "Architecture (target)" framing intact — the section
  still describes where we're headed, with the current version
  flagged inline.
- Cross-references #32 in all three spots so an agent lands on
  the license-gate context in one hop.
- When the hobby license lands and we flip back to v4.5.x (per
  3495afd's commit message), these three strings are what need
  to change back.

Refs #32
