### PR TITLE
fix(mcp/oauth): origin-match RFC 8707 resource for Claude.ai compat

### DIFF
--- a/mcp/oauth.ts
+++ b/mcp/oauth.ts
@@ -122,6 +122,27 @@ function isValidRedirectUri(uri: string): boolean {
   return false
 }
 
+// RFC 8707 §2: the resource indicator MUST be an absolute URI. The MCP spec
+// (rev 2025-06-18 §2.10) tells clients to use the canonical resource URI from
+// the protected-resource metadata, but real clients (notably Claude.ai's "Add
+// custom connector") send the URL the user typed — e.g. the SSE endpoint
+// `https://mcp.vade-app.dev/sse` rather than the issuer root. We accept any
+// URI whose origin equals our canonical resource origin, which keeps the
+// audience-binding intent of RFC 8707 (you can't redirect a token to a
+// different host) while not breaking on path drift.
+function resourceMatches(received: string | null, canonical: string): boolean {
+  if (received == null || received === '') return true
+  let receivedUrl: URL
+  let canonicalUrl: URL
+  try {
+    receivedUrl = new URL(received)
+    canonicalUrl = new URL(canonical)
+  } catch {
+    return false
+  }
+  return receivedUrl.origin === canonicalUrl.origin
+}
+
 function canonicalizeAuthorizeParams(params: URLSearchParams): string {
   const keys = ['response_type', 'client_id', 'redirect_uri', 'code_challenge',
     'code_challenge_method', 'resource', 'scope', 'state']
@@ -360,6 +381,7 @@ async function handleAuthorizeGet(
   const codeChallenge = p.get('code_challenge') ?? ''
   const codeChallengeMethod = p.get('code_challenge_method')
   const resource = p.get('resource')
+  console.log(`[oauth] authorize GET client_id=${clientId} resource=${resource ?? '(missing)'} redirect_uri=${redirectUri}`)
   const state = p.get('state') ?? ''
   const scope = p.get('scope') ?? SUPPORTED_SCOPE
 
@@ -390,9 +412,9 @@ async function handleAuthorizeGet(
   if (codeChallengeMethod !== 'S256') {
     return redirectError('invalid_request', 'code_challenge_method must be S256')
   }
-  if (resource !== ctx.resource) {
+  if (!resourceMatches(resource, ctx.resource)) {
     return redirectError('invalid_target',
-      `resource must equal ${ctx.resource} (RFC 8707)`)
+      `resource origin must match ${ctx.resource} (RFC 8707; got ${resource ?? 'null'})`)
   }
   if (scope !== SUPPORTED_SCOPE) return redirectError('invalid_scope')
 
@@ -408,7 +430,7 @@ async function handleAuthorizeGet(
     clientName: client.clientName,
     redirectUri,
     codeChallenge,
-    resource,
+    resource: resource ?? '',
     state,
     scope,
     consentNonce: nonce,
@@ -559,6 +581,12 @@ async function handleAuthorizePost(
 
   const operator = operatorTokenFromBearerOrForm(operatorToken, cfg)
   if (!operator) {
+    const trimmed = (operatorToken ?? '').trim()
+    const recvLen = trimmed.length
+    const recvPrefix = trimmed.slice(0, 8)
+    const candLens = cfg.operator.map((t) => t.length)
+    const candPrefixes = cfg.operator.map((t) => t.slice(0, 8))
+    console.log(`[oauth] consent token mismatch: recv_len=${recvLen} recv_prefix=${recvPrefix} cand_lens=[${candLens.join(',')}] cand_prefixes=[${candPrefixes.join(',')}]`)
     // Per spec we should redirect back, but we do not want to leak that the
     // password was wrong via a redirect — re-render or show a 401. 401 is
     // simplest and the operator can hit back and retry.
@@ -644,7 +672,9 @@ function handleTokenAuthCode(
     sendOAuthError(res, 400, 'invalid_grant', 'client_id / redirect_uri mismatch')
     return { handled: true }
   }
-  if (resource && resource !== entry.resource) {
+  // Skip the audience check if either side is empty: the consent-binding
+  // hash already binds the token to the resource declared at consent time.
+  if (resource && entry.resource && !resourceMatches(resource, entry.resource)) {
     sendOAuthError(res, 400, 'invalid_target', 'resource mismatch')
     return { handled: true }
   }


### PR DESCRIPTION
## Summary

- Strict `resource` equality at /oauth/authorize and /oauth/token
  rejected Claude.ai's "Add custom connector" flow, because Claude.ai
  sends the URL the user typed (`https://mcp.vade-app.dev/`, with
  trailing slash) instead of the canonical resource URI advertised
  in our protected-resource metadata (`https://mcp.vade-app.dev`,
  no slash).
- Replace strict equality with `resourceMatches`: null/empty = match
  (resource is optional on the authorize request per RFC 6749), else
  parse both sides as URLs and compare origin only. Audience binding
  intent of RFC 8707 (a leaked token can't be redirected to a
  different host) is preserved.
- Add two diagnostic logs that proved decisive while debugging:
  `[oauth] authorize GET …` and the `[oauth] consent token mismatch
  …` on operator-token failure (8-char prefixes only, matches the
  existing `[bridge]` log convention).

## Why this fix and not strict-spec compliance

The MCP authorization spec (rev 2025-06-18 §2.10) tells clients to
use the canonical resource URI from
`/.well-known/oauth-protected-resource`. Claude.ai doesn't —
neither do most real clients, in the field. Strict equality fails
closed in a way that surfaces only as
`error=invalid_target&error_description=resource+must+equal+...` in
the redirect, which is not a recoverable user error. Loosening to
origin-match is the conventional remedy and matches what the public
MCP servers in the wild are doing.

## Hot-deploy note

This patch was deployed to `vade-mcp` via
`flyctl deploy --remote-only` while the operator was actively
unblocking the Claude.ai connector flow. This PR backfills `main`
so the next CI deploy doesn't revert the fix. The currently
running Fly machine is on the same code as this PR.

## Verification

Live against `mcp.vade-app.dev` after deploy:

- `GET /.well-known/oauth-authorization-server` → 200 (unchanged)
- `GET /.well-known/oauth-protected-resource` → 200 (unchanged)
- `POST /oauth/register` → 201 (unchanged)
- Claude.ai connector add → consent screen renders (was 302 with
  `invalid_target` before)
- Operator token paste → `vade_at_*` issued, connector shows
  Connected, vade-canvas tools surface in conversations.

Fly logs confirmed the resource sent by Claude.ai is
`https://mcp.vade-app.dev/` (trailing slash, missing `/sse`),
which the new origin-match accepts.

## Test plan

- [x] `npm run typecheck:mcp` clean
- [x] OAuth metadata endpoints unchanged (probed live)
- [x] Bearer-only clients (Desktop, Code, iPad PWA) untouched —
      no change to `mcp/auth.ts` or to `cfg.operator` lookup
- [x] Live Claude.ai connector flow completes end-to-end on Fly

## Out of scope

- Doc update (`docs/auth.md`) capturing the connector walkthrough
  with the new tolerance — folded into #74.