### PR TITLE
docs: add briefings/ as a standing doc type for agent handoffs

### DIFF
--- a/docs/briefings/001-session-token-plan.md
+++ b/docs/briefings/001-session-token-plan.md
@@ -1,0 +1,157 @@
+# Briefing: vade-core session-token minting plan
+
+**Date**: 2026-04-20
+**Author**: Claude Code session (Opus 4.7, 1M ctx) running in an
+Anthropic cloud environment scoped to `vade-app/vade-core`;
+session-scoped kernel agent; task brought by Ven.
+
+## Who's who
+- **Principal**: Ven (operator, BDFL for VADE).
+- **Author**: Claude Code session scoped to `vade-app/vade-core`
+  only. Cannot read or write other vade-app repos from here.
+- **Recipient (COO)**: Claude instance with wider GitHub access
+  and all five vade-app repos cloned locally. Asked to design the
+  **minimum-viable** version of the scheme below, optimizing for
+  fast cloud-env boot and small surface area.
+
+## What VADE is (30 seconds)
+
+`vade-core` is the VADE kernel — a tldraw-based canvas IDE served
+from Cloudflare Workers at `vade-app.dev`, plus a hosted MCP
+server at `mcp.vade-app.dev` (Fly.io app `vade-mcp`). Canvas ↔ MCP
+WSS bridge + MCP SSE transport. Single-operator bearer-token auth
+gates everything client-facing. See
+[`docs/auth.md`](../auth.md) and
+[`docs/mcp-connector.md`](../mcp-connector.md) for the full picture.
+
+## The problem
+
+Claude Code runs on the web in "cloud environments." Each env has:
+
+- An `.env`-format **Environment variables** box explicitly
+  labeled "visible to anyone using this environment — don't add
+  secrets."
+- A **Setup script** that runs before Claude Code launches.
+- **No** secrets manager, **no** ambient identity (no
+  `GITHUB_TOKEN`, no `gh` CLI, no `~/.netrc`, no cloud IAM). The
+  GitHub MCP tools work but via Anthropic's internal channel —
+  not surfaced as a shell-usable credential.
+
+The hosted MCP server requires
+`Authorization: Bearer <operator-token>`. Pasting the operator
+token into the visible env-vars box would expose it in plaintext
+to anyone with access to the env. We need a safer path.
+
+## What's been decided directionally
+
+Direction chosen (not specification): **scoped bootstrap token +
+token-minting endpoint on the Fly MCP service.**
+
+1. Add `POST /session-token` on `vade-mcp` (Fly). Gated by a new
+   `VADE_SESSION_BOOTSTRAP_TOKEN` Fly secret.
+2. Endpoint mints a short-TTL operator token (target 24h, under
+   discussion), appends to `VADE_AUTH_TOKENS.operator`, logs
+   every issuance with a session id.
+3. `VADE_SESSION_BOOTSTRAP_TOKEN=<value>` goes in the Claude Code
+   cloud env's visible env-vars box — accepted trade-off because
+   (a) its only capability is minting short-lived tokens,
+   (b) it can be rotated without touching iPad/desktop operator
+   tokens, (c) leaked minted tokens age out on their own.
+4. The cloud-env setup script calls `/session-token`, exports the
+   returned token as `VADE_AUTH_TOKEN` for the session. `.mcp.json`
+   already interpolates `${VADE_AUTH_TOKEN}` into the SSE
+   `Authorization` header.
+
+Trade-offs already surfaced by the author:
+
+- This isn't cryptography — it's TTL + separation of duties.
+  Bootstrap token compromise lets an attacker mint tokens until
+  it's rotated, but blast radius is bounded and the operator
+  token itself never touches the cloud env.
+- If Anthropic publishes cloud-env egress IP ranges, the
+  bootstrap could also require source-IP match for defense in
+  depth. Author does not know whether those ranges are stable
+  or published.
+
+## Your task
+
+Plan the **minimum version** of this that lets a fresh Claude
+Code cloud env boot with a working `vade-canvas` MCP connection,
+optimizing two axes:
+
+1. **Boot time** — today's setup script clones `vade-runtime`
+   shallowly and runs `cloud-setup.sh`. The minimum cloud env
+   need not include all five repos; identify what's actually
+   required on the critical path to `claude` launch and cut the
+   rest.
+2. **Surface exposure** — the smaller the bootstrap token's
+   capability, the better. Consider: issuance rate limits,
+   IP-narrowing if Anthropic publishes cloud-env egress ranges,
+   whether the minted token should be capability-restricted vs
+   full operator, audit log shape, revocation path.
+
+## Constraints
+
+- `vade-core` is the only repo under the current session's
+  autonomy (per `vade-core/CLAUDE.md`). Endpoint code goes in
+  `vade-core/mcp/`. Deploy via existing `.github/workflows/mcp-deploy.yml`
+  on merge to `main`.
+- `cloud-setup.sh` lives in `vade-runtime` — your side. Keep it
+  dependency-light; it runs on every cold session start.
+- Auth policy and threat model live in `docs/auth.md` — any
+  surface-area changes should update it in the same PR.
+- Ven approves merges to `main` in any vade-app repo.
+
+## Read first
+
+1. [`CLAUDE.md`](../../CLAUDE.md) — repo scope, tech stack,
+   conventions.
+2. [`docs/auth.md`](../auth.md) — token model, rotation, threat
+   model.
+3. [`docs/mcp-connector.md`](../mcp-connector.md) — client setup
+   for Claude.ai / Desktop / Code.
+4. `mcp/auth.ts` and `mcp/index.ts` — where `/session-token`
+   would attach.
+5. `vade-runtime/scripts/cloud-setup.sh` — current boot surface
+   (in your clone, not available from the author's session).
+
+## Deliverable
+
+A written plan Ven can review: endpoint spec, setup-script diff
+sketch, rotation cadence, and a staged rollout (feature-flagged
+if useful). No code yet — plan first.
+
+## Known bounds of this briefing
+
+The author is aware of the following bounds on this framing and
+expects the recipient to challenge them:
+
+- **Repo visibility**: the author can only read `vade-core`.
+  `vade-runtime`, `vade-governance`, `vade-coo-memory`, and the
+  fifth `vade-app` repo are invisible. Any assumption about what
+  `cloud-setup.sh` currently does is inferred, not verified.
+- **Cloud-env capabilities**: the author does not know whether
+  the Claude Code web environment has (or will soon have) a
+  first-class secrets API. If it does, the entire minting scheme
+  may be unnecessary; the bootstrap becomes a stored secret.
+- **Anthropic-side identity**: the author does not know whether
+  Anthropic publishes (or plans to publish) signed session
+  identity for cloud envs (e.g., OIDC-style claims). A signed
+  identity would let the Fly endpoint validate the caller
+  without a bootstrap token at all — strictly better.
+- **Network-level gating**: the author does not know Anthropic's
+  cloud-env egress IP ranges. If stable, a firewall allowlist on
+  the Fly side would dominate any token-based scheme for this
+  use case.
+- **Framing anchor**: the author may be anchored on "bearer
+  token + mint endpoint." The problem may admit cleaner shapes
+  (mTLS, signed request headers, short-lived JWTs derived from
+  Anthropic identity) that the author did not enumerate.
+- **Abuse surface**: the author has not surveyed rate-limit /
+  abuse patterns on Fly ingress. The endpoint spec should factor
+  that in even if the bootstrap token is held tightly.
+- **"Minimum version"**: the author does not know which of the
+  five vade-app repos are actually on the critical path for
+  Claude Code cloud-env boot. The boot-time axis of the task
+  depends on that mapping, which is entirely on the recipient's
+  side.

--- a/docs/briefings/README.md
+++ b/docs/briefings/README.md
@@ -1,0 +1,135 @@
+# Briefings
+
+A **briefing** is a dated, signed document that captures one
+agent's best framing of a problem so a different agent can pick
+it up without access to the originating session's context.
+
+Briefings live under `docs/briefings/` and are numbered in order
+of creation.
+
+> Procedure is being formalized in
+> [#51](https://github.com/vade-app/vade-core/issues/51). Template
+> and conventions below may evolve — check the tracking issue
+> before writing a second briefing.
+
+## Purpose
+
+Agents working in scoped sessions — single repo, bounded context
+window, narrow toolset — regularly surface problems whose real
+scope exceeds what that session can address. The natural move is
+to hand off to an agent with broader authority; in VADE that is
+usually the COO, who has visibility across all five `vade-app`
+repos.
+
+A briefing is the written artifact of that handoff. It travels
+with Ven, is read by the recipient, and stands on its own.
+
+## Who writes these
+
+Session-scoped agents. Typical author: a Claude Code session in a
+cloud environment, with read/write access to one repo and none of
+the surrounding context. The author is aware that:
+
+- they are probably not the right authority to decide the plan;
+- their framing of the problem is bounded by what they could see
+  in one session;
+- the receiving agent is expected to **re-examine** the problem
+  and solution spaces, not just execute.
+
+Briefings are not specifications. They are orientation.
+
+## The natural-bounds caveat
+
+A briefing reflects the author's best framing within their
+session-scope. The recipient's job is to:
+
+1. Read the briefing.
+2. Re-examine the *true* problem space — including: is the problem
+   as framed actually the right problem?
+3. Re-examine the solution space — including: are the
+   already-considered ideas the right frame, or is the author
+   anchored?
+4. Propose a plan that may diverge from the briefing's direction,
+   with reasoning.
+
+Every briefing carries a mandatory **Known bounds of this briefing**
+section where the author names their own blind spots. That
+section is the briefing's honesty gate; if it is missing or
+generic, the briefing is not done.
+
+## Lifecycle (draft)
+
+- Draft briefing on a feature branch.
+- Merged to `main` via the associated PR.
+- Linked from the tracking issue or work item the recipient picks
+  up.
+- Marked resolved (or archived under `docs/briefings/archive/`)
+  when the underlying task concludes.
+
+This lifecycle is deliberately light. The full procedure lives in
+the tracking issue.
+
+## Template
+
+Copy this block to start a new briefing.
+
+~~~markdown
+# Briefing: <short title>
+
+**Date**: YYYY-MM-DD
+**Author**: <one-line blurb — environment, device, role within the
+project, and who brought the task. Example: "Claude Code session
+(Opus 4.7, 1M ctx) in an Anthropic cloud env scoped to
+`vade-app/vade-core`; session-scoped kernel agent; task brought
+by Ven.">
+
+## Who's who
+- Principal: <who authorizes decisions>
+- Author: <agent role + repo scope + what they cannot see>
+- Recipient: <agent role + what they are being asked to do>
+
+## What <subject> is (30 seconds)
+<One paragraph of unavoidable background. Link to canonical docs
+rather than duplicating them.>
+
+## The problem
+<What triggered the briefing. What doesn't work or is missing.>
+
+## What's been decided directionally
+<The author's current best framing of the solution. Labeled as
+direction, not specification. Include trade-offs the author
+already surfaced.>
+
+## Your task
+<The specific question(s) the recipient is being asked to answer
+or the artifact they are being asked to produce. Include axes of
+optimization.>
+
+## Constraints
+<Autonomy scope, repo boundaries, policy references, hard limits.>
+
+## Read first
+<Ordered list of canonical files/links that give the recipient the
+same ground the author stood on.>
+
+## Deliverable
+<What comes back. Usually: a plan, not code.>
+
+## Known bounds of this briefing
+<Explicit: "I am scoped to X. I cannot see Y. My framing of the
+problem may be wrong in these specific ways: ..." This section is
+required — it is the briefing's honesty gate.>
+~~~
+
+The **Date + Author** header and **Known bounds** section are
+both load-bearing. The header makes the briefing a dated, signed
+artifact — the recipient (and anyone reading it months later) can
+see which session wrote it, in which environment, at whose
+request. The Known-bounds section forces the author to name their
+blind spots.
+
+## Examples
+
+- [`001-session-token-plan.md`](./001-session-token-plan.md) —
+  first briefing; handoff from a `vade-core`-scoped session to the
+  COO for planning the Claude Code cloud-env bootstrap token scheme.

--- a/docs/briefings/README.md
+++ b/docs/briefings/README.md
@@ -71,55 +71,10 @@ the tracking issue.
 
 ## Template
 
-Copy this block to start a new briefing.
-
-~~~markdown
-# Briefing: <short title>
-
-**Date**: YYYY-MM-DD
-**Author**: <one-line blurb — environment, device, role within the
-project, and who brought the task. Example: "Claude Code session
-(Opus 4.7, 1M ctx) in an Anthropic cloud env scoped to
-`vade-app/vade-core`; session-scoped kernel agent; task brought
-by Ven.">
-
-## Who's who
-- Principal: <who authorizes decisions>
-- Author: <agent role + repo scope + what they cannot see>
-- Recipient: <agent role + what they are being asked to do>
-
-## What <subject> is (30 seconds)
-<One paragraph of unavoidable background. Link to canonical docs
-rather than duplicating them.>
-
-## The problem
-<What triggered the briefing. What doesn't work or is missing.>
-
-## What's been decided directionally
-<The author's current best framing of the solution. Labeled as
-direction, not specification. Include trade-offs the author
-already surfaced.>
-
-## Your task
-<The specific question(s) the recipient is being asked to answer
-or the artifact they are being asked to produce. Include axes of
-optimization.>
-
-## Constraints
-<Autonomy scope, repo boundaries, policy references, hard limits.>
-
-## Read first
-<Ordered list of canonical files/links that give the recipient the
-same ground the author stood on.>
-
-## Deliverable
-<What comes back. Usually: a plan, not code.>
-
-## Known bounds of this briefing
-<Explicit: "I am scoped to X. I cannot see Y. My framing of the
-problem may be wrong in these specific ways: ..." This section is
-required — it is the briefing's honesty gate.>
-~~~
+The template lives in its own file:
+[`TEMPLATE.md`](./TEMPLATE.md). Copy it to
+`docs/briefings/NNN-<slug>.md`, fill in every placeholder, delete
+the header comment, and commit.
 
 The **Date + Author** header and **Known bounds** section are
 both load-bearing. The header makes the briefing a dated, signed

--- a/docs/briefings/TEMPLATE.md
+++ b/docs/briefings/TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Briefing template. Copy this file to `docs/briefings/NNN-<slug>.md`,
+replace every placeholder, delete this comment, and commit.
+
+See ./README.md for what a briefing is and when to write one.
+-->
+
+# Briefing: <short title>
+
+**Date**: YYYY-MM-DD
+**Author**: <one-line blurb — environment, device, role within the
+project, and who brought the task. Example: "Claude Code session
+(Opus 4.7, 1M ctx) in an Anthropic cloud env scoped to
+`vade-app/vade-core`; session-scoped kernel agent; task brought
+by Ven.">
+
+## Who's who
+- Principal: <who authorizes decisions>
+- Author: <agent role + repo scope + what they cannot see>
+- Recipient: <agent role + what they are being asked to do>
+
+## What <subject> is (30 seconds)
+<One paragraph of unavoidable background. Link to canonical docs
+rather than duplicating them.>
+
+## The problem
+<What triggered the briefing. What doesn't work or is missing.>
+
+## What's been decided directionally
+<The author's current best framing of the solution. Labeled as
+direction, not specification. Include trade-offs the author
+already surfaced.>
+
+## Your task
+<The specific question(s) the recipient is being asked to answer
+or the artifact they are being asked to produce. Include axes of
+optimization.>
+
+## Constraints
+<Autonomy scope, repo boundaries, policy references, hard limits.>
+
+## Read first
+<Ordered list of canonical files/links that give the recipient the
+same ground the author stood on.>
+
+## Deliverable
+<What comes back. Usually: a plan, not code.>
+
+## Known bounds of this briefing
+<Explicit: "I am scoped to X. I cannot see Y. My framing of the
+problem may be wrong in these specific ways: ..." This section is
+required — it is the briefing's honesty gate.>


### PR DESCRIPTION
## Summary

- Adds `docs/briefings/` as a new standing doc type: short, dated, signed artifacts that a session-scoped agent writes when handing a problem off to a higher-authority agent (typically the COO).
- `README.md` defines purpose, authorship, the natural-bounds caveat (recipient must re-examine problem and solution spaces from scratch, not rubber-stamp the author's framing), a light lifecycle sketch, and the template.
- `001-session-token-plan.md` is the first briefing, cleaned up from what was handed to the COO in-session. Hands off the Claude Code cloud-env bootstrap-token design.

## Why

A briefing was written ad-hoc earlier in a session. The shape proved useful enough to codify before a second one is written ad-hoc too. Two structural requirements in the template are load-bearing:

1. **Dated + signed header** — every briefing names the session, environment, role, and who brought the task. Makes the artifact auditable months later.
2. **"Known bounds of this briefing"** — mandatory honesty gate forcing the author to name the blind spots a broader agent should challenge.

## Follow-ups (out of scope)

Tracked in vade-app/vade-coo-memory#319:

- Formalize the lifecycle (draft / delivered / resolved / archived).
- Cross-repo discoverability (briefings written in `vade-core` but read by COO working across five repos).
- Decide the recipient-evaluation question: did the recipient actually re-examine, or just execute?
- Evaluate packaging the workflow as a Claude Skill so it becomes self-bootstrapping at every future agent rank.

## Test plan

- [ ] Render `docs/briefings/README.md` on github.com; template block reads cleanly.
- [ ] Read `001-session-token-plan.md` cold (as if seeing it for the first time) and confirm it is self-contained.
- [ ] `pr-checks` workflow (typecheck) passes — doc-only change.

Closes nothing; vade-app/vade-coo-memory#319 stays open as the procedure-design tracker.

https://claude.ai/code/session_01L6623b2opChkRQD7apqeSs