### PR TITLE
CI/CD: build SHA in canvas + typecheck:mcp + Actions workflows (#10)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -51,7 +51,9 @@
       "Bash(gh api *)",
       "Bash(flyctl scale *)",
       "mcp__claude_ai_tldraw__exec",
-      "mcp__vade-canvas__loadCanvas"
+      "mcp__vade-canvas__loadCanvas",
+      "Bash(mkdir -p /root/.claude/plans)",
+      "Read(//root/.claude/plans/**)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,10 @@
       "mcp__claude_ai_tldraw__exec",
       "mcp__vade-canvas__loadCanvas",
       "Bash(mkdir -p /root/.claude/plans)",
-      "Read(//root/.claude/plans/**)"
+      "Read(//root/.claude/plans/**)",
+      "Bash(gh auth *)",
+      "Bash(ssh -T git@github.com)",
+      "mcp__claude_ai_Customgithub__pull_request_read"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.github/workflows/mcp-deploy.yml
+++ b/.github/workflows/mcp-deploy.yml
@@ -1,0 +1,45 @@
+name: mcp-deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - mcp/**
+      - Dockerfile
+      - fly.toml
+      - tsconfig.mcp.build.json
+      - package.json
+      - package-lock.json
+
+concurrency:
+  group: mcp-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.1
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck MCP server
+        run: npm run typecheck:mcp
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: flyctl deploy --remote-only --app vade-mcp
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Smoke test /healthz
+        run: curl --fail --retry 5 --retry-delay 5 https://mcp.vade-app.dev/healthz

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,33 @@
+name: pr-checks
+
+on:
+  pull_request:
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.1
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build canvas
+        run: npm run build
+
+      - name: Typecheck worker
+        run: npm run typecheck:worker
+
+      - name: Typecheck MCP server
+        run: npm run typecheck:mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,25 @@ other `vade-app` repositories from sessions started here.
 See [vade-governance/authority.md](https://github.com/vade-app/vade-governance/blob/main/authority.md)
 for the authoritative list.
 
+## Hitting an OAuth/scope wall on `git push` from a remote session
+
+Claude Code on the web sessions push through a scoped-down git
+proxy. The two recurring blockers are:
+
+- `git push` rejected with `refusing to allow an OAuth App to
+  create or update workflow ... without 'workflow' scope` (any
+  `.github/workflows/*` change).
+- GitHub MCP `create_or_update_file` / `push_files` returning
+  `404 Not Found` despite reads working.
+
+Don't burn cycles retrying or asking for token swaps. Commit the
+work locally on the branch, then suggest the user `/teleport` the
+session to their local Claude Code and finish the push from there
+— typically with `git push git@github.com:OWNER/REPO.git BRANCH`.
+SSH key auth bypasses the OAuth-app scope restriction entirely.
+The unblock for vade-core PR #49 (workflow files) on 2026-04-20
+is the canonical example.
+
 ## Current state
 
 **Pre-alpha MVP scaffold is in `main`.** The canvas is live at

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # vade-core
 
+[![mcp-deploy](https://github.com/vade-app/vade-core/actions/workflows/mcp-deploy.yml/badge.svg)](https://github.com/vade-app/vade-core/actions/workflows/mcp-deploy.yml)
+[![pr-checks](https://github.com/vade-app/vade-core/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/vade-app/vade-core/actions/workflows/pr-checks.yml)
+
 **VADE kernel and canvas IDE.** The primary application repo for
 [VADE](https://github.com/vade-app) — a Visual Agent-based
 Development Environment. Canvas-based IDE/OS hybrid where AI agents
@@ -67,8 +70,20 @@ Worker's library routes instead of a local filesystem. Redeploy with
 
 The two services share a bearer: the Worker holds it as
 `LIBRARY_BEARER` (`wrangler secret put`), the Fly container holds it
-as `VADE_LIBRARY_BEARER` (`flyctl secrets set`). CI/CD via GitHub
-Actions is tracked under issue #10.
+as `VADE_LIBRARY_BEARER` (`flyctl secrets set`).
+
+CI/CD is wired via GitHub Actions (see
+[issue #10](https://github.com/vade-app/vade-core/issues/10)):
+
+- `pr-checks.yml` typechecks the canvas, Worker, and MCP server on
+  every pull request.
+- `mcp-deploy.yml` runs `flyctl deploy` when `mcp/**`, `Dockerfile`,
+  or `fly.toml` change on `main`, then smoke-tests
+  `https://mcp.vade-app.dev/healthz`.
+- Cloudflare's Git integration remains authoritative for the canvas
+  Worker deploy on push to `main`. A short commit SHA is baked into
+  the build and surfaced in the canvas `ConnectionIndicator` so
+  deploys are visually verifiable from iPad.
 
 ## Governance
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev:all": "concurrently \"npm run dev\" \"npm run mcp\"",
     "deploy": "npm run build && wrangler deploy",
     "migrate-library": "tsx scripts/migrate-library.ts",
-    "typecheck:worker": "tsc -p tsconfig.worker.json"
+    "typecheck:worker": "tsc -p tsconfig.worker.json",
+    "typecheck:mcp": "tsc -p tsconfig.mcp.build.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ function readStoredToken(): string | null {
   }
 }
 
+const COMMIT_SHA = import.meta.env.VITE_COMMIT_SHA
+
 function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onClearToken: () => void }) {
   const [status, setStatus] = useState<BridgeStatus>('disconnected')
 
@@ -75,6 +77,9 @@ function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onC
         }}
       />
       {labels[status]}
+      {COMMIT_SHA && COMMIT_SHA !== 'dev' && (
+        <span style={{ color: '#6c7086' }}>· {COMMIT_SHA}</span>
+      )}
     </div>
   )
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_COMMIT_SHA: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,31 @@
+import { execSync } from 'node:child_process'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 import { cloudflare } from "@cloudflare/vite-plugin";
 
+function resolveCommitSha(): string {
+  const fromEnv =
+    process.env.WORKERS_CI_COMMIT_SHA ||
+    process.env.CF_PAGES_COMMIT_SHA ||
+    process.env.GITHUB_SHA
+  if (fromEnv) return fromEnv.slice(0, 7)
+
+  try {
+    return execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+      .slice(0, 7)
+  } catch {
+    return 'dev'
+  }
+}
+
 export default defineConfig({
   plugins: [react(), cloudflare()],
+  define: {
+    'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(resolveCommitSha()),
+  },
   server: {
     host: true,
     port: 5173,


### PR DESCRIPTION
Closes #10.

## Summary

- **Build SHA in the canvas UI.** `vite.config.ts` resolves a 7-char commit SHA via env cascade (`WORKERS_CI_COMMIT_SHA` → `CF_PAGES_COMMIT_SHA` → `GITHUB_SHA` → `git rev-parse HEAD` → `'dev'`) and injects it as `import.meta.env.VITE_COMMIT_SHA`. `ConnectionIndicator` renders it after the status label so iPad refreshes are visually verifiable. Cloudflare's existing `npm run build` picks this up with zero build-command changes; the git fallback is the safety net if Cloudflare renames the env var.
- **`typecheck:mcp` script** for parity with `typecheck:worker`, used by both workflows.
- **README** gains two workflow badges and a CI/CD section.

## Workflow files (blocked on token scope — needs manual push)

Two GitHub Actions workflows are part of this PR but could not be pushed from this session — the git path lacks the `workflow` OAuth scope, and the GitHub MCP write path returned 404. The exact file contents live in the repo under `.github/workflows/` locally on the branch (unstaged) and below; please push them from a local checkout with a token that has `workflow` scope, or paste them directly.

<details>
<summary><code>.github/workflows/mcp-deploy.yml</code></summary>

```yaml
name: mcp-deploy

on:
  push:
    branches: [main]
    paths:
      - mcp/**
      - Dockerfile
      - fly.toml
      - tsconfig.mcp.build.json
      - package.json
      - package-lock.json

concurrency:
  group: mcp-deploy
  cancel-in-progress: false

permissions:
  contents: read

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: actions/setup-node@v4
        with:
          node-version: 20.19.1
          cache: npm

      - run: npm ci

      - name: Typecheck MCP server
        run: npm run typecheck:mcp

      - uses: superfly/flyctl-actions/setup-flyctl@master

      - name: Deploy to Fly
        run: flyctl deploy --remote-only --app vade-mcp
        env:
          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

      - name: Smoke test /healthz
        run: curl --fail --retry 5 --retry-delay 5 https://mcp.vade-app.dev/healthz
```

</details>

<details>
<summary><code>.github/workflows/pr-checks.yml</code></summary>

```yaml
name: pr-checks

on:
  pull_request:

concurrency:
  group: pr-checks-${{ github.ref }}
  cancel-in-progress: true

permissions:
  contents: read

jobs:
  typecheck:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: actions/setup-node@v4
        with:
          node-version: 20.19.1
          cache: npm

      - run: npm ci

      - name: Build canvas
        run: npm run build

      - name: Typecheck worker
        run: npm run typecheck:worker

      - name: Typecheck MCP server
        run: npm run typecheck:mcp
```

</details>

## Manual setup (outside the PR diff)

1. **`FLY_API_TOKEN`** Actions secret: `flyctl tokens create deploy --app vade-mcp` → `gh secret set FLY_API_TOKEN -R vade-app/vade-core`. Required before `mcp-deploy.yml` can go green.
2. **`VADE_BEARER_TOKEN`** Actions secret: store now (issue #10 calls it out); no step in this PR consumes it. Smoke test uses unauthenticated `/healthz`.

## Decisions

- **One PR, not split.** Version-string piece could land alone, but each deliverable is small and together they close #10.
- **PR-checks is included.** Cloudflare doesn't build PRs, so without it broken code can reach `main`.
- **Smoke test is `/healthz` only.** No bearer in CI until an authenticated probe earns it.
- **Node `20.19.1`** everywhere to match the `Dockerfile` pin.

## Test plan

- [x] `npm ci`
- [x] `npm run build` — succeeds; the SHA `fe7c7d9` is embedded in `dist/client/assets/index-*.js`
- [x] `npm run typecheck:worker`
- [x] `npm run typecheck:mcp`
- [x] Push workflow files (see above)
- [x] Add `FLY_API_TOKEN` Actions secret
- [ ] Push a no-op commit to `main` after merge → refresh iPad PWA → SHA in pill matches `git rev-parse --short HEAD`
- [ ] Push a `mcp/**` change → `mcp-deploy.yml` goes green → `curl https://mcp.vade-app.dev/healthz` returns `200 ok`
- [ ] Open a throwaway PR that introduces a TS error → `pr-checks.yml` fails

https://claude.ai/code/session_0115wnaHZ52mwUZzdpjHozD6