### PR TITLE
chore: verify briefing 003 artefact-commit path

### DIFF
--- a/.vade/plans/verify-003.md
+++ b/.vade/plans/verify-003.md
@@ -1,0 +1,8 @@
+# Verify briefing 003 session-lifecycle hooks
+
+End-to-end verification of vade-runtime PR #10.
+
+- Confirm SessionStart prints the SOP-MEM-001 reminder with a suggested run_id.
+- Run `search_memories` for `user_id=ven, agent_id=claude-code`; note newest run_id and artifact_refs.
+- Commit this plan to `vade-core/.vade/plans/verify-003.md` on `claude/verify-briefing-003` and record SHA.
+- Write one `session_summary` episodic Mem0 entry with `artifact_refs` to that commit.

--- a/.vade/plans/verify-003.md
+++ b/.vade/plans/verify-003.md
@@ -1,8 +1,10 @@
-# Verify briefing 003 session-lifecycle hooks
+# verify-003 — briefing 003 lifecycle hooks
 
-End-to-end verification of vade-runtime PR #10.
+End-to-end verification of vade-runtime PR #10 (session-lifecycle hooks)
+in a fresh Claude Code cloud session.
 
-- Confirm SessionStart prints the SOP-MEM-001 reminder with a suggested run_id.
-- Run `search_memories` for `user_id=ven, agent_id=claude-code`; note newest run_id and artifact_refs.
-- Commit this plan to `vade-core/.vade/plans/verify-003.md` on `claude/verify-briefing-003` and record SHA.
-- Write one `session_summary` episodic Mem0 entry with `artifact_refs` to that commit.
+1. Confirm both SessionStart reminders printed at boot.
+2. Exercise the artefact-commit path by committing this plan to
+   vade-core/.vade/plans/verify-003.md.
+3. Write one episodic session_summary to Mem0 with artifact_refs
+   pointing at the committed plan, per SOP-MEM-001 §5.


### PR DESCRIPTION
## Summary

End-to-end verification of `vade-runtime` PR #10 (session-lifecycle hooks per briefing 003). This PR captures the step-3 artefact-commit exercise: writing a plan file to `~/.claude/plans/` and persisting it to `<repo>/.vade/plans/` via GitHub MCP.

## What worked

- `create_branch` + `create_or_update_file` via GitHub MCP produced commit `390af32` on `claude/verify-briefing-003` — a valid `artifact_ref` target for a Mem0 `session_summary` entry.

## What did not work (out of this PR's scope)

End-to-end verification is **blocked** by three gaps external to this repo:

1. **Container predates vade-runtime PR #10.** The running image does not ship `scripts/session-lifecycle.sh`; `install-agent-hooks.sh` still wires only the digest hook. Boot output in a fresh session is just `[vade-setup] GITHUB_TOKEN unset; skipping discussions digest.` — no SOP-MEM-001 reminder, no suggested `run_id`. **Fix:** rebuild the vade-runtime image off main post-PR-#10.
2. **No Mem0 MCP tools attached.** `search_memories` / `add_memory` are not exposed to the session — `ToolSearch` returns zero matches. Steps 2 and 4 of the verification checklist cannot run. **Fix:** register the Mem0 MCP server in the runtime's MCP config.
3. **`HOME` discrepancy.** Bash `$HOME=/root` in-container, but Claude Code's Write tool resolves `~/` to `/home/user/`. `session-lifecycle.sh` reads `$HOME/.claude/plans` so plans Claude writes via `~/.claude/plans/...` are invisible to the Stop-hook's candidate list until mirrored. **Fix:** either normalise `HOME` in bootstrap or have the script check both paths. Tracking separately — likely a one-line PR to vade-runtime.

## Test plan

- [x] File lands at `.vade/plans/verify-003.md` on `claude/verify-briefing-003`.
- [ ] Re-run verification after container rebuild + Mem0 MCP attachment + `GITHUB_TOKEN`.
- [ ] Episodic Mem0 entry written with `artifact_refs=["vade-core/.vade/plans/verify-003.md@390af32..."]` — blocked on (2).