### PR TITLE
refactor: cache OPERATOR_TOKENS parse per isolate (#94)

### DIFF
--- a/worker/library.ts
+++ b/worker/library.ts
@@ -61,6 +61,37 @@ function canvasKey(slug: string): string {
   return `canvases/${slug}/snapshot.tldr`
 }
 
+// Per-isolate cache of the parsed OPERATOR_TOKENS JSON. Keyed off the raw
+// env value so a secret rotation (which spawns a new isolate with a fresh
+// env) naturally invalidates without explicit reset. The parse cost is
+// invisible at single-operator scale today; the cache becomes load-bearing
+// if/when OPERATOR_TOKENS migrates to Secrets Store, where each access
+// flips from sync `env.X` to async `await env.X.get()`.
+let operatorTokensCache: {
+  raw: string
+  tokens: readonly string[]
+} | null = null
+
+function getOperatorTokens(env: Env): readonly string[] {
+  const raw = env.OPERATOR_TOKENS
+  if (!raw) return []
+  if (operatorTokensCache?.raw === raw) return operatorTokensCache.tokens
+  try {
+    const parsed = JSON.parse(raw) as { operator?: unknown; agents?: unknown }
+    const operator = Array.isArray(parsed.operator) ? parsed.operator : []
+    const agents = Array.isArray(parsed.agents) ? parsed.agents : []
+    const tokens = [...operator, ...agents].filter(
+      (t): t is string => typeof t === 'string',
+    )
+    operatorTokensCache = { raw, tokens }
+    return tokens
+  } catch (err) {
+    console.warn('OPERATOR_TOKENS is not valid JSON; ignoring', err)
+    operatorTokensCache = { raw, tokens: [] }
+    return []
+  }
+}
+
 // Accept LIBRARY_BEARER (service-to-service secret shared with Fly) OR any
 // token listed in OPERATOR_TOKENS.{operator,agents}[] (same JSON shape as
 // Fly's VADE_AUTH_TOKENS). The second path lets the SPA reach /library/*
@@ -75,21 +106,8 @@ function isAuthorized(req: Request, env: Env): boolean {
 
   if (env.LIBRARY_BEARER && token === env.LIBRARY_BEARER) return true
 
-  if (env.OPERATOR_TOKENS) {
-    try {
-      const parsed = JSON.parse(env.OPERATOR_TOKENS) as {
-        operator?: unknown
-        agents?: unknown
-      }
-      const operator = Array.isArray(parsed.operator) ? parsed.operator : []
-      const agents = Array.isArray(parsed.agents) ? parsed.agents : []
-      for (const t of [...operator, ...agents]) {
-        if (typeof t === 'string' && t === token) return true
-      }
-    } catch (err) {
-      // Malformed JSON: log once per request and treat as absent rather than 500.
-      console.warn('OPERATOR_TOKENS is not valid JSON; ignoring', err)
-    }
+  for (const t of getOperatorTokens(env)) {
+    if (t === token) return true
   }
 
   return false


### PR DESCRIPTION
## Summary

Hoist the `JSON.parse(env.OPERATOR_TOKENS)` from inside `isAuthorized` to a module-scope getter keyed off the raw env value. Invisible-cost today at single-operator scale; becomes load-bearing when:

- `OPERATOR_TOKENS` migrates to Secrets Store (per-request `await env.X.get()` instead of free sync `env.X`), or
- the token JSON grows past a handful of entries.

Cache invalidates automatically on rotation: each new isolate sees a fresh raw string, so the keyed-cache miss re-parses once and re-stores.

Behaviour identical to the previous inline path: malformed JSON still logs once and treats the token list as empty rather than 500-ing the request.

## Test plan

- [ ] Diff review — single function added, single call site changed.
- [ ] Locally: `npm run -s typecheck` passes (no new TS errors; `Env.OPERATOR_TOKENS?: string` shape unchanged).
- [ ] Manual: hit `/library/canvases` with a valid operator token; expect `200` (cache populated). Hit again; expect same `200` with cache hit (no re-parse).
- [ ] Negative: hit with invalid token; expect `401` (unchanged).

Closes vade-core#94.

https://claude.ai/code/session_0173pp51CB7g8hLYzdgqWrq2