### PR TITLE
fix(fly): pin vade-mcp to a single machine (OAuth client_id race)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,8 +22,9 @@ primary_region = 'fra'
   internal_port = 8080
   force_https = true
   auto_stop_machines = false
-  auto_start_machines = true
+  auto_start_machines = false
   min_machines_running = 1
+  max_machines_running = 1
   processes = ['app']
 
   [[http_service.checks]]


### PR DESCRIPTION
## Summary

- Flip `auto_start_machines` to `false` and add `max_machines_running = 1` in `fly.toml` so Fly cannot silently scale `vade-mcp` past one machine.
- Fixes the Claude.ai custom-connector failure `{"error":"invalid_request","error_description":"unknown client_id"}` reported 2026-04-28.

## Root cause

`mcp/oauth.ts` keeps the OAuth client/code/token store in an in-memory `Map` on each Fly machine (see `OAuthStore` at `mcp/oauth.ts:65-93`). With more than one replica, `/oauth/register` and `/oauth/authorize` land on different machines under load balancing — the second machine has never seen the `client_id` minted by the first, so it returns `400 invalid_request`.

`auto_start_machines = true` had silently grown the `vade-mcp` cluster from 1 to 3 machines (1 nine-day-old machine on the prior deployment, 2 spawned ~3h before the report on a newer deployment). Fly's dashboard surfaced the multi-image warning explicitly.

## Repro

```bash
RESP=\$(curl -s -X POST https://mcp.vade-app.dev/oauth/register \
  -H "Content-Type: application/json" \
  -d '{"redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"client_name":"probe","token_endpoint_auth_method":"none"}')
CID=\$(echo "\$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['client_id'])")
for i in 1 2 3 4 5; do
  curl -s -o /dev/null -w "attempt %{http_code}\n" \
    "https://mcp.vade-app.dev/oauth/authorize?response_type=code&client_id=\${CID}&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=abc&code_challenge_method=S256&state=x&resource=https%3A%2F%2Fmcp.vade-app.dev%2Fsse"
done
```

Before the destroy of strays: alternated `400 / 400 / 200 / 200 / 400`.
After the destroy of strays (same one-machine state this PR enforces): `200 / 200 / 200 / 200 / 200 / 200 / 200 / 200`.

## Why this is the right posture for now

- The MCP server today is a single-operator surface — horizontal scaling brings no benefit.
- The in-memory `OAuthStore` is correct under the single-machine assumption; it fails silently and intermittently if that assumption breaks.
- A `min_machines_running = 1` floor is preserved, so we still get auto-restart on health-check failure within a single machine.

## Durable fix (out of scope)

Filed as a follow-up issue: persist `OAuthStore.{clients, codes, accessTokens, refreshTokens, consentNonces}` to a shared backend (Upstash Redis / LiteFS-sqlite). After that lands, this `max_machines_running = 1` cap can be relaxed.

## Test plan

- [ ] CI green
- [ ] Merge to `main`
- [ ] Cloudflare/Fly redeploy from `main` (via Fly's GitHub integration if configured, otherwise `flyctl deploy --remote-only` from a checkout)
- [ ] `flyctl status --app vade-mcp` shows 1 machine, no multi-image warning
- [ ] Claude.ai "Add custom connector" → `https://mcp.vade-app.dev/sse` connects on the first try (no `unknown client_id`)
- [ ] Repro script above returns `200` on every attempt

## Companion ops action (already done)

Two stray machines were destroyed via `flyctl machine destroy --force`:
- \`1855746a25e748\` (billowing-waterfall-9759)
- \`48e0321f16e468\` (misty-bush-2584)

Kept the 9-day-old \`2869e6ea9d4968\` (winter-frog-4871) which has been the working machine all week. The current state is already healthy; this PR just prevents the strays from coming back.

https://claude.ai/code/session_017ngFs8oYMVNAqxoAZyA4vJ