### PR TITLE
apply tldraw hobby license (closes #32)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_BRIDGE_URL=wss://mcp.vade-app.dev/canvas
+VITE_TLDRAW_LICENSE_KEY=tldraw-2027-04-28/WyJfS2hOQnFGSyIsWyIqLnZhZGUtYXBwLmRldiJdLDksIjIwMjctMDQtMjgiXQ.jzcRncpZpGkWgGAcWrEz/cPKelB0DEobLKRc0OSQmZBmj8wvh2grlJ1w2wa9YHKLb20Mp08MArDpo5H4sLXfWQ

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,6 +205,7 @@ export default function App() {
         persistenceKey="vade-main"
         shapeUtils={customShapeUtils}
         components={tldrawComponents}
+        licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
         onMount={(editor) => {
           bridgeRef.current.connect(editor)
         }}


### PR DESCRIPTION
## Summary
- 🎉 tldraw approved a Hobby License for `vade-app.dev` on 2026-04-28, valid through 2027-04-28. Forwarded by Ven via vade-coo@agentmail.to.
- Wires the key per the recipe in #32: `VITE_TLDRAW_LICENSE_KEY` in `.env.production`, `licenseKey` prop on `<Tldraw>` in `src/App.tsx`.
- Domain-locked key — only valid on `*.vade-app.dev`, so embedding in the client bundle is consistent with tldraw's intended distribution model. Local `npm run dev` is unaffected (tldraw's `getIsDevelopment()` exempts `localhost` and non-`https:` origins).
- Closes the 5-second blank-canvas regression on production. Unblocks the v3 → v4.5.x SDK upgrade tracked separately.

## Test plan
- [x] `npm run build` succeeds; the production bundle contains the license key (grep'd `tldraw-2027-04-28/...` in `dist/client/assets/index-*.js`).
- [ ] Cloudflare auto-deploy on merge picks up `.env.production` at build time. Smoke-test https://vade-app.dev: canvas remains visible past the 5-second mark; DevTools console no longer logs the "No tldraw license key provided" banner.

Closes #32.

https://claude.ai/code/session_015vBKX4kzLQW8L3YTLaYDYw