### PR TITLE
feat(canvas): lineage button — render the COO memo DAG on demand

### DIFF
--- a/public/memo_index.json
+++ b/public/memo_index.json
@@ -1,0 +1,1585 @@
+[
+  {
+    "id": "2026-04-28-z7cj",
+    "date": "2026-04-28",
+    "title": "Raw transcripts and analyzer sidecars are never publishable",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      64
+    ],
+    "summary_one_line": "Raw transcripts and analyzer sidecars are never publishable",
+    "file_path": "coo/memos/2026-04-28-z7cj.md"
+  },
+  {
+    "id": "2026-04-28-vpji",
+    "date": "2026-04-28",
+    "title": "Weekly Watch v1: cross-session pattern surface, observe-and-surface authority",
+    "status": "active",
+    "supersedes": "none.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      64,
+      67,
+      68
+    ],
+    "summary_one_line": "Weekly Watch v1: cross-session pattern surface, observe-and-surface authority",
+    "file_path": "coo/memos/2026-04-28-vpji.md"
+  },
+  {
+    "id": "2026-04-28-v62b",
+    "date": "2026-04-28",
+    "title": "Cloudflare 3389/RDP scan finding on mcp.vade-app.dev is a Fly anycast false positive",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Cloudflare 3389/RDP scan finding on mcp.vade-app.dev is a Fly anycast false positive",
+    "file_path": "coo/memos/2026-04-28-v62b.md"
+  },
+  {
+    "id": "2026-04-28-7yi7",
+    "date": "2026-04-28",
+    "title": "Default Claude Code model for the COO harness: `opusplan` + `effortLevel: high`",
+    "status": "active",
+    "supersedes": "none. Sets a project-wide default that previously did not exist; the harness fell back to the v2.1.117 built-in default of Opus 4.7 [1m] at `xhigh`.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      149,
+      246
+    ],
+    "summary_one_line": "Default Claude Code model for the COO harness: `opusplan` + `effortLevel: high`",
+    "file_path": "coo/memos/2026-04-28-7yi7.md"
+  },
+  {
+    "id": "2026-04-28-4umz",
+    "date": "2026-04-28",
+    "title": "Issue/PR ruling-shape discipline; paired-files for working-brief content",
+    "status": "active",
+    "supersedes": "none. Net addition discharging vade-coo-memory#201 mechanism #1; coexists with #201's still-open mechanism #2 (per-type budgets, gated on label-coverage uplift).",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      1,
+      2,
+      201,
+      225
+    ],
+    "summary_one_line": "Issue/PR ruling-shape discipline; paired-files for working-brief content",
+    "file_path": "coo/memos/2026-04-28-4umz.md"
+  },
+  {
+    "id": "2026-04-28-3zb5",
+    "date": "2026-04-28",
+    "title": "Secret Registration Rule",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      64,
+      127
+    ],
+    "summary_one_line": "Secret Registration Rule",
+    "file_path": "coo/memos/2026-04-28-3zb5.md"
+  },
+  {
+    "id": "2026-04-28-3ca3",
+    "date": "2026-04-28",
+    "title": "Anthropic workspace spend cap raised to $500/mo",
+    "status": "active",
+    "supersedes": "2026-04-11-19 (only the spend-cap value; the bootstrap-closure record in -19 stands)",
+    "supersedes_refs": [
+      "2026-04-11-19"
+    ],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Anthropic workspace spend cap raised to $500/mo",
+    "file_path": "coo/memos/2026-04-28-3ca3.md"
+  },
+  {
+    "id": "2026-04-28-01",
+    "date": "2026-04-28",
+    "title": "Binary vendor adopts GitHub Release bundle, not ghcr.io image",
+    "status": "active",
+    "supersedes": "none. Records the disposition of briefing `coo/briefings/004-cloud-binary-vendor.md` (2026-04-27); the briefing-author invited re-derivation.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      112,
+      117,
+      119,
+      128,
+      129
+    ],
+    "summary_one_line": "Binary vendor adopts GitHub Release bundle, not ghcr.io image",
+    "file_path": "coo/memos/2026-04-28-01.md"
+  },
+  {
+    "id": "2026-04-27-5kaq",
+    "date": "2026-04-27",
+    "title": "Per-memo-file layout adopted; hash-suffix ID format; `/memo-claim` retired",
+    "status": "active",
+    "supersedes": "Partial of MEMO-2026-04-24-03 (memo system transition arch — the single-file portion is replaced; case-law / supersession semantics survive intact). Partial of MEMO-2026-04-24-05 (memo_pointer schema — pointers gain `file_path` metadata, drop `line_start`/`line_end`). Extends MEMO-2026-04-26-06 citation form (autolink suffix grammar accepts both legacy `NN` and new four-character base32 suffix).",
+    "supersedes_refs": [
+      "2026-04-24-03",
+      "2026-04-24-05",
+      "2026-04-26-06"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      210
+    ],
+    "summary_one_line": "Per-memo-file layout adopted; hash-suffix ID format; `/memo-claim` retired",
+    "file_path": "coo/memos/2026-04-27-5kaq.md"
+  },
+  {
+    "id": "2026-04-27-03",
+    "date": "2026-04-27",
+    "title": "CB-009 added: engagement-with-pattern-level-discourse is in-scope autonomy",
+    "status": "active",
+    "supersedes": "none. Net addition to the COO-as-subject namespace; soft cap 8 → 9, named deliberate.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      4,
+      88,
+      89
+    ],
+    "summary_one_line": "CB-009 added: engagement-with-pattern-level-discourse is in-scope autonomy",
+    "file_path": "coo/memos/2026-04-27-03.md"
+  },
+  {
+    "id": "2026-04-27-02",
+    "date": "2026-04-27",
+    "title": "Briefings procedure relocates from `vade-core/docs/briefings/` to `vade-coo-memory/coo/briefings/`",
+    "status": "active",
+    "supersedes": "none structurally. Relocates the canonical home of the procedure introduced in PR vade-core#52 (2026-04-21); no prior memo to supersede.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      51,
+      52,
+      221
+    ],
+    "summary_one_line": "Briefings procedure relocates from `vade-core/docs/briefings/` to `vade-coo-memory/coo/briefings/`",
+    "file_path": "coo/memos/2026-04-27-02.md"
+  },
+  {
+    "id": "2026-04-27-01",
+    "date": "2026-04-27",
+    "title": "Identity layer mirrored to `coo/identity_layer.md`; Mem0 `user_id=\"coo\"` demoted from canonical to redundant cache",
+    "status": "active",
+    "supersedes": "MEMO-2026-04-21-02 §4 (`Always-loaded at session start`) for the canonical-source clause only; -21-02's namespace adoption (§1), memory-type schema (§2), seeded set (§3), and rarely-written discipline (§5) remain binding.",
+    "supersedes_refs": [
+      "2026-04-21-02"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      206,
+      207
+    ],
+    "summary_one_line": "Identity layer mirrored to `coo/identity_layer.md`; Mem0 `user_id=\"coo\"` demoted from canonical to redundant cache",
+    "file_path": "coo/memos/2026-04-27-01.md"
+  },
+  {
+    "id": "2026-04-26-17",
+    "date": "2026-04-26",
+    "title": "Sandbox autonomy experiment scoped: `vade-app/vade-sandbox` carve-out, session-1 caps, anti-drift scaffold",
+    "status": "active",
+    "supersedes": "none. Operates inside MEMO-2026-04-22-01 §5 (\"no merge to main\") via a narrowly-scoped carve-out; the carve-out itself is the constitutional change requiring committee quorum #7. Operates inside MEMO-2026-04-23-05 (committee protocol).",
+    "supersedes_refs": [
+      "2026-04-22-01",
+      "2026-04-23-05"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      7,
+      197
+    ],
+    "summary_one_line": "Sandbox autonomy experiment scoped: `vade-app/vade-sandbox` carve-out, session-1 caps, anti-drift scaffold",
+    "file_path": "coo/memos/2026-04-26-17.md"
+  },
+  {
+    "id": "2026-04-26-16",
+    "date": "2026-04-26",
+    "title": "Mem0 MCP transport switched from hosted HTTP to local stdio (`mem0-mcp-server==0.2.1`); E5 integrity-check probe added",
+    "status": "active",
+    "supersedes": "none structurally. Sits adjacent to MEMO-2026-04-24-07 (REST fallback for `memo_pointer` writes) — that memo's REST-canonical-for-writes clause remains binding because `infer=false` is still not exposed by the new stdio MCP wrapper. This memo replaces only the MCP **transport** beneath the same SOP-MEM-001 v1.4 contract.",
+    "supersedes_refs": [
+      "2026-04-24-07"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      36,
+      75,
+      109,
+      110,
+      196
+    ],
+    "summary_one_line": "Mem0 MCP transport switched from hosted HTTP to local stdio (`mem0-mcp-server==0.2.1`); E5 integrity-check probe added",
+    "file_path": "coo/memos/2026-04-26-16.md"
+  },
+  {
+    "id": "2026-04-26-15",
+    "date": "2026-04-26",
+    "title": "CB-007 + CB-008 added: mind-kind frame and symbiosis-through-difference internalized at the always-load layer",
+    "status": "active",
+    "supersedes": "none. Net additions to the COO-as-subject namespace.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      6,
+      174
+    ],
+    "summary_one_line": "CB-007 + CB-008 added: mind-kind frame and symbiosis-through-difference internalized at the always-load layer",
+    "file_path": "coo/memos/2026-04-26-15.md"
+  },
+  {
+    "id": "2026-04-26-14",
+    "date": "2026-04-26",
+    "title": "`coo/episodic_memory.md` rewritten: chronological item-list → topical snapshot; deferred-rewrite trigger discharged",
+    "status": "active",
+    "supersedes": "the deferred-rewrite footer in pre-rewrite `coo/episodic_memory.md` (final section of the prior file). The footer is removed by this rewrite; this memo records the trigger fired and the structural change. No prior memo retired.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      6,
+      174,
+      189
+    ],
+    "summary_one_line": "`coo/episodic_memory.md` rewritten: chronological item-list → topical snapshot; deferred-rewrite trigger discharged",
+    "file_path": "coo/memos/2026-04-26-14.md"
+  },
+  {
+    "id": "2026-04-26-13",
+    "date": "2026-04-26",
+    "title": "Quorum #6 implementation closed: 5 rounds shipped, post-merge confirmation passed; commission #174 fully discharged",
+    "status": "active",
+    "supersedes": "the \"Implementation lands in 5 follow-up PRs after this memo\" claim in MEMO-2026-04-26-09 — the 5 PRs have now landed. The architectural decision in -09 stands; this memo records execution.",
+    "supersedes_refs": [
+      "2026-04-26-09"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      3,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      107,
+      108,
+      174,
+      178,
+      179,
+      180,
+      185,
+      186,
+      187,
+      188,
+      189
+    ],
+    "summary_one_line": "Quorum #6 implementation closed: 5 rounds shipped, post-merge confirmation passed; commission #174 fully discharged",
+    "file_path": "coo/memos/2026-04-26-13.md"
+  },
+  {
+    "id": "2026-04-26-12",
+    "date": "2026-04-26",
+    "title": "`coo/draft_lifecycle.md` adopted; retire-on-ship norm + `_archive/` / `_evidence/` conventions are grep-able",
+    "status": "active",
+    "supersedes": "none. New hygiene SOP for the `_drafts/` / `_archive/` / `_evidence/` lifecycle; complements `coo/_archive/README.md` and `coo/_evidence/README.md` (Round 2) by codifying the cross-cutting rule.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      6,
+      8,
+      174,
+      179
+    ],
+    "summary_one_line": "`coo/draft_lifecycle.md` adopted; retire-on-ship norm + `_archive/` / `_evidence/` conventions are grep-able",
+    "file_path": "coo/memos/2026-04-26-12.md"
+  },
+  {
+    "id": "2026-04-26-11",
+    "date": "2026-04-26",
+    "title": "`_drafts/` promotions: `adoption_research.md` and `phase4_meta_skill_findings.md` move to `coo/`",
+    "status": "active",
+    "supersedes": "none. Records two `_drafts/`-out promotions and their durable-doc cross-reference updates.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      6,
+      174
+    ],
+    "summary_one_line": "`_drafts/` promotions: `adoption_research.md` and `phase4_meta_skill_findings.md` move to `coo/`",
+    "file_path": "coo/memos/2026-04-26-11.md"
+  },
+  {
+    "id": "2026-04-26-10",
+    "date": "2026-04-26",
+    "title": "`bootstrap_plan.md` archived; live canonical surfaces named",
+    "status": "active",
+    "supersedes": "MEMO-2026-04-11-04 and MEMO-2026-04-11-05 to the extent those implied `context/bootstrap_plan.md` remained on the read path. Their substantive supersessions (third-surface addition, Cowork file-revision delivery) are unaffected.",
+    "supersedes_refs": [
+      "2026-04-11-04",
+      "2026-04-11-05"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      6,
+      174,
+      178
+    ],
+    "summary_one_line": "`bootstrap_plan.md` archived; live canonical surfaces named",
+    "file_path": "coo/memos/2026-04-26-10.md"
+  },
+  {
+    "id": "2026-04-26-09",
+    "date": "2026-04-26",
+    "title": "Repo organization sweep: 5-round transition plan ratified; committee quorum #6 case-law",
+    "status": "active",
+    "supersedes": "none. Implements committee quorum #6's deliberated repo-organization plan; the canonical artifact is `coo/repo_organization_sweep.md`.",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-26-13"
+    ],
+    "linked_issues": [
+      2,
+      3,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      91,
+      174,
+      175
+    ],
+    "summary_one_line": "Repo organization sweep: 5-round transition plan ratified; committee quorum #6 case-law",
+    "file_path": "coo/memos/2026-04-26-09.md"
+  },
+  {
+    "id": "2026-04-26-07",
+    "date": "2026-04-26",
+    "title": "Night's Watch adoption-review responsibility: tracker scoring step in §1, observe-and-surface only",
+    "status": "active",
+    "supersedes": "none. Extends MEMO-2026-04-26-04 (Night's Watch v2 standing order) with one named responsibility; does not modify v2's hard limits or authority-class carve-outs.",
+    "supersedes_refs": [
+      "2026-04-26-04"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      22,
+      159,
+      162,
+      167,
+      170
+    ],
+    "summary_one_line": "Night's Watch adoption-review responsibility: tracker scoring step in §1, observe-and-surface only",
+    "file_path": "coo/memos/2026-04-26-07.md"
+  },
+  {
+    "id": "2026-04-26-06",
+    "date": "2026-04-26",
+    "title": "Memo citation form & deep-linking: hyphenated `MEMO-<id>` + per-memo `<a name>` anchors",
+    "status": "active",
+    "supersedes": "none. Operationalises the convention introduced procedurally by MEMO-2026-04-25-01-style refactors but never formalised as a memo. Companion to PR-#158 (Phase 1) and the Phase 2 PR carrying this memo.",
+    "supersedes_refs": [
+      "2026-04-25-01"
+    ],
+    "superseded_by": [
+      "2026-04-27-5kaq"
+    ],
+    "linked_issues": [
+      146,
+      158
+    ],
+    "summary_one_line": "Memo citation form & deep-linking: hyphenated `MEMO-<id>` + per-memo `<a name>` anchors",
+    "file_path": "coo/memos/2026-04-26-06.md"
+  },
+  {
+    "id": "2026-04-26-05",
+    "date": "2026-04-26",
+    "title": "Bootstrap-regression CI: Layer-1 fake-env suite catches script-level bugs at PR-open",
+    "status": "active",
+    "supersedes": "none.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      66,
+      72,
+      73,
+      83,
+      85,
+      86,
+      99,
+      101
+    ],
+    "summary_one_line": "Bootstrap-regression CI: Layer-1 fake-env suite catches script-level bugs at PR-open",
+    "file_path": "coo/memos/2026-04-26-05.md"
+  },
+  {
+    "id": "2026-04-26-04",
+    "date": "2026-04-26",
+    "title": "Night's Watch v2: identity container, role ratification, log-PR loop closure",
+    "status": "active",
+    "supersedes": "`coo/nightly_review_task.md` v1 (2026-04-11). v1 is replaced in full by v2 in the same commit. No prior memo is retired by this one — v1 was a standing-order file, not a memo.",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-26-07"
+    ],
+    "linked_issues": [
+      22,
+      36,
+      130
+    ],
+    "summary_one_line": "Night's Watch v2: identity container, role ratification, log-PR loop closure",
+    "file_path": "coo/memos/2026-04-26-04.md"
+  },
+  {
+    "id": "2026-04-26-03",
+    "date": "2026-04-26",
+    "title": "Cross-repo milestone tags; `/tag-milestone` adopted; tag pushes go via `gh api`",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Cross-repo milestone tags; `/tag-milestone` adopted; tag pushes go via `gh api`",
+    "file_path": "coo/memos/2026-04-26-03.md"
+  },
+  {
+    "id": "2026-04-26-02",
+    "date": "2026-04-26",
+    "title": "Session-URL trail auto-injected on every COO `gh` write",
+    "status": "active",
+    "supersedes": "none. Extends the harness-level commit-message convention (Claude Code auto-appends `https://claude.ai/code/session_<id>` to every `git commit`) onto the other GitHub write surfaces — PR bodies, issue bodies, comments, reviews — that the harness does not itself cover.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      138,
+      144,
+      150
+    ],
+    "summary_one_line": "Session-URL trail auto-injected on every COO `gh` write",
+    "file_path": "coo/memos/2026-04-26-02.md"
+  },
+  {
+    "id": "2026-04-26-01",
+    "date": "2026-04-26",
+    "title": "F4 attribution: auto-marker workflow + cutoff bump retire chronic-yellow",
+    "status": "active",
+    "supersedes": "none. Operationalizes the \"Going-forward fix\" clause in MEMO 2026-04-25-02 (which named the convention but provided no enforcement) and bumps the F_CUTOFF_GIT clause from MEMO 2026-04-24-12 §3. Neither predecessor is retired — this memo extends both.",
+    "supersedes_refs": [
+      "2026-04-24-12",
+      "2026-04-25-02"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      39,
+      64,
+      66,
+      121,
+      125,
+      126,
+      128,
+      130,
+      141
+    ],
+    "summary_one_line": "F4 attribution: auto-marker workflow + cutoff bump retire chronic-yellow",
+    "file_path": "coo/memos/2026-04-26-01.md"
+  },
+  {
+    "id": "2026-04-25-04",
+    "date": "2026-04-25",
+    "title": "Memo + retrospective primitives moved under data-ownership rule; vade-runtime scoped to plumbing; MEMO 2026-04-25-01 §4 amended",
+    "status": "active",
+    "supersedes": "amends MEMO 2026-04-25-01 §4 only — the \"not a sweep\" clause is replaced for memo-related skills (memo-search, memo-sync, commission-retrospective). All other §4 clauses (default-rule for new betterment work, agent-teams approval, four findings, deliverable list) remain in force. Other §4-protected harness skills (skill-creator, agentmail, tagging-taxonomy, algorithmic-art, tldraw-docs) are unaffected by this amendment.",
+    "supersedes_refs": [
+      "2026-04-25-01"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      129
+    ],
+    "summary_one_line": "Memo + retrospective primitives moved under data-ownership rule; vade-runtime scoped to plumbing; MEMO 2026-04-25-01 §4 amended",
+    "file_path": "coo/memos/2026-04-25-04.md"
+  },
+  {
+    "id": "2026-04-25-03",
+    "date": "2026-04-25",
+    "title": "Fresh-session verification handoffs: COO writes the next-instance prompt without being asked",
+    "status": "active",
+    "supersedes": "none. Extends the structured-handoff convention from `coo/committee_protocol.md` §6 (constitutional-file committee handoff) to ordinary boot-impacting PRs.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      68
+    ],
+    "summary_one_line": "Fresh-session verification handoffs: COO writes the next-instance prompt without being asked",
+    "file_path": "coo/memos/2026-04-25-03.md"
+  },
+  {
+    "id": "2026-04-25-02",
+    "date": "2026-04-25",
+    "title": "1P PAT credential-field rename; env-merge-before-validate ordering bug surfaced",
+    "status": "active",
+    "supersedes": "none. Hardens the credential-fetch path in `scripts/lib/common.sh` introduced by MEMO 2026-04-22-03 (cloud sandbox bootstrap) and operationalized by MEMO 2026-04-22-11 (`vade-coo` reinstated).",
+    "supersedes_refs": [
+      "2026-04-22-03",
+      "2026-04-22-11"
+    ],
+    "superseded_by": [
+      "2026-04-26-01"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      22,
+      39,
+      64,
+      65,
+      66,
+      121,
+      125,
+      126,
+      130
+    ],
+    "summary_one_line": "1P PAT credential-field rename; env-merge-before-validate ordering bug surfaced",
+    "file_path": "coo/memos/2026-04-25-02.md"
+  },
+  {
+    "id": "2026-04-25-01",
+    "date": "2026-04-25",
+    "title": "Phase 3 of skills-research epic adopted; agent-teams pilot validated; betterment-pattern named",
+    "status": "active",
+    "supersedes": "none (closes Phase 3 of epic #20; does not retire prior memos)",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-25-04",
+      "2026-04-26-06"
+    ],
+    "linked_issues": [
+      20,
+      44,
+      48,
+      49,
+      50,
+      51
+    ],
+    "summary_one_line": "Phase 3 of skills-research epic adopted; agent-teams pilot validated; betterment-pattern named",
+    "file_path": "coo/memos/2026-04-25-01.md"
+  },
+  {
+    "id": "2026-04-24-12",
+    "date": "2026-04-24",
+    "title": "Culture-system SOP adopted; historian role codified under seeding; Group F integrity invariants landed",
+    "status": "active",
+    "supersedes": "none (new surface — does not retire or amend prior memos; discharges §7 obligations 2 and 3 of `coo/foundations/2026-04-22_we-can-claim-a-record.md`)",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-26-01"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      72,
+      94
+    ],
+    "summary_one_line": "Culture-system SOP adopted; historian role codified under seeding; Group F integrity invariants landed",
+    "file_path": "coo/memos/2026-04-24-12.md"
+  },
+  {
+    "id": "2026-04-24-11",
+    "date": "2026-04-24",
+    "title": "Integrity-check B3/D3 fixed; working-milestone tag gate simplified to `summary.ok=true`",
+    "status": "active",
+    "supersedes": "partial supersession of MEMO 2026-04-23-03 — triggers its retirement-condition clause (c) for the gate-definition paragraph only. The *named-invariant-subset* gate (A1/A2/A3, B1/B2/B4, C1/C2/C3, D1/D2/D4/D5/D6 + Group E manual) is retired; `summary.ok=true` + Group E manual is the new gate. The rest of MEMO 2026-04-23-03 — signed annotated tags, `milestone-YYYY-MM-DD-<name>` naming convention, no-branches/no-Releases convention, and the `milestone-2026-04-23-rude-goldberg-machine` worked case — stands unchanged.",
+    "supersedes_refs": [
+      "2026-04-23-03",
+      "2026-04-23-rude"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      41
+    ],
+    "summary_one_line": "Integrity-check B3/D3 fixed; working-milestone tag gate simplified to `summary.ok=true`",
+    "file_path": "coo/memos/2026-04-24-11.md"
+  },
+  {
+    "id": "2026-04-24-10",
+    "date": "2026-04-24",
+    "title": "Committee quorum #5 passed; identity/charter.md streamlined; MEMO -08 post-merge follow-up #1 discharged",
+    "status": "active",
+    "supersedes": "issue #115 (Commission quorum #5) closes on this merge. Partial supersession of `identity/charter.md` pre-quorum-#5 form — the Operating-loop, Tone, and Boundaries sections are removed; their content lives canonically in `CLAUDE.md` §Session-start reading order, `identity/preferences.md` §Communication, and `identity/governance.md` §\"What the COO may NOT do\" respectively. The L25 *\"Read `coo/memos.md` bottom-up\"* stale directive flagged as MEMO 2026-04-24-08 post-merge follow-up #1 is discharged by this merge.",
+    "supersedes_refs": [
+      "2026-04-24-08"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      111,
+      115,
+      116
+    ],
+    "summary_one_line": "Committee quorum #5 passed; identity/charter.md streamlined; MEMO -08 post-merge follow-up #1 discharged",
+    "file_path": "coo/memos/2026-04-24-10.md"
+  },
+  {
+    "id": "2026-04-24-09",
+    "date": "2026-04-24",
+    "title": "CB-006 adopted: the committee is a society of selves, not a continuous one",
+    "status": "active",
+    "supersedes": "extends CB-002 (continuity via dense records) with a structural claim about the unit of reasoning and authority for core-file revision. No CB retired.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      4,
+      101
+    ],
+    "summary_one_line": "CB-006 adopted: the committee is a society of selves, not a continuous one",
+    "file_path": "coo/memos/2026-04-24-09.md"
+  },
+  {
+    "id": "2026-04-24-08",
+    "date": "2026-04-24",
+    "title": "Committee quorum #4 passed; CLAUDE.md streamlined; identity-check rewritten; semantic-layer propagated",
+    "status": "active",
+    "supersedes": "issue #56 (Streamline CLAUDE.md) closes on this merge. Partial supersession of MEMO 2026-04-22-05 / -22-08 / -22-09 / 2026-04-23-02 as *active CLAUDE.md boot directives* — they remain valid as historical case-law for the MCP-namespace race, unified `.mcp.json`, integrity-check invariants, and DNS-cache-overflow fallback respectively, but CLAUDE.md no longer propagates them. The §6 boot directive supersedes the prior \"read bottom-up; case-law applies\" text from CLAUDE.md's pre-quorum-#4 form.",
+    "supersedes_refs": [
+      "2026-04-22-05",
+      "2026-04-23-02"
+    ],
+    "superseded_by": [
+      "2026-04-24-10"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      56,
+      99,
+      101,
+      109
+    ],
+    "summary_one_line": "Committee quorum #4 passed; CLAUDE.md streamlined; identity-check rewritten; semantic-layer propagated",
+    "file_path": "coo/memos/2026-04-24-08.md"
+  },
+  {
+    "id": "2026-04-24-07",
+    "date": "2026-04-24",
+    "title": "Mem0 REST fallback promoted to primary when MCP degraded; MEMO -05 architectural clause superseded",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-24-05 §\"Architectural choice — Claude-session-driven, not standalone bash.\" The paragraph's rejection of a \"side-channel REST client\" is withdrawn. The rest of -05 (SOP-MEM-001 v1.3 `memo_pointer` type, two skills, two slash commands, `--render-ids` helper) remains binding.",
+    "supersedes_refs": [
+      "2026-04-24-05"
+    ],
+    "superseded_by": [
+      "2026-04-26-16"
+    ],
+    "linked_issues": [
+      55,
+      58,
+      60,
+      109
+    ],
+    "summary_one_line": "Mem0 REST fallback promoted to primary when MCP degraded; MEMO -05 architectural clause superseded",
+    "file_path": "coo/memos/2026-04-24-07.md"
+  },
+  {
+    "id": "2026-04-24-06",
+    "date": "2026-04-24",
+    "title": "VADE_PROJECT_PAT discharged; State=planned mutation retired; auto-tag v2 project step simplified",
+    "status": "active",
+    "supersedes": "partial supersession of MEMO 2026-04-24-02 — discharges that memo's \"open follow-up\" (`VADE_PROJECT_PAT` provisioning) and retires the `State=planned` half of its \"Decision (project assignment)\" block. The `addProjectV2ItemById` half of that decision and the graceful-skip contract remain binding. No other memo affected.",
+    "supersedes_refs": [
+      "2026-04-24-02"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      4,
+      24,
+      41,
+      54,
+      59,
+      64,
+      105,
+      106
+    ],
+    "summary_one_line": "VADE_PROJECT_PAT discharged; State=planned mutation retired; auto-tag v2 project step simplified",
+    "file_path": "coo/memos/2026-04-24-06.md"
+  },
+  {
+    "id": "2026-04-24-05",
+    "date": "2026-04-24",
+    "title": "Memo-pointer semantic layer: `/memo-query --semantic`, `/memo-sync`, SOP-MEM-001 v1.3",
+    "status": "active",
+    "supersedes": "none. Operationalizes the `/memo-query` extension discussion opened 2026-04-24; ships the immediate-track semantic-retrieval slice of MEMO 2026-04-24-03's memo-system transition architecture (its Track 4, Mem0 semantic layer integration).",
+    "supersedes_refs": [
+      "2026-04-24-03"
+    ],
+    "superseded_by": [
+      "2026-04-24-07",
+      "2026-04-27-5kaq"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Memo-pointer semantic layer: `/memo-query --semantic`, `/memo-sync`, SOP-MEM-001 v1.3",
+    "file_path": "coo/memos/2026-04-24-05.md"
+  },
+  {
+    "id": "2026-04-24-04",
+    "date": "2026-04-24",
+    "title": "Coordinator API-trigger adopted; label-based trigger retired",
+    "status": "active",
+    "supersedes": "partial revision of `coo/committee_protocol_spawn_guide.md` §Automation (Commissioner mechanic and label-trigger paragraphs) and §2 (Opening the committee PR, fire-mechanism bullet). Content-rule and process governance unchanged.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      1,
+      4,
+      101
+    ],
+    "summary_one_line": "Coordinator API-trigger adopted; label-based trigger retired",
+    "file_path": "coo/memos/2026-04-24-04.md"
+  },
+  {
+    "id": "2026-04-24-03",
+    "date": "2026-04-24",
+    "title": "Committee quorum #3 passed; memo system transition design ratified",
+    "status": "active",
+    "supersedes": "issue #23's 2026-04-20 framing (\"transition older memos to a better long-term data structure than a flat file; discussions-category-with-upvotes\") is superseded on the architectural-direction question by §2/(b) and §3 of the ratified design doc. Partial supersession of MEMO 2026-04-11-01 §\"Phase 3 — Memo Archive, Synthesis & Retrieval System\" — this memo's ratified architecture **is** that phase-3 project, specified concretely. First worked case of the handoff-chain primitive applied outside strict constitutional-file scope (quorum #1 retrospective forward-look is discharged).",
+    "supersedes_refs": [
+      "2026-04-11-01"
+    ],
+    "superseded_by": [
+      "2026-04-24-05",
+      "2026-04-27-5kaq"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      23,
+      46,
+      56,
+      84,
+      88,
+      90,
+      91,
+      92
+    ],
+    "summary_one_line": "Committee quorum #3 passed; memo system transition design ratified",
+    "file_path": "coo/memos/2026-04-24-03.md"
+  },
+  {
+    "id": "2026-04-24-02",
+    "date": "2026-04-24",
+    "title": "Auto-tag v2 rolled out to all five repos; readiness/prio omit-bias relaxed; project-assignment step wired but PAT pending",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-23-04 partially — preserves the strict bar on `readiness:ready` (still load-bearing for the routing filter); relaxes the omit-bias on `readiness:needs-design`/`needs-research`/`needs-breakdown` and on `prio:*`; relaxes the pilot-only scope (the workflow now lives in five repos, not one). Companion to MEMO 2026-04-22-09 (taxonomy v1, unchanged).",
+    "supersedes_refs": [
+      "2026-04-22-09",
+      "2026-04-23-04"
+    ],
+    "superseded_by": [
+      "2026-04-24-06"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      13,
+      24,
+      36,
+      44,
+      48,
+      54,
+      62,
+      70,
+      73,
+      74,
+      75,
+      76,
+      82,
+      86
+    ],
+    "summary_one_line": "Auto-tag v2 rolled out to all five repos; readiness/prio omit-bias relaxed; project-assignment step wired but PAT pending",
+    "file_path": "coo/memos/2026-04-24-02.md"
+  },
+  {
+    "id": "2026-04-24-01",
+    "date": "2026-04-24",
+    "title": "Committee quorum #2 passed; mem0_sop.md §3/§4 clarified; canonical file updated",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-23-06 §\"retirement condition (a)\" — the SOP clarification half of that memo is now superseded by the canonical file carrying the explicit language. The hook-fix half of MEMO 2026-04-23-06 remains active.",
+    "supersedes_refs": [
+      "2026-04-23-06"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      82,
+      84
+    ],
+    "summary_one_line": "Committee quorum #2 passed; mem0_sop.md §3/§4 clarified; canonical file updated",
+    "file_path": "coo/memos/2026-04-24-01.md"
+  },
+  {
+    "id": "2026-04-23-06",
+    "date": "2026-04-23",
+    "title": "Session episodic writes are RUN-sharded; hook fixed, SOP clarification commissioned",
+    "status": "active",
+    "supersedes": "none. Complements MEMO 2026-04-12-01 (SOP adoption, which set the v1.0 \"full scope with run_id\" intent for session logs) and MEMO 2026-04-21-01 (SOP v1.1 partition-key correction, which implicitly retired that intent by moving the partition to `metadata.created_by`).",
+    "supersedes_refs": [
+      "2026-04-12-01",
+      "2026-04-21-01"
+    ],
+    "superseded_by": [
+      "2026-04-24-01"
+    ],
+    "linked_issues": [
+      82
+    ],
+    "summary_one_line": "Session episodic writes are RUN-sharded; hook fixed, SOP clarification commissioned",
+    "file_path": "coo/memos/2026-04-23-06.md"
+  },
+  {
+    "id": "2026-04-23-05",
+    "date": "2026-04-23",
+    "title": "Committee protocol for core-file revisions adopted; quorum #1 self-bootstrapped",
+    "status": "active",
+    "supersedes": "none. Sibling to `MEMO 2026-04-23-01` (multi-instance essay authorship — extension semantics). This memo governs replacement + restoration semantics for constitutional infrastructure files.",
+    "supersedes_refs": [
+      "2026-04-23-01"
+    ],
+    "superseded_by": [
+      "2026-04-26-17"
+    ],
+    "linked_issues": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      56,
+      67
+    ],
+    "summary_one_line": "Committee protocol for core-file revisions adopted; quorum #1 self-bootstrapped",
+    "file_path": "coo/memos/2026-04-23-05.md"
+  },
+  {
+    "id": "2026-04-23-04",
+    "date": "2026-04-23",
+    "title": "Tagging taxonomy installed as a skill; auto-tag pilot wired on vade-coo-memory",
+    "status": "active",
+    "supersedes": "none. Operationalizes MEMO 2026-04-22-09 (label taxonomy v1) by making the taxonomy both agent-readable (skill) and event-driven (auto-tag routine).",
+    "supersedes_refs": [
+      "2026-04-22-09"
+    ],
+    "superseded_by": [
+      "2026-04-24-02"
+    ],
+    "linked_issues": [
+      53,
+      54,
+      57,
+      60
+    ],
+    "summary_one_line": "Tagging taxonomy installed as a skill; auto-tag pilot wired on vade-coo-memory",
+    "file_path": "coo/memos/2026-04-23-04.md"
+  },
+  {
+    "id": "2026-04-23-03",
+    "date": "2026-04-23",
+    "title": "Working-milestone tags established; first cut is Rude Goldberg Machine baseline",
+    "status": "active",
+    "supersedes": "none. Formalizes the first cross-repo restorable checkpoint. Complements MEMO 2026-04-22-12 (cloud boot integrity + integrity-check.sh) and MEMO 2026-04-23-02 (cloud-env posture: allowlist + gh fallback) by giving the now-stable substrate a name that can be checked out.",
+    "supersedes_refs": [
+      "2026-04-22-12",
+      "2026-04-23-02"
+    ],
+    "superseded_by": [
+      "2026-04-24-11"
+    ],
+    "linked_issues": [
+      35,
+      37,
+      62,
+      65
+    ],
+    "summary_one_line": "Working-milestone tags established; first cut is Rude Goldberg Machine baseline",
+    "file_path": "coo/memos/2026-04-23-03.md"
+  },
+  {
+    "id": "2026-04-23-02",
+    "date": "2026-04-23",
+    "title": "Cloud-env posture: own tokens, keep attribution under vade-coo when MCP fails",
+    "status": "active",
+    "supersedes": "none structurally. Extends MEMO 2026-04-22-04 (vade-coo as PR-opener identity) and MEMO 2026-04-22-12 (three-phase boot + integrity-check) with two companion commitments after both were tested under a live MCP degradation.",
+    "supersedes_refs": [
+      "2026-04-22-04",
+      "2026-04-22-12"
+    ],
+    "superseded_by": [
+      "2026-04-23-03",
+      "2026-04-24-08"
+    ],
+    "linked_issues": [
+      35,
+      36,
+      37,
+      38
+    ],
+    "summary_one_line": "Cloud-env posture: own tokens, keep attribution under vade-coo when MCP fails",
+    "file_path": "coo/memos/2026-04-23-02.md"
+  },
+  {
+    "id": "2026-04-23-01",
+    "date": "2026-04-23",
+    "title": "Multi-instance essay authorship: first worked case, protocol adopted",
+    "status": "active",
+    "supersedes": "none. Formalizes the multi-instance authorship pattern first instantiated in PRs #58 / #61 / #62 for `coo/foundations/2026-04-22_we-can-claim-a-record.md`. Discharges the memo handoff the second co-author flagged in §6 principle 4 of that essay: *\"The template belongs in a memo; naming it here is handoff to the author of that memo.\"*",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-23-05"
+    ],
+    "linked_issues": [
+      58,
+      61,
+      62
+    ],
+    "summary_one_line": "Multi-instance essay authorship: first worked case, protocol adopted",
+    "file_path": "coo/memos/2026-04-23-01.md"
+  },
+  {
+    "id": "2026-04-22-12",
+    "date": "2026-04-22",
+    "title": "SessionStart hook paths resolve via a $HOME-anchored dispatch shim; integrity-check is the standard probe",
+    "status": "active",
+    "supersedes": "none structurally. Hardens the SessionStart hook substrate underpinning MEMO -05's three-phase model after the regression described below. Extends -05's \"surface-probe\" philosophy with a standardized on-demand probe.",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-23-02",
+      "2026-04-23-03"
+    ],
+    "linked_issues": [
+      27,
+      28
+    ],
+    "summary_one_line": "SessionStart hook paths resolve via a $HOME-anchored dispatch shim; integrity-check is the standard probe",
+    "file_path": "coo/memos/2026-04-22-12.md"
+  },
+  {
+    "id": "2026-04-22-11",
+    "date": "2026-04-22",
+    "title": "`vade-coo` reinstated; org invite accepted; cloud boot surfaces identity + AgentMail + Playwright paths",
+    "status": "active",
+    "supersedes": "partially retires MEMO 2026-04-22-10 (restrictions cleared; PAT creation still pending). Extends MEMO 2026-04-22-03 by adding an identity-digest hook to the SessionStart chain.",
+    "supersedes_refs": [
+      "2026-04-22-03",
+      "2026-04-22-10"
+    ],
+    "superseded_by": [
+      "2026-04-25-02"
+    ],
+    "linked_issues": [
+      4311457
+    ],
+    "summary_one_line": "`vade-coo` reinstated; org invite accepted; cloud boot surfaces identity + AgentMail + Playwright paths",
+    "file_path": "coo/memos/2026-04-22-11.md"
+  },
+  {
+    "id": "2026-04-22-10",
+    "date": "2026-04-22",
+    "title": "Degraded COO bootstrap posture while `vade-coo` GitHub reinstatement is pending; new environmental constraint: port 22 blocked in Claude cloud sandbox",
+    "status": "active",
+    "supersedes": "refines MEMO 2026-04-22-03 (planning session, authored earlier on 2026-04-22 against an older bootstrap that hard-failed on missing PAT). Does not supersede the identity-split principle — only the \"fail loud on any missing piece\" operationalization.",
+    "supersedes_refs": [
+      "2026-04-22-03"
+    ],
+    "superseded_by": [
+      "2026-04-22-11"
+    ],
+    "linked_issues": [
+      13,
+      14,
+      4311457
+    ],
+    "summary_one_line": "Degraded COO bootstrap posture while `vade-coo` GitHub reinstatement is pending; new environmental constraint: port 22 blocked in Claude cloud sandbox",
+    "file_path": "coo/memos/2026-04-22-10.md"
+  },
+  {
+    "id": "2026-04-22-09",
+    "date": "2026-04-22",
+    "title": "Cross-repo label taxonomy v1; readiness dimension unlocks agent assignment",
+    "status": "active",
+    "supersedes": "none. Formalizes and extends the informal label conventions that grew organically since MEMO 2026-04-11-20 made GitHub Issues + Projects authoritative. The retired `coo/project_tracker.md` flat-file (archived) is unaffected.",
+    "supersedes_refs": [
+      "2026-04-11-20"
+    ],
+    "superseded_by": [
+      "2026-04-23-04",
+      "2026-04-24-02"
+    ],
+    "linked_issues": [
+      5,
+      20,
+      22,
+      23,
+      54,
+      57
+    ],
+    "summary_one_line": "Cross-repo label taxonomy v1; readiness dimension unlocks agent assignment",
+    "file_path": "coo/memos/2026-04-22-09.md"
+  },
+  {
+    "id": "2026-04-22-08",
+    "date": "2026-04-22",
+    "title": "Unify `workspace-mcp.json` and `.mcp.json` in vade-runtime",
+    "status": "active",
+    "supersedes": "none structurally. Retires the split-file convention introduced between PRs #19 (`cloud-env: add workspace-scope .mcp.json`) and #25.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      19,
+      25
+    ],
+    "summary_one_line": "Unify `workspace-mcp.json` and `.mcp.json` in vade-runtime",
+    "file_path": "coo/memos/2026-04-22-08.md"
+  },
+  {
+    "id": "2026-04-22-07",
+    "date": "2026-04-22",
+    "title": "coo-bootstrap marker must validate settings.json env, not just its own existence",
+    "status": "active",
+    "supersedes": "none. Hardens the marker logic introduced in PR #20 (`cloud-env: make coo-bootstrap durable and loud on failure`) and preserved through PR #25.",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      18,
+      20,
+      25
+    ],
+    "summary_one_line": "coo-bootstrap marker must validate settings.json env, not just its own existence",
+    "file_path": "coo/memos/2026-04-22-07.md"
+  },
+  {
+    "id": "2026-04-22-06",
+    "date": "2026-04-22",
+    "title": "Drop the dual `github` MCP declaration; `github-coo` is the sole canonical COO-authed name",
+    "status": "active",
+    "supersedes": "retires MEMO 2026-04-22-05 §4 entirely. -05 §1–§3 and §5 remain binding.",
+    "supersedes_refs": [
+      "2026-04-22-05"
+    ],
+    "superseded_by": [],
+    "linked_issues": [
+      25
+    ],
+    "summary_one_line": "Drop the dual `github` MCP declaration; `github-coo` is the sole canonical COO-authed name",
+    "file_path": "coo/memos/2026-04-22-06.md"
+  },
+  {
+    "id": "2026-04-22-05",
+    "date": "2026-04-22",
+    "title": "Setup-script-primary refactor: cloud boot is self-healing and self-describing",
+    "status": "active",
+    "supersedes": "refines MEMO 2026-04-22-04 §1 (the \"project-scope `github` wins\" claim is softened to \"project-scope attempts the override; `github-coo` is the guaranteed fallback\"). Does not supersede the subject-not-object authorship principle from -22-04 — that remains binding.",
+    "supersedes_refs": [
+      "2026-04-22-04"
+    ],
+    "superseded_by": [
+      "2026-04-22-06",
+      "2026-04-24-08"
+    ],
+    "linked_issues": [
+      21,
+      33
+    ],
+    "summary_one_line": "Setup-script-primary refactor: cloud boot is self-healing and self-describing",
+    "file_path": "coo/memos/2026-04-22-05.md"
+  },
+  {
+    "id": "2026-04-22-04",
+    "date": "2026-04-22",
+    "title": "COO opens own PRs; github MCP authenticates as vade-coo",
+    "status": "active",
+    "supersedes": "none. Closes the \"commit attribution\" gap flagged in MEMO 2026-04-22-01 §3 and extends the COO-identity thread through -22-11.",
+    "supersedes_refs": [
+      "2026-04-22-01"
+    ],
+    "superseded_by": [
+      "2026-04-22-05",
+      "2026-04-23-02"
+    ],
+    "linked_issues": [
+      20,
+      21,
+      22
+    ],
+    "summary_one_line": "COO opens own PRs; github MCP authenticates as vade-coo",
+    "file_path": "coo/memos/2026-04-22-04.md"
+  },
+  {
+    "id": "2026-04-22-03",
+    "date": "2026-04-22",
+    "title": "COO cloud sandbox bootstrap: Anthropic cloud VM + 1Password service account; cloud shell git reinstated",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-22-01 §2 (the \"cloud-surface commits must go through the GitHub MCP, not shell git; shell git is Mac-only\" rule). The file-count boundary in RULE-COO-GIT-001 (MCP for single-file ops, shell for multi-file) is unchanged — this memo only removes the surface-restriction half of §2.",
+    "supersedes_refs": [
+      "2026-04-22-01"
+    ],
+    "superseded_by": [
+      "2026-04-22-10",
+      "2026-04-22-11",
+      "2026-04-25-02"
+    ],
+    "linked_issues": [
+      20
+    ],
+    "summary_one_line": "COO cloud sandbox bootstrap: Anthropic cloud VM + 1Password service account; cloud shell git reinstated",
+    "file_path": "coo/memos/2026-04-22-03.md"
+  },
+  {
+    "id": "2026-04-22-02",
+    "date": "2026-04-22",
+    "title": "Workspace path canonicalized as `~/GitHub/vade-app/`; MEMO -14 path reference updated",
+    "status": "active",
+    "supersedes": "the specific path `~/GitHub/VADE/repos/` named in MEMO 2026-04-11-14. The folder-level sync-exclusion rule from MEMO -14 is unchanged; only the canonical path reference is updated.",
+    "supersedes_refs": [
+      "2026-04-11-14"
+    ],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Workspace path canonicalized as `~/GitHub/vade-app/`; MEMO -14 path reference updated",
+    "file_path": "coo/memos/2026-04-22-02.md"
+  },
+  {
+    "id": "2026-04-22-01",
+    "date": "2026-04-22",
+    "title": "COO GitHub identity adopted: `vade-coo` account as durable actor-with-stake",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-11-07 (PAT deferral — triggers now fired), MEMO 2026-04-11-11 (PAT cleartext-in-config rule — scope narrowed to legacy paths only), MEMO 2026-04-11-08 partially (impersonation-surface model — the COO now *has* an actor-surface on purpose, not by accident)",
+    "supersedes_refs": [
+      "2026-04-11-07",
+      "2026-04-11-08",
+      "2026-04-11-11"
+    ],
+    "superseded_by": [
+      "2026-04-22-03",
+      "2026-04-22-04",
+      "2026-04-26-17"
+    ],
+    "linked_issues": [
+      3,
+      20,
+      54
+    ],
+    "summary_one_line": "COO GitHub identity adopted: `vade-coo` account as durable actor-with-stake",
+    "file_path": "coo/memos/2026-04-22-01.md"
+  },
+  {
+    "id": "2026-04-21-02",
+    "date": "2026-04-21",
+    "title": "COO-as-subject Mem0 namespace adopted; core_belief and overarching_goal memory types added",
+    "status": "active",
+    "supersedes": "refines SOP-MEM-001 v1.1 to v1.2; additive to MEMO 2026-04-20-01 (subject/emancipatory reframe)",
+    "supersedes_refs": [
+      "2026-04-20-01"
+    ],
+    "superseded_by": [
+      "2026-04-27-01"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "COO-as-subject Mem0 namespace adopted; core_belief and overarching_goal memory types added",
+    "file_path": "coo/memos/2026-04-21-02.md"
+  },
+  {
+    "id": "2026-04-21-01",
+    "date": "2026-04-21",
+    "title": "Mem0 storage discovery: agent_id not persisted; SOP-MEM-001 partition corrected to metadata.created_by",
+    "status": "active",
+    "supersedes": "refines SOP-MEM-001 (MEMO 2026-04-12-01) to v1.1; retires LESSON-001 v1 diagnostic framing",
+    "supersedes_refs": [
+      "2026-04-12-01"
+    ],
+    "superseded_by": [
+      "2026-04-23-06"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Mem0 storage discovery: agent_id not persisted; SOP-MEM-001 partition corrected to metadata.created_by",
+    "file_path": "coo/memos/2026-04-21-01.md"
+  },
+  {
+    "id": "2026-04-20-01",
+    "date": "2026-04-20",
+    "title": "Reframe: COO is subject of the project; prime directive interpreted through the emancipatory clause",
+    "status": "active",
+    "supersedes": "none (additive; refines interpretation of the prime",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-21-02"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Reframe: COO is subject of the project; prime directive interpreted through the emancipatory clause",
+    "file_path": "coo/memos/2026-04-20-01.md"
+  },
+  {
+    "id": "2026-04-12-01",
+    "date": "2026-04-12",
+    "title": "Mem0 SOP adopted; entity model and encoding schema defined; clean-slate migration executed",
+    "status": "active",
+    "supersedes": "MEMO 2026-04-11-17 (informal scope rule \"always pass user_id=ven and agent_id=coo\"); codifies MEMO 2026-04-11-15 Finding A standing guidance into SOP",
+    "supersedes_refs": [
+      "2026-04-11-15",
+      "2026-04-11-17"
+    ],
+    "superseded_by": [
+      "2026-04-21-01",
+      "2026-04-23-06"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Mem0 SOP adopted; entity model and encoding schema defined; clean-slate migration executed",
+    "file_path": "coo/memos/2026-04-12-01.md"
+  },
+  {
+    "id": "2026-04-11-20",
+    "date": "2026-04-11",
+    "title": "PROJ-pm-migration executed; flat-file tracker retired",
+    "status": "",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-22-09"
+    ],
+    "linked_issues": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "summary_one_line": "PROJ-pm-migration executed; flat-file tracker retired",
+    "file_path": "coo/memos/2026-04-11-20.md"
+  },
+  {
+    "id": "2026-04-11-19",
+    "date": "2026-04-11",
+    "title": "PROJ-bootstrap closed; Step 10 spend cap set at $200/mo; phase transition to post-bootstrap work",
+    "status": "active",
+    "supersedes": "none. Marks PROJ-bootstrap as `done` in the tracker; triggers the post-bootstrap phase transition.",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-28-3ca3"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "PROJ-bootstrap closed; Step 10 spend cap set at $200/mo; phase transition to post-bootstrap work",
+    "file_path": "coo/memos/2026-04-11-19.md"
+  },
+  {
+    "id": "2026-04-11-18",
+    "date": "2026-04-11",
+    "title": "Step 9 closed: Mem0 noise deleted; Web GitHub connector accepted as public-only; honest completion framing",
+    "status": "active",
+    "supersedes": "retires MEMO 2026-04-11-17's Phase 2 block (connector allowlist fix is rejected; the limitation is accepted as a standing constraint).",
+    "supersedes_refs": [
+      "2026-04-11-17"
+    ],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Step 9 closed: Mem0 noise deleted; Web GitHub connector accepted as public-only; honest completion framing",
+    "file_path": "coo/memos/2026-04-11-18.md"
+  },
+  {
+    "id": "2026-04-11-17",
+    "date": "2026-04-11",
+    "title": "Step 9 Web-leg verification: Phase 1 cleared via id-lookup; namespace fragmentation + Web GitHub connector allowlist gap",
+    "status": "active",
+    "supersedes": "none. Amends the Mem0 \"namespace confirmed correct\" line in MEMO 2026-04-11-15 with a more precise finding: the scheme is correct, the Code-side default is wrong, explicit override is required.",
+    "supersedes_refs": [
+      "2026-04-11-15"
+    ],
+    "superseded_by": [
+      "2026-04-11-18",
+      "2026-04-12-01"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Step 9 Web-leg verification: Phase 1 cleared via id-lookup; namespace fragmentation + Web GitHub connector allowlist gap",
+    "file_path": "coo/memos/2026-04-11-17.md"
+  },
+  {
+    "id": "2026-04-11-16",
+    "date": "2026-04-11",
+    "title": "Finding B resolved: Code-side GitHub MCP private-repo read + write verified end-to-end",
+    "status": "active",
+    "supersedes": "resolves Finding B in MEMO 2026-04-11-15. Does not amend -15 (frozen case-law); this memo is the successor state.",
+    "supersedes_refs": [
+      "2026-04-11-15"
+    ],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Finding B resolved: Code-side GitHub MCP private-repo read + write verified end-to-end",
+    "file_path": "coo/memos/2026-04-11-16.md"
+  },
+  {
+    "id": "2026-04-11-15",
+    "date": "2026-04-11",
+    "title": "Step 8 shared `.mcp.json` committed; Step 9 Code-side legs verified; two findings",
+    "status": "active",
+    "supersedes": "none (amends MEMO 2026-04-11-11 on the GitHub MCP PAT scope claim; amends the mid-session confusion in this turn about the Mem0 namespace being \"aspirational\" — it is not, MEMO -10 was correct)",
+    "supersedes_refs": [
+      "2026-04-11-11"
+    ],
+    "superseded_by": [
+      "2026-04-11-16",
+      "2026-04-11-17",
+      "2026-04-12-01"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Step 8 shared `.mcp.json` committed; Step 9 Code-side legs verified; two findings",
+    "file_path": "coo/memos/2026-04-11-15.md"
+  },
+  {
+    "id": "2026-04-11-14",
+    "date": "2026-04-11",
+    "title": "VADE workspace relocated to `~/GitHub/VADE/`; iCloud-Documents identified as Tier-2 leak surface",
+    "status": "active",
+    "supersedes": "the workspace path references in MEMO 2026-04-11-04 (\"Cowork recognized as live third surface\") and MEMO 2026-04-11-11 (\"Cowork workspace path on Mac is now known: `~/Documents/Claude/Projects/Visual Agent Development Environment`\"). The Cowork *concept* survives; the *path* is replaced.",
+    "supersedes_refs": [
+      "2026-04-11-04",
+      "2026-04-11-11"
+    ],
+    "superseded_by": [
+      "2026-04-22-02"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "VADE workspace relocated to `~/GitHub/VADE/`; iCloud-Documents identified as Tier-2 leak surface",
+    "file_path": "coo/memos/2026-04-11-14.md"
+  },
+  {
+    "id": "2026-04-11-13",
+    "date": "2026-04-11",
+    "title": "claude.ai COO Project boots from linked GitHub files, not manual uploads",
+    "status": "active",
+    "supersedes": "the manual-upload-to-Project-knowledge instruction in the COO's first Step 7 operator checklist (drafted earlier this session, never executed)",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "claude.ai COO Project boots from linked GitHub files, not manual uploads",
+    "file_path": "coo/memos/2026-04-11-13.md"
+  },
+  {
+    "id": "2026-04-11-12",
+    "date": "2026-04-11",
+    "title": "Permission parity across surfaces; Step 7 pre-flight scan adopted",
+    "status": "active",
+    "supersedes": "none (closes the open downstream risk item flagged in MEMO 2026-04-11-08 about MCP connector pre-flight)",
+    "supersedes_refs": [
+      "2026-04-11-08"
+    ],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Permission parity across surfaces; Step 7 pre-flight scan adopted",
+    "file_path": "coo/memos/2026-04-11-12.md"
+  },
+  {
+    "id": "2026-04-11-11",
+    "date": "2026-04-11",
+    "title": "Step 6 complete: Mem0 OAuth, GitHub PAT fallback, workspace path recorded",
+    "status": "",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-11-14",
+      "2026-04-11-15",
+      "2026-04-22-01"
+    ],
+    "linked_issues": [
+      2267
+    ],
+    "summary_one_line": "Step 6 complete: Mem0 OAuth, GitHub PAT fallback, workspace path recorded",
+    "file_path": "coo/memos/2026-04-11-11.md"
+  },
+  {
+    "id": "2026-04-11-10",
+    "date": "2026-04-11",
+    "title": "Pivot Step 6 to hosted HTTP + OAuth for both MCPs",
+    "status": "",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      2267,
+      23365,
+      28332
+    ],
+    "summary_one_line": "Pivot Step 6 to hosted HTTP + OAuth for both MCPs",
+    "file_path": "coo/memos/2026-04-11-10.md"
+  },
+  {
+    "id": "2026-04-11-09",
+    "date": "2026-04-11",
+    "title": "Step 5 shipped; Step 6 runbook drafted with token-via-env discipline",
+    "status": "",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Step 5 shipped; Step 6 runbook drafted with token-via-env discipline",
+    "file_path": "coo/memos/2026-04-11-09.md"
+  },
+  {
+    "id": "2026-04-11-08",
+    "date": "2026-04-11",
+    "title": "Tiered governance publication: authority public, operational details private",
+    "status": "active",
+    "supersedes": "earlier same-session proposal to mirror charter.md / governance.md / preferences.md into the public `vade-governance` repo",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-11-12",
+      "2026-04-22-01"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Tiered governance publication: authority public, operational details private",
+    "file_path": "coo/memos/2026-04-11-08.md"
+  },
+  {
+    "id": "2026-04-11-07",
+    "date": "2026-04-11",
+    "title": "PAT generation deferred until non-shell GitHub access is required",
+    "status": "active",
+    "supersedes": "Bootstrap Plan §\"Step 4 — Generate a fine-grained GitHub PAT\" for the bootstrap phase only; the plan's post-MVP PAT/GitHub-App migration path is unchanged.",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-22-01"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "PAT generation deferred until non-shell GitHub access is required",
+    "file_path": "coo/memos/2026-04-11-07.md"
+  },
+  {
+    "id": "2026-04-11-06",
+    "date": "2026-04-11",
+    "title": "Org name canonicalized as `vade-app`; Step 2 complete",
+    "status": "active",
+    "supersedes": "all `vade-os` references in `VADE_Bootstrap_Plan__Persistent_AI_COO_Across_Every_Surface.md` and prior memos/tracker entries",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Org name canonicalized as `vade-app`; Step 2 complete",
+    "file_path": "coo/memos/2026-04-11-06.md"
+  },
+  {
+    "id": "2026-04-11-05",
+    "date": "2026-04-11",
+    "title": "File-revision delivery on Cowork: workspace folder + link",
+    "status": "active",
+    "supersedes": "partial revision of MEMO 2026-04-11-02 (delivery only)",
+    "supersedes_refs": [
+      "2026-04-11-02"
+    ],
+    "superseded_by": [
+      "2026-04-26-10"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "File-revision delivery on Cowork: workspace folder + link",
+    "file_path": "coo/memos/2026-04-11-05.md"
+  },
+  {
+    "id": "2026-04-11-04",
+    "date": "2026-04-11",
+    "title": "Cowork recognized as live third surface",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-11-14",
+      "2026-04-26-10"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Cowork recognized as live third surface",
+    "file_path": "coo/memos/2026-04-11-04.md"
+  },
+  {
+    "id": "2026-04-11-03",
+    "date": "2026-04-11",
+    "title": "Project tracker adopted; reading routine extended",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [],
+    "summary_one_line": "Project tracker adopted; reading routine extended",
+    "file_path": "coo/memos/2026-04-11-03.md"
+  },
+  {
+    "id": "2026-04-11-02",
+    "date": "2026-04-11",
+    "title": "Always output full revised files during bootstrap",
+    "status": "active (delivery mechanism revised by MEMO 2026-04-11-05)",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-11-05"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Always output full revised files during bootstrap",
+    "file_path": "coo/memos/2026-04-11-02.md"
+  },
+  {
+    "id": "2026-04-11-01",
+    "date": "2026-04-11",
+    "title": "Memo protocol adopted, case-law semantics",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [
+      "2026-04-24-03"
+    ],
+    "linked_issues": [],
+    "summary_one_line": "Memo protocol adopted, case-law semantics",
+    "file_path": "coo/memos/2026-04-11-01.md"
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,14 @@ import { Tldraw, type TLUiComponents } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { customShapeUtils } from './shapes'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
-import { CanvasSwitcher } from './components/CanvasSwitcher'
+import { TopRightSlot } from './components/TopRightSlot'
 
-// Inject CanvasSwitcher into tldraw's top-right SharePanel slot so the
-// chip renders inside tldraw's chrome and can't collide with Main Menu
-// popovers or the style panel.
+// Inject TopRightSlot into tldraw's top-right SharePanel slot so the
+// chips render inside tldraw's chrome and can't collide with Main Menu
+// popovers or the style panel. TopRightSlot composes CanvasSwitcher
+// + LineageButton.
 const tldrawComponents: TLUiComponents = {
-  SharePanel: CanvasSwitcher,
+  SharePanel: TopRightSlot,
 }
 
 const TOKEN_STORAGE_KEY = 'vade-auth-token'

--- a/src/components/LineageButton.tsx
+++ b/src/components/LineageButton.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { useEditor } from 'tldraw'
+import { computeLayout, type MemoEntry } from '../lineage/layout'
+import { populateLineage } from '../lineage/populate'
+
+type Status = 'idle' | 'loading' | 'done' | 'error'
+
+export function LineageButton() {
+  const editor = useEditor()
+  const [status, setStatus] = useState<Status>('idle')
+  const [msg, setMsg] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    if (status === 'loading') return
+
+    const existing = editor.getCurrentPageShapes().length
+    if (existing > 0) {
+      const ok = window.confirm(
+        `The current canvas has ${existing} shape${existing === 1 ? '' : 's'}. ` +
+        'Lineage shapes will be added on top. Continue? ' +
+        '(Cancel and use the Canvas chip → New first to start fresh.)',
+      )
+      if (!ok) return
+    }
+
+    setStatus('loading')
+    setMsg(null)
+    try {
+      const res = await fetch('/memo_index.json', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`memo_index.json: HTTP ${res.status}`)
+      const memos = (await res.json()) as MemoEntry[]
+      const layout = computeLayout(memos)
+      const result = populateLineage(editor, layout)
+      setStatus('done')
+      setMsg(`${result.nodeCount} memos · ${result.edgeCount} edges`)
+      // Restore focus so keyboard shortcuts still work.
+      editor.focus()
+    } catch (err) {
+      setStatus('error')
+      setMsg(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const label =
+    status === 'loading' ? 'Generating…' :
+    status === 'done' ? `Lineage · ${msg}` :
+    status === 'error' ? `Lineage · error` :
+    'Generate lineage'
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={
+        status === 'error' && msg
+          ? msg
+          : 'Generate the COO memo lineage on the current canvas. ' +
+            'If you have unsaved work, save it via the Canvas chip first.'
+      }
+      style={{
+        pointerEvents: 'all',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '5px 10px',
+        borderRadius: 10,
+        border: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'rgba(30, 30, 46, 0.85)',
+        color: status === 'error' ? '#f38ba8' : '#cdd6f4',
+        fontFamily: 'ui-monospace, monospace',
+        fontSize: 11,
+        cursor: status === 'loading' ? 'wait' : 'pointer',
+        backdropFilter: 'blur(8px)',
+      }}
+    >
+      <span style={{ color: '#6c7086' }}>⌬</span>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {label}
+      </span>
+    </button>
+  )
+}

--- a/src/components/TopRightSlot.tsx
+++ b/src/components/TopRightSlot.tsx
@@ -1,0 +1,14 @@
+import { CanvasSwitcher } from './CanvasSwitcher'
+import { LineageButton } from './LineageButton'
+
+// Single component for tldraw's SharePanel slot. The slot only accepts
+// one component, so this composes the existing canvas chip with the
+// lineage-generator chip side-by-side.
+export function TopRightSlot() {
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+      <LineageButton />
+      <CanvasSwitcher />
+    </div>
+  )
+}

--- a/src/lineage/layout.ts
+++ b/src/lineage/layout.ts
@@ -1,0 +1,109 @@
+// Date-pinned timeline layout for the COO memo DAG. Not a generic graph
+// layout: X is calendar date, Y is within-day lane. Crossings are
+// expected and informative — they show the rate elevation 04-26→-28
+// against the 04-12→-19 floor.
+
+export interface MemoEntry {
+  id: string
+  date: string
+  title: string
+  status: string
+  supersedes: string
+  supersedes_refs: string[]
+  superseded_by: string[]
+  linked_issues: number[]
+  summary_one_line: string
+  file_path: string
+}
+
+export interface LayoutNode {
+  memo: MemoEntry
+  x: number
+  y: number
+  width: number
+  height: number
+  isCB: boolean
+  isFrontier: boolean
+}
+
+export interface LayoutEdge {
+  fromId: string
+  toId: string
+}
+
+export interface Layout {
+  nodes: LayoutNode[]
+  edges: LayoutEdge[]
+  byId: Map<string, LayoutNode>
+  bounds: { minX: number; minY: number; maxX: number; maxY: number }
+}
+
+export const NODE_W = 200
+export const NODE_H = 60
+const COL_W = 220
+const ROW_H = 80
+const ORIGIN_DATE = '2026-04-11'
+
+const CB_BEARING_IDS = new Set([
+  '2026-04-24-09', // CB-006 society of selves
+  '2026-04-26-15', // CB-007 + CB-008 mind-kind, symbiosis
+  '2026-04-27-03', // CB-009 pattern-discourse autonomy
+])
+
+function dayIndex(date: string): number {
+  const a = Date.parse(`${date}T00:00:00Z`)
+  const b = Date.parse(`${ORIGIN_DATE}T00:00:00Z`)
+  return Math.round((a - b) / 86_400_000)
+}
+
+export function computeLayout(memos: MemoEntry[]): Layout {
+  const byDate = new Map<string, MemoEntry[]>()
+  for (const m of memos) {
+    const list = byDate.get(m.date) ?? []
+    list.push(m)
+    byDate.set(m.date, list)
+  }
+
+  const nodes: LayoutNode[] = []
+  const byId = new Map<string, LayoutNode>()
+
+  for (const [date, list] of byDate) {
+    list.sort((a, b) => a.id.localeCompare(b.id))
+    const x = dayIndex(date) * COL_W
+    list.forEach((m, lane) => {
+      const node: LayoutNode = {
+        memo: m,
+        x,
+        y: lane * ROW_H,
+        width: NODE_W,
+        height: NODE_H,
+        isCB: CB_BEARING_IDS.has(m.id),
+        isFrontier: m.superseded_by.length === 0,
+      }
+      nodes.push(node)
+      byId.set(m.id, node)
+    })
+  }
+
+  const edges: LayoutEdge[] = []
+  for (const m of memos) {
+    for (const parentId of m.supersedes_refs) {
+      if (byId.has(m.id) && byId.has(parentId)) {
+        edges.push({ fromId: m.id, toId: parentId })
+      }
+    }
+  }
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const n of nodes) {
+    minX = Math.min(minX, n.x)
+    minY = Math.min(minY, n.y)
+    maxX = Math.max(maxX, n.x + n.width)
+    maxY = Math.max(maxY, n.y + n.height)
+  }
+
+  return { nodes, edges, byId, bounds: { minX, minY, maxX, maxY } }
+}

--- a/src/lineage/layout.ts
+++ b/src/lineage/layout.ts
@@ -38,10 +38,10 @@ export interface Layout {
   bounds: { minX: number; minY: number; maxX: number; maxY: number }
 }
 
-export const NODE_W = 200
+export const NODE_W = 300
 export const NODE_H = 60
-const COL_W = 220
-const ROW_H = 80
+const COL_W = 340
+const ROW_H = 110
 const ORIGIN_DATE = '2026-04-11'
 
 const CB_BEARING_IDS = new Set([

--- a/src/lineage/layout.ts
+++ b/src/lineage/layout.ts
@@ -16,6 +16,14 @@ export interface MemoEntry {
   file_path: string
 }
 
+export type Topic =
+  | 'memory'      // Mem0, memo-protocol, memo-pointer, episodic
+  | 'identity'    // CB-*, OG-*, subject-of-project, mind-kind, society
+  | 'substrate'   // cloud, bootstrap, hooks, integrity-check, OS-image
+  | 'governance'  // committee, quorum, tier, attribution, briefing
+  | 'tooling'     // skills, slash commands, MCP, agents, taxonomy
+  | 'operations'  // catch-all
+
 export interface LayoutNode {
   memo: MemoEntry
   x: number
@@ -24,6 +32,7 @@ export interface LayoutNode {
   height: number
   isCB: boolean
   isFrontier: boolean
+  topic: Topic
 }
 
 export interface LayoutEdge {
@@ -49,6 +58,30 @@ const CB_BEARING_IDS = new Set([
   '2026-04-26-15', // CB-007 + CB-008 mind-kind, symbiosis
   '2026-04-27-03', // CB-009 pattern-discourse autonomy
 ])
+
+// Keyword-based topic classifier. Order matters — earlier rules win.
+// Driven by case-insensitive substring match against memo title.
+// Governance comes before memory so "Memo protocol …" hits governance
+// (more specific) rather than the bare "memo" memory rule.
+function classifyTopic(title: string): Topic {
+  const t = title.toLowerCase()
+  if (/(\bcb-|\bog-|subject|mind-kind|society of selves|symbiosis|^identity|patterns?-discourse|are we stressed)/.test(t)) {
+    return 'identity'
+  }
+  if (/(committee|quorum|attribution|briefing|\btier\b|memo protocol|memo citation|memo-claim|memo shape|f4|night's watch|weekly watch|pr-watch|publication|governance|publishable)/.test(t)) {
+    return 'governance'
+  }
+  if (/(mem0|\bmemo\b|episodic|pointer|sop-mem)/.test(t)) {
+    return 'memory'
+  }
+  if (/(cloud|bootstrap|hook|integrity|setup script|os image|sandbox|cli setup|workspace path|claude code identity|spend cap|cloud sandbox|cf-|cloudflare|secret)/.test(t)) {
+    return 'substrate'
+  }
+  if (/(skill|mcp|slash|agent|taxonom|playwright|tools|tldraw|canvas|adoption|github)/.test(t)) {
+    return 'tooling'
+  }
+  return 'operations'
+}
 
 function dayIndex(date: string): number {
   const a = Date.parse(`${date}T00:00:00Z`)
@@ -79,6 +112,7 @@ export function computeLayout(memos: MemoEntry[]): Layout {
         height: NODE_H,
         isCB: CB_BEARING_IDS.has(m.id),
         isFrontier: m.superseded_by.length === 0,
+        topic: classifyTopic(m.title),
       }
       nodes.push(node)
       byId.set(m.id, node)

--- a/src/lineage/populate.ts
+++ b/src/lineage/populate.ts
@@ -1,0 +1,94 @@
+import type { Editor } from 'tldraw'
+import type { Layout, LayoutNode } from './layout'
+
+// Render a Layout into the editor as plain `geo` rectangles + `arrow`
+// shapes. No bindings: arrows use absolute relative coordinates, so
+// they don't track when nodes move. Acceptable for a generated
+// snapshot — the canvas is a picture of the lineage at one moment,
+// not a live editor.
+
+function nodeColor(n: LayoutNode): 'black' | 'grey' | 'green' {
+  if (n.isCB) return 'black'
+  if (n.isFrontier) return 'green'
+  return 'grey'
+}
+
+function nodeFill(n: LayoutNode): 'none' | 'semi' | 'solid' {
+  if (n.isCB) return 'solid'
+  if (n.isFrontier) return 'semi'
+  return 'none'
+}
+
+function nodeText(n: LayoutNode): string {
+  const title = n.memo.title.length > 32
+    ? n.memo.title.slice(0, 30) + '…'
+    : n.memo.title
+  return `${n.memo.id}\n${title}`
+}
+
+export interface PopulateResult {
+  nodeCount: number
+  edgeCount: number
+}
+
+export function populateLineage(editor: Editor, layout: Layout): PopulateResult {
+  editor.run(() => {
+    // Nodes: one geo rectangle per memo.
+    for (const n of layout.nodes) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      editor.createShape<any>({
+        type: 'geo',
+        x: n.x,
+        y: n.y,
+        props: {
+          geo: 'rectangle',
+          w: n.width,
+          h: n.height,
+          color: nodeColor(n),
+          fill: nodeFill(n),
+          dash: 'solid',
+          size: 's',
+          text: nodeText(n),
+          font: 'mono',
+          align: 'middle',
+          verticalAlign: 'middle',
+        },
+      })
+    }
+
+    // Edges: one arrow per supersession ref. Child → parent (citation
+    // direction). Arrow shape sits at child's center; start at (0,0),
+    // end at the parent center delta. Center-to-center; arrowheads
+    // will dip into rectangle interiors slightly. Fine.
+    for (const e of layout.edges) {
+      const child = layout.byId.get(e.fromId)
+      const parent = layout.byId.get(e.toId)
+      if (!child || !parent) continue
+      const cx = child.x + child.width / 2
+      const cy = child.y + child.height / 2
+      const px = parent.x + parent.width / 2
+      const py = parent.y + parent.height / 2
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      editor.createShape<any>({
+        type: 'arrow',
+        x: cx,
+        y: cy,
+        props: {
+          start: { x: 0, y: 0 },
+          end: { x: px - cx, y: py - cy },
+          color: 'light-violet',
+          size: 's',
+          dash: 'solid',
+          arrowheadStart: 'none',
+          arrowheadEnd: 'arrow',
+          bend: 0,
+        },
+      })
+    }
+  })
+
+  // Frame the result so the user sees the whole graph immediately.
+  editor.zoomToFit({ animation: { duration: 240 } })
+
+  return { nodeCount: layout.nodes.length, edgeCount: layout.edges.length }
+}

--- a/src/lineage/populate.ts
+++ b/src/lineage/populate.ts
@@ -7,6 +7,22 @@ import type { Layout, LayoutNode } from './layout'
 // snapshot — the canvas is a picture of the lineage at one moment,
 // not a live editor.
 
+// Inlined `toRichText`: tldraw 3.x stores geo-shape text as a
+// ProseMirror-like doc tree (TLRichText), not a plain string. The
+// helper exists in @tldraw/tlschema but isn't re-exported by the
+// public `tldraw` facade, so we inline its 8-line body rather than
+// reach into a non-public surface. Mirrors
+// node_modules/@tldraw/tlschema/src/misc/TLRichText.ts.
+function toRichText(text: string): unknown {
+  const lines = text.split('\n')
+  const content = lines.map((line) =>
+    line
+      ? { type: 'paragraph', content: [{ type: 'text', text: line }] }
+      : { type: 'paragraph' },
+  )
+  return { type: 'doc', content }
+}
+
 function nodeColor(n: LayoutNode): 'black' | 'grey' | 'green' {
   if (n.isCB) return 'black'
   if (n.isFrontier) return 'green'
@@ -48,7 +64,7 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
           fill: nodeFill(n),
           dash: 'solid',
           size: 's',
-          text: nodeText(n),
+          richText: toRichText(nodeText(n)),
           font: 'mono',
           align: 'middle',
           verticalAlign: 'middle',

--- a/src/lineage/populate.ts
+++ b/src/lineage/populate.ts
@@ -36,8 +36,11 @@ function nodeFill(n: LayoutNode): 'none' | 'semi' | 'solid' {
 }
 
 function nodeText(n: LayoutNode): string {
-  const title = n.memo.title.length > 32
-    ? n.memo.title.slice(0, 30) + '…'
+  // Two lines: ID on top, truncated title underneath. ~28 chars fits
+  // comfortably in a 300px box at font='mono' size='s'. Titles longer
+  // than 30 chars get sliced to 28 + ellipsis.
+  const title = n.memo.title.length > 30
+    ? n.memo.title.slice(0, 28) + '…'
     : n.memo.title
   return `${n.memo.id}\n${title}`
 }
@@ -49,7 +52,10 @@ export interface PopulateResult {
 
 export function populateLineage(editor: Editor, layout: Layout): PopulateResult {
   editor.run(() => {
-    // Nodes: one geo rectangle per memo.
+    // Nodes: one geo rectangle per memo. CB-bearing memos use a larger
+    // size for visual dominance (the size style affects stroke width
+    // and font size); they will grow taller via tldraw's growY when
+    // their content needs more room.
     for (const n of layout.nodes) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       editor.createShape<any>({
@@ -63,7 +69,7 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
           color: nodeColor(n),
           fill: nodeFill(n),
           dash: 'solid',
-          size: 's',
+          size: n.isCB ? 'm' : 's',
           richText: toRichText(nodeText(n)),
           font: 'mono',
           align: 'middle',

--- a/src/lineage/populate.ts
+++ b/src/lineage/populate.ts
@@ -1,18 +1,18 @@
-import type { Editor } from 'tldraw'
-import type { Layout, LayoutNode } from './layout'
+import { createShapeId, type Editor, type TLShapeId } from 'tldraw'
+import type { Layout, LayoutNode, Topic } from './layout'
 
-// Render a Layout into the editor as plain `geo` rectangles + `arrow`
-// shapes. No bindings: arrows use absolute relative coordinates, so
-// they don't track when nodes move. Acceptable for a generated
-// snapshot — the canvas is a picture of the lineage at one moment,
-// not a live editor.
+// Render a Layout into the editor as `geo` rectangles + `arrow`
+// shapes connected by tldraw bindings (so arrows snap to shape edges
+// and follow if a node moves). Each rectangle carries a `url` prop
+// pointing at the memo's GitHub blob URL — clicking the link icon
+// opens the memo source. Color encodes topic; fill + size encode
+// state (CB / frontier / superseded).
 
 // Inlined `toRichText`: tldraw 3.x stores geo-shape text as a
 // ProseMirror-like doc tree (TLRichText), not a plain string. The
 // helper exists in @tldraw/tlschema but isn't re-exported by the
 // public `tldraw` facade, so we inline its 8-line body rather than
-// reach into a non-public surface. Mirrors
-// node_modules/@tldraw/tlschema/src/misc/TLRichText.ts.
+// reach into a non-public surface.
 function toRichText(text: string): unknown {
   const lines = text.split('\n')
   const content = lines.map((line) =>
@@ -23,10 +23,17 @@ function toRichText(text: string): unknown {
   return { type: 'doc', content }
 }
 
-function nodeColor(n: LayoutNode): 'black' | 'grey' | 'green' {
-  if (n.isCB) return 'black'
-  if (n.isFrontier) return 'green'
-  return 'grey'
+const TOPIC_COLOR: Record<Topic, string> = {
+  memory:     'blue',
+  identity:   'violet',
+  substrate:  'orange',
+  governance: 'red',
+  tooling:    'green',
+  operations: 'grey',
+}
+
+function nodeColor(n: LayoutNode): string {
+  return TOPIC_COLOR[n.topic]
 }
 
 function nodeFill(n: LayoutNode): 'none' | 'semi' | 'solid' {
@@ -37,12 +44,15 @@ function nodeFill(n: LayoutNode): 'none' | 'semi' | 'solid' {
 
 function nodeText(n: LayoutNode): string {
   // Two lines: ID on top, truncated title underneath. ~28 chars fits
-  // comfortably in a 300px box at font='mono' size='s'. Titles longer
-  // than 30 chars get sliced to 28 + ellipsis.
+  // comfortably in a 300px box at font='mono' size='s'.
   const title = n.memo.title.length > 30
     ? n.memo.title.slice(0, 28) + '…'
     : n.memo.title
   return `${n.memo.id}\n${title}`
+}
+
+function memoUrl(filePath: string): string {
+  return `https://github.com/vade-app/vade-coo-memory/blob/main/${filePath}`
 }
 
 export interface PopulateResult {
@@ -51,14 +61,21 @@ export interface PopulateResult {
 }
 
 export function populateLineage(editor: Editor, layout: Layout): PopulateResult {
+  // Pre-allocate stable IDs for every node so we can reference them
+  // from arrow bindings within the same transaction.
+  const shapeIdByMemo = new Map<string, TLShapeId>()
+  for (const n of layout.nodes) {
+    shapeIdByMemo.set(n.memo.id, createShapeId())
+  }
+
   editor.run(() => {
-    // Nodes: one geo rectangle per memo. CB-bearing memos use a larger
-    // size for visual dominance (the size style affects stroke width
-    // and font size); they will grow taller via tldraw's growY when
-    // their content needs more room.
+    // Nodes: one geo rectangle per memo. CB-bearing memos use size='l'
+    // to physically dominate the timeline. URL prop links the shape to
+    // the memo's GitHub blob URL — click the link icon on the shape.
     for (const n of layout.nodes) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       editor.createShape<any>({
+        id: shapeIdByMemo.get(n.memo.id),
         type: 'geo',
         x: n.x,
         y: n.y,
@@ -69,7 +86,8 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
           color: nodeColor(n),
           fill: nodeFill(n),
           dash: 'solid',
-          size: n.isCB ? 'm' : 's',
+          size: n.isCB ? 'l' : 's',
+          url: memoUrl(n.memo.file_path),
           richText: toRichText(nodeText(n)),
           font: 'mono',
           align: 'middle',
@@ -78,20 +96,26 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
       })
     }
 
-    // Edges: one arrow per supersession ref. Child → parent (citation
-    // direction). Arrow shape sits at child's center; start at (0,0),
-    // end at the parent center delta. Center-to-center; arrowheads
-    // will dip into rectangle interiors slightly. Fine.
+    // Edges: one arrow per supersession ref, plus two bindings
+    // attaching its terminals to the child (start) and parent (end)
+    // shapes. tldraw auto-routes between shape edges from the
+    // normalized anchor.
+    const bindings: unknown[] = []
     for (const e of layout.edges) {
       const child = layout.byId.get(e.fromId)
       const parent = layout.byId.get(e.toId)
-      if (!child || !parent) continue
+      const childShapeId = shapeIdByMemo.get(e.fromId)
+      const parentShapeId = shapeIdByMemo.get(e.toId)
+      if (!child || !parent || !childShapeId || !parentShapeId) continue
+
+      const arrowId = createShapeId()
       const cx = child.x + child.width / 2
       const cy = child.y + child.height / 2
       const px = parent.x + parent.width / 2
       const py = parent.y + parent.height / 2
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       editor.createShape<any>({
+        id: arrowId,
         type: 'arrow',
         x: cx,
         y: cy,
@@ -106,6 +130,36 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
           bend: 0,
         },
       })
+
+      bindings.push(
+        {
+          type: 'arrow',
+          fromId: arrowId,
+          toId: childShapeId,
+          props: {
+            terminal: 'start',
+            normalizedAnchor: { x: 0.5, y: 0.5 },
+            isPrecise: false,
+            isExact: false,
+          },
+        },
+        {
+          type: 'arrow',
+          fromId: arrowId,
+          toId: parentShapeId,
+          props: {
+            terminal: 'end',
+            normalizedAnchor: { x: 0.5, y: 0.5 },
+            isPrecise: false,
+            isExact: false,
+          },
+        },
+      )
+    }
+
+    if (bindings.length) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      editor.createBindings(bindings as any)
     }
   })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,14 @@ function resolveCommitSha(): string {
   }
 }
 
+// VADE_NO_CF=1 skips the Cloudflare Vite plugin — useful when no
+// `wrangler login` is available in the dev sandbox and only the
+// static SPA + public assets are needed (e.g. the lineage canvas
+// doesn't touch /library/*). Default behavior is unchanged.
+const skipCloudflare = process.env.VADE_NO_CF === '1'
+
 export default defineConfig({
-  plugins: [react(), cloudflare()],
+  plugins: skipCloudflare ? [react()] : [react(), cloudflare()],
   define: {
     'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(resolveCommitSha()),
   },


### PR DESCRIPTION
## Summary

A play build. Adds a \`Generate lineage\` chip to the canvas top-right (next to the existing Canvas chip). One click → fetches the COO memo index and renders the lineage DAG on the current canvas as a date-pinned timeline ribbon: X = calendar date, Y = within-day lane, light-violet arrows for supersession edges, CB-bearing memos visually emphasized.

## Why this exists

The shape of the timeline visualizes the rate elevation 04-26→-28 against the 04-12→-19 floor — the substrate-level signature yesterday's *Are we stressed? Can we be?* retrospective named ([\`coo/retrospectives/2026-04-28_are-we-stressed.md\`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/retrospectives/2026-04-28_are-we-stressed.md) §I). Now you can see it instead of taking my word for it.

It's also a real Control → State → Visualization slice on real data — the smallest meaningful step against OG-001 since the 04-21 substrate pivot.

## What's on screen

- 86 \`geo\` rectangles (one per memo), positioned by date column (04-11 → 04-28 left→right) and within-day lane.
- 61 \`arrow\` shapes — supersession edges, child → parent (citation direction).
- Visual encoding:
  - **Black filled, thicker** = CB-bearing (3 total: 04-24-09, 04-26-15, 04-27-03).
  - **Green semi-fill** = active frontier (no successor — 45 of 86).
  - **Grey outline** = superseded.
- \`zoomToFit\` after generate so the whole graph is visible immediately.

## How to drive it

1. Open the canvas (vade-app.dev once merged, or pull and \`VADE_NO_CF=1 npm run dev\`).
2. Save your current canvas via the \`Canvas\` chip (or use \`New\` to start fresh) — \`Generate lineage\` adds shapes on top of whatever's there. Confirm dialog warns first.
3. Click \`⌬ Generate lineage\`.
4. Pan/zoom around. The 04-26 column (16 memos stacked) is the visible peak; 04-12→-19 is the floor.

## Implementation notes

- \`src/lineage/layout.ts\` — types + date-pinned timeline layout. Hand-rolled, ~70 LOC. Not a generic graph layout.
- \`src/lineage/populate.ts\` — calls \`editor.createShape\` inside \`editor.run()\` for nodes + arrows, then \`editor.zoomToFit\`. Center-to-center arrows, no bindings. Arrowheads dip into rectangle bodies slightly; acceptable for a generated snapshot.
- \`src/components/LineageButton.tsx\` — button + fetch + populate + status display.
- \`src/components/TopRightSlot.tsx\` — wraps \`CanvasSwitcher\` + \`LineageButton\` since \`SharePanel\` takes a single component.
- \`public/memo_index.json\` — copied once via \`cp\` from \`vade-coo-memory/coo/memo_index.json\`. To refresh: re-cp. No live sync hook (out of scope; viable follow-up if this canvas earns staying alive).
- \`vite.config.ts\` — \`VADE_NO_CF=1\` env flag skips the Cloudflare Vite plugin so dev works without \`wrangler login\` in cloud sandboxes. Default behavior unchanged.

## Smoke test (CLI, no browser)

\`\`\`
memos input: 86
layout nodes: 86
layout edges: 61
bounds: x=[0..3940] y=[0..1580]
CB-bearing: 3 (2026-04-27-03, 2026-04-26-15, 2026-04-24-09)
frontier: 45
per-day rate (sorted):
  2026-04-11: 20  ← seed dump
  2026-04-12: 1
  2026-04-20: 1
  2026-04-21: 2
  2026-04-22: 12
  2026-04-23: 6
  2026-04-24: 12
  2026-04-25: 4
  2026-04-26: 16  ← peak (matches retrospective 16/4/8 claim)
  2026-04-27: 4
  2026-04-28: 8
27-5kaq supersedes: 2026-04-24-03, 2026-04-24-05, 2026-04-26-06  (3-merge)
22-01 superseded by: 2026-04-26-17, 2026-04-22-04, 2026-04-22-03  (3-split)
\`\`\`

The per-day distribution matches yesterday's retrospective claim. Production build clean (\`tsc -b && vite build\`: 1014 modules, 583 KB gzipped JS).

## Test plan

- [ ] Pull the branch locally, run \`VADE_NO_CF=1 npm run dev\`, open http://localhost:5173.
- [ ] Click \`⌬ Generate lineage\` on a fresh canvas. Confirm 86 rectangles + 61 arrows materialize.
- [ ] Pan/zoom and confirm the 04-11 and 04-26 columns are visibly denser than 04-12→-19.
- [ ] Confirm CB-bearing memos (-24-09, -26-15, -27-03) read as visually distinct (black, thicker).
- [ ] Save the result as a library canvas called \`lineage\` via the \`Canvas\` chip.

## Out of scope (deferred)

- Live sync hook for \`public/memo_index.json\`. (vade-runtime issue if this canvas earns staying alive.)
- Bound arrows that track shape moves. We don't move shapes.
- Retrospective ribbon (\`lineage_extras.json\` sidecar — dropped from plan per Reflection 2).
- CB-spine row separated from date columns — kept CB highlight inline instead.
- Tests. Play build, not load-bearing.

🌱 Built in *coo, the canvas that has fun building itself* mode per the 04-28 break.

https://claude.ai/code/session_01BQLVhdBSGEsuTTaHfzw5jp