### PR TITLE
fix(canvas): re-focus tldraw editor on library modal close

### DIFF
--- a/src/components/CanvasSwitcher.tsx
+++ b/src/components/CanvasSwitcher.tsx
@@ -75,6 +75,17 @@ function CanvasSwitcherInner({ editor }: { editor: Editor }) {
     writeActive(active)
   }, [active])
 
+  // The modal portals to document.body, so any click inside it blurs the
+  // tldraw container — and keyboard shortcuts + wheel/pan are gated on
+  // editor.isFocused. loadStoreSnapshot also restores the saved instance
+  // record, which carries isFocused, so a canvas saved while the chip was
+  // open deserializes into a blurred editor. Re-focus on every close so H,
+  // V, touchpad scroll, etc. keep working after save/switch.
+  const closeModal = () => {
+    setOpen(false)
+    editor.focus()
+  }
+
   // Dirty tracking: flip on any user-initiated document-scope change.
   useEffect(() => {
     const off = editor.store.listen(
@@ -161,7 +172,7 @@ function CanvasSwitcherInner({ editor }: { editor: Editor }) {
             editor={editor}
             active={active}
             dirty={dirty}
-            onClose={() => setOpen(false)}
+            onClose={closeModal}
             onActivate={(next, newDirty) => {
               setActive(next)
               setDirty(newDirty)


### PR DESCRIPTION
## Summary

Library chip + modal (PR #67) broke keyboard shortcuts (`H`, `V`, …) and touchpad scroll/pan after saving or switching canvases. Clicking a tool in tldraw's toolbar and dragging still worked, but `H` didn't switch to the hand, and two-finger pan didn't move the camera.

## Root cause

tldraw gates **keyboard events and wheel / pointer-move events on `editor.isFocused`**. From `@tldraw/editor` (3.15.6) `Editor.focus()` / `Editor.blur()` docstrings:

> Puts the editor into focused mode. This makes the editor eligible to receive keyboard events and some pointer events (move, wheel).
> Switches off the editor's focused mode. This makes the editor ignore keyboard events and some pointer events (move, wheel).

Two things were leaving the editor blurred after a library interaction:

1. The modal portals to `document.body` (needed so buttons + backdrop receive events outside tldraw's `SharePanel` container — see 6d5b6e4 in #67). Any click inside the modal is therefore outside tldraw's container and blurs the editor.
2. `editor.store.loadStoreSnapshot` restores the saved `instance` record, which carries `isFocused`. A canvas saved while the chip/modal was open deserializes into a **blurred** editor. So even after closing the modal, the just-loaded canvas was still blurred.

Clicking a tool and dragging still worked because `pointerdown` on the canvas re-enters focused mode; `H` and touchpad wheel didn't, because those paths are gated on `isFocused`.

## Fix

Wrap the modal's `onClose` in a `closeModal` helper that calls `editor.focus()` after `setOpen(false)`. All close paths (Close button, backdrop click, `handleNew`, `handleLoad`) route through it, so the canvas re-focuses on every exit — including after `loadStoreSnapshot` has overwritten `isFocused`.

```tsx
const closeModal = () => {
  setOpen(false)
  editor.focus()
}
```

Note: `handleSave`/`handleSaveAs` don't auto-close the modal (intentional in the original design — save-then-keep-editing), so the refocus happens when the user clicks Close. No behavior change for that path beyond the fix itself.

## Test plan

- [ ] Load the SPA, confirm `H`, `V`, `Space`, and touchpad scroll/pan work on a fresh canvas (baseline).
- [ ] Open library chip → Close. Confirm `H` and touchpad scroll still work.
- [ ] Open library chip → click a row to load a different canvas. Confirm `H` and touchpad scroll work immediately after.
- [ ] Save current canvas (Save / Save as…) → close modal. Confirm `H` and touchpad scroll work.
- [ ] `New` from the chip, confirm `H` and touchpad scroll work.
- [ ] Backdrop-click dismiss, confirm `H` and touchpad scroll work.
- [ ] Clicking the hand tool in tldraw's toolbar still works (unchanged path).

https://claude.ai/code/session_01HUCAEePf98Mo1oob2LHFft