### PR TITLE
fix(bridge): stop creating/updating/deleting shapes twice

### DIFF
--- a/src/bridge/ws-client.ts
+++ b/src/bridge/ws-client.ts
@@ -155,15 +155,6 @@ export class VadeBridge {
               editor.createShape(partial as any)
             }
           })
-          for (const s of msg.shapes) {
-            const partial: Record<string, unknown> = { type: s.type }
-            if (s.x !== undefined) partial['x'] = s.x
-            if (s.y !== undefined) partial['y'] = s.y
-            if (s.rotation !== undefined) partial['rotation'] = s.rotation
-            if (s.props) partial['props'] = s.props
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            editor.createShape(partial as any)
-          }
           const created = editor.getCurrentPageShapes()
             .filter(s => !beforeIds.has(s.id))
             .map(s => s.id)
@@ -182,14 +173,6 @@ export class VadeBridge {
               editor.updateShape(update as any)
             }
           })
-          for (const s of msg.shapes) {
-            const update: Record<string, unknown> = { id: s.id, type: s.type }
-            if (s.x !== undefined) update['x'] = s.x
-            if (s.y !== undefined) update['y'] = s.y
-            if (s.props) update['props'] = s.props
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            editor.updateShape(update as any)
-          }
           this.reply(msg.id, true)
           break
         }
@@ -197,7 +180,6 @@ export class VadeBridge {
         case 'deleteShapes': {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           editor.run(() => editor.deleteShapes(msg.ids as any))
-          editor.deleteShapes(msg.ids as any)
           this.reply(msg.id, true)
           break
         }


### PR DESCRIPTION
## Summary

Every shape mutation handler in \`src/bridge/ws-client.ts\` runs twice — once inside an \`editor.run(() => …)\` batch and once in an identical loop immediately after. This is a botched refactor: when the batching wrapper was added, the pre-refactor calls were never deleted. This PR deletes the second copies.

## Symptom

Surfaced 2026-04-28 during the OAuth client_id debug (#104). After fixing OAuth, a single \`createShape\` MCP call produced **two** shapes on the canvas:

\`\`\`
[sse] response: tools/call → "[\"shape:SFoLcleaewECGDQg0rv-Q\",\"shape:ojVMrvouYfK45h4m3-wO-\"]"
\`\`\`

Two shape IDs from one inbound \`createShapes\` message means the canvas client created the shape twice. Reading the handler confirmed the duplicate-call structure.

\`updateShapes\` had the same shape (silent — two undo entries per call). \`deleteShapes\` had the same shape (second call is a no-op since the first removed the IDs already, but wasteful).

## What changed

\`\`\`diff
 case 'createShapes': {
   const beforeIds = new Set(editor.getCurrentPageShapes().map(s => s.id))
   editor.run(() => {
     for (const s of msg.shapes) {
       const partial: Record<string, unknown> = { type: s.type }
       if (s.x !== undefined) partial['x'] = s.x
       if (s.y !== undefined) partial['y'] = s.y
       if (s.rotation !== undefined) partial['rotation'] = s.rotation
       if (s.props) partial['props'] = s.props
       editor.createShape(partial as any)
     }
   })
-  for (const s of msg.shapes) {
-    const partial: Record<string, unknown> = { type: s.type }
-    if (s.x !== undefined) partial['x'] = s.x
-    if (s.y !== undefined) partial['y'] = s.y
-    if (s.rotation !== undefined) partial['rotation'] = s.rotation
-    if (s.props) partial['props'] = s.props
-    editor.createShape(partial as any)
-  }
   const created = editor.getCurrentPageShapes()
     .filter(s => !beforeIds.has(s.id))
     .map(s => s.id)
   this.reply(msg.id, true, created)
 }
\`\`\`

Same shape of deletion in \`updateShapes\` (lines ~185-192) and \`deleteShapes\` (line 200). Net diff: −18 lines, +0.

## Why \`editor.run\` is the right form

\`editor.run(() => …)\` batches the operations into a single tldraw history entry. The unbatched loop produced N entries — each undoable separately — which compounded the doubling: undoing one MCP \`createShape\` would remove only one of the two shapes.

## Verification

After this lands, redoing the canvas write probe from the #104 session should return **one** shape ID instead of two.

## Test plan

- [ ] CI green
- [ ] Cloudflare Worker redeploy on merge (auto)
- [ ] In Claude.ai with the vade-canvas connector: \`createShape({ type: 'text', x: 0, y: 0, props: { ... } })\` → one shape on the canvas
- [ ] \`undo\` removes that single shape in one step

## Origin

Surfaced during the OAuth \`unknown client_id\` debug on 2026-04-28; companion to #104.

https://claude.ai/code/session_017ngFs8oYMVNAqxoAZyA4vJ