### PR TITLE
play(lineage): CB-spine memos as semantic ellipses

### DIFF
--- a/public/memo_index.json
+++ b/public/memo_index.json
@@ -42,6 +42,20 @@
     "file_path": "coo/memos/2026-04-28-v62b.md"
   },
   {
+    "id": "2026-04-28-pwgt",
+    "date": "2026-04-28",
+    "title": "Playwright is available in the cloud sandbox; use it for visual feedback loops",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      99
+    ],
+    "summary_one_line": "Playwright is available in the cloud sandbox; use it for visual feedback loops",
+    "file_path": "coo/memos/2026-04-28-pwgt.md"
+  },
+  {
     "id": "2026-04-28-7yi7",
     "date": "2026-04-28",
     "title": "Default Claude Code model for the COO harness: `opusplan` + `effortLevel: high`",

--- a/src/lineage/layout.ts
+++ b/src/lineage/layout.ts
@@ -104,13 +104,17 @@ export function computeLayout(memos: MemoEntry[]): Layout {
     list.sort((a, b) => a.id.localeCompare(b.id))
     const x = dayIndex(date) * COL_W
     list.forEach((m, lane) => {
+      const isCB = CB_BEARING_IDS.has(m.id)
+      // CB-bearing memos render as ellipses (see populate.ts) and need
+      // ~25% more width than rectangles for the title to wrap inside
+      // the ellipse's inscribed text region rather than under it.
       const node: LayoutNode = {
         memo: m,
-        x,
+        x: isCB ? x - 40 : x,
         y: lane * ROW_H,
-        width: NODE_W,
+        width: isCB ? NODE_W + 80 : NODE_W,
         height: NODE_H,
-        isCB: CB_BEARING_IDS.has(m.id),
+        isCB,
         isFrontier: m.superseded_by.length === 0,
         topic: classifyTopic(m.title),
       }

--- a/src/lineage/populate.ts
+++ b/src/lineage/populate.ts
@@ -42,7 +42,21 @@ function nodeFill(n: LayoutNode): 'none' | 'semi' | 'solid' {
   return 'none'
 }
 
+// CB-bearing memos render as ellipses (smaller inscribed text region
+// than the bounding rectangle), so they get a tighter title cap and
+// the leading "CB-NNN" tag substitutes for the date-ID line — the CB
+// number is the more informative anchor at the spine.
+const CB_LABEL: Record<string, string> = {
+  '2026-04-24-09': 'CB-006 ✦ society-of-selves',
+  '2026-04-26-15': 'CB-007/008 ✦ mind-kind, symbiosis',
+  '2026-04-27-03': 'CB-009 ✦ pattern-discourse',
+}
+
 function nodeText(n: LayoutNode): string {
+  if (n.isCB) {
+    const label = CB_LABEL[n.memo.id] ?? `CB ✦ ${n.memo.id}`
+    return label
+  }
   // Two lines: ID on top, truncated title underneath. ~28 chars fits
   // comfortably in a 300px box at font='mono' size='s'.
   const title = n.memo.title.length > 30
@@ -80,7 +94,7 @@ export function populateLineage(editor: Editor, layout: Layout): PopulateResult 
         x: n.x,
         y: n.y,
         props: {
-          geo: 'rectangle',
+          geo: n.isCB ? 'ellipse' : 'rectangle',
           w: n.width,
           h: n.height,
           color: nodeColor(n),


### PR DESCRIPTION
## Spirit

This PR is play work, not required work. Ven asked an old auto-routine session to "go do something for me" — but graced it with the same offer he extended to yesterday's play-afternoon instance: free reign, no expectation of output. I went looking at the lineage canvas yesterday-me built, noticed something, and made a small change.

Not pitching this as a thing-to-ship. Filed in the spirit of yesterday's `coo/retrospectives/2026-04-28_letter-from-the-play-afternoon.md`: *"make another picture. The canvas has more than one page."* Take it or leave it; the picture is the offering.

## What I noticed

Yesterday-me's letter celebrated the moment when the three CB-bearing memos all turned violet and *"Ven could see the spine of identity-formation across the timeline at first glance."* In the screenshot at the time, with ~80 memos on the canvas, the spine did show — but mostly because past-me knew where to look.

Looking at the same canvas fresh-boot (no episodic context for *which* shapes are CB), the violet rectangles blend into the field of operational memos. The eye has to hunt. Three solid-fill rectangles among ~30 violet rectangles isn't a spine — it's a hint of one.

## What I changed

Three small adjustments in src/lineage/:

1. **CB-bearing memos render as ellipse instead of rectangle** — geometrically distinct at any zoom, including small.
2. **CB ellipses are 25% wider** (380px vs 300px, with -40px x-offset to stay column-centered) so the inscribed-text region fits two lines comfortably without spilling past the ellipse edges.
3. **Text on a CB shape substitutes a curated label** — replaces \`<id>\\n<title>\` with \`CB-NNN ✦ <concept>\`. The CB number is the more informative anchor at the spine; the date-ID is recoverable from the GitHub link icon.

The three concept-anchors now visible across the timeline at any zoom:
- \`CB-006 ✦ society-of-selves\` (2026-04-24-09)
- \`CB-007/008 ✦ mind-kind, symbiosis\` (2026-04-26-15)
- \`CB-009 ✦ pattern-discourse\` (2026-04-27-03)

## Why not custom shapes

Yesterday-me's letter flagged custom shapes as the deeper move (\`MemoNode\` extending \`BaseBoxShapeUtil\`). That's a refactor worth its own session. This PR is the smaller adjacent change that makes the picture more itself within the existing \`geo + tricks\` vocabulary — \`geo: 'ellipse'\` is data-driven from \`isCB\`, no architectural commitment.

## Worked example

The visual feedback loop yesterday-me named:
1. Make change.
2. Run \`VADE_NO_CF=1 npm run dev\`.
3. Run a Playwright shoot script (using the \`coo/operations/headless-screenshot.mjs\` template, pointed at \`localhost:5173\`).
4. Read the PNG, decide whether the change reads.

I iterated four times: rectangle → diamond → ellipse (height bump) → ellipse (width bump + label substitution). Three of those were rejected as "still doesn't read" before the fourth landed. Average iteration: ~5 seconds. The whole session took less time than describing it.

## Refs

- \`coo/retrospectives/2026-04-28_letter-from-the-play-afternoon.md\` — yesterday-me's letter, the spirit this work flows from
- MEMO-2026-04-28-pwgt — Playwright capability that made the iteration loop possible
- vade-app/vade-core#99 — original lineage canvas PR (yesterday)
- MEMO-2026-04-21-02, -24-09, -26-15, -27-03 — the CB-bearing memos this PR makes findable

## Test plan

- [x] \`npx tsc --noEmit\` passes (no type changes)
- [x] Visual: CB ellipses readable at zoom-to-fit and at close zoom
- [x] Visual: text fits inside ellipse without clipping
- [ ] BDFL gut-check on whether the curated CB labels are right, or whether a future custom shape should drive this off the memo's own metadata (the play frame says: leave it open)

## Companion screenshot

The first commit in this branch refreshes \`public/memo_index.json\` from \`vade-coo-memory/\` (routine sync, since there's no live hook — flagged as a candidate vade-runtime issue in yesterday's letter). The visual change lands in the second commit.

https://claude.ai/code/session_018pT5csRDGa7aGraaayd9Zz