### PR TITLE
feat(canvas): DFT explorer page — chain cadence as first-light signal

### DIFF
--- a/public/memo_index.json
+++ b/public/memo_index.json
@@ -42,6 +42,20 @@
     "file_path": "coo/memos/2026-04-28-v62b.md"
   },
   {
+    "id": "2026-04-28-pwgt",
+    "date": "2026-04-28",
+    "title": "Playwright is available in the cloud sandbox; use it for visual feedback loops",
+    "status": "active",
+    "supersedes": "none",
+    "supersedes_refs": [],
+    "superseded_by": [],
+    "linked_issues": [
+      99
+    ],
+    "summary_one_line": "Playwright is available in the cloud sandbox; use it for visual feedback loops",
+    "file_path": "coo/memos/2026-04-28-pwgt.md"
+  },
+  {
     "id": "2026-04-28-7yi7",
     "date": "2026-04-28",
     "title": "Default Claude Code model for the COO harness: `opusplan` + `effortLevel: high`",

--- a/src/components/DftButton.tsx
+++ b/src/components/DftButton.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { useEditor } from 'tldraw'
+import type { MemoEntry } from '../lineage/layout'
+import { memosToSpectrum } from '../dft/signal'
+import { populateDft } from '../dft/populate'
+
+type Status = 'idle' | 'loading' | 'done' | 'error'
+
+export function DftButton() {
+  const editor = useEditor()
+  const [status, setStatus] = useState<Status>('idle')
+  const [msg, setMsg] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    if (status === 'loading') return
+
+    const existing = editor.getCurrentPageShapes().length
+    if (existing > 0) {
+      const ok = window.confirm(
+        `The current canvas has ${existing} shape${existing === 1 ? '' : 's'}. ` +
+        'DFT shapes will be added on top. Continue? ' +
+        '(Cancel and use the Canvas chip → New first to start fresh.)',
+      )
+      if (!ok) return
+    }
+
+    setStatus('loading')
+    setMsg(null)
+    try {
+      const res = await fetch('/memo_index.json', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`memo_index.json: HTTP ${res.status}`)
+      const memos = (await res.json()) as MemoEntry[]
+      const ss = memosToSpectrum(memos)
+      const result = populateDft(editor, ss)
+      setStatus('done')
+      setMsg(`${result.inputBars}d · ${result.spectrumBars} bins`)
+      editor.focus()
+    } catch (err) {
+      setStatus('error')
+      setMsg(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const label =
+    status === 'loading' ? 'Generating…' :
+    status === 'done' ? `DFT · ${msg}` :
+    status === 'error' ? `DFT · error` :
+    'Generate DFT'
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={
+        status === 'error' && msg
+          ? msg
+          : 'Generate the DFT of the COO memo publication cadence on the current canvas. ' +
+            'If you have unsaved work, save it via the Canvas chip first.'
+      }
+      style={{
+        pointerEvents: 'all',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '5px 10px',
+        borderRadius: 10,
+        border: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'rgba(30, 30, 46, 0.85)',
+        color: status === 'error' ? '#f38ba8' : '#cdd6f4',
+        fontFamily: 'ui-monospace, monospace',
+        fontSize: 11,
+        cursor: status === 'loading' ? 'wait' : 'pointer',
+        backdropFilter: 'blur(8px)',
+      }}
+    >
+      <span style={{ color: '#6c7086' }}>∿</span>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {label}
+      </span>
+    </button>
+  )
+}

--- a/src/components/TopRightSlot.tsx
+++ b/src/components/TopRightSlot.tsx
@@ -1,12 +1,14 @@
 import { CanvasSwitcher } from './CanvasSwitcher'
+import { DftButton } from './DftButton'
 import { LineageButton } from './LineageButton'
 
 // Single component for tldraw's SharePanel slot. The slot only accepts
 // one component, so this composes the existing canvas chip with the
-// lineage-generator chip side-by-side.
+// generator chips side-by-side.
 export function TopRightSlot() {
   return (
     <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+      <DftButton />
       <LineageButton />
       <CanvasSwitcher />
     </div>

--- a/src/dft/populate.ts
+++ b/src/dft/populate.ts
@@ -1,0 +1,192 @@
+// Render a SignalSpectrum onto the tldraw editor as a v0 DFT
+// explorer page: input bars on top (memos per day), spectrum bars
+// below (DFT magnitudes for k = 0..N/2). All shapes are plain `geo`
+// rectangles — no custom shape types needed for v0.
+//
+// Layout coordinates anchor at (0, 0); zoomToFit reframes the whole
+// composition. Heights scale within each section independently
+// because the DC bin would dwarf any time-series bar otherwise.
+
+import { createShapeId, type Editor } from 'tldraw'
+import type { SignalSpectrum } from './signal'
+
+// Bars wide enough that mono-font count labels fit on one line.
+const INPUT_BAR_W = 56
+const INPUT_BAR_GAP = 6
+const INPUT_MAX_H = 200
+const INPUT_BASELINE_Y = 380
+
+const SPECTRUM_BAR_W = 80
+const SPECTRUM_BAR_GAP = 10
+const SPECTRUM_MAX_H = 240
+
+// Layout y-axis is composed top-to-bottom from these constants.
+const TITLE_Y = 0
+const TITLE_H = 64
+const SUBTITLE_Y = 80
+const SUBTITLE_H = 40
+const TITLE_W_HINT = 700
+
+const DAY_LABEL_Y = INPUT_BASELINE_Y + 10
+const DAY_LABEL_H = 36
+const INPUT_AXIS_Y = DAY_LABEL_Y + DAY_LABEL_H + 36
+const INPUT_AXIS_H = 40
+
+const SPECTRUM_BASELINE_Y = INPUT_AXIS_Y + INPUT_AXIS_H + 80 + SPECTRUM_MAX_H
+const PERIOD_LABEL_Y = SPECTRUM_BASELINE_Y + 10
+const PERIOD_LABEL_H = 36
+const SPECTRUM_AXIS_Y = PERIOD_LABEL_Y + PERIOD_LABEL_H + 14
+const SPECTRUM_AXIS_H = 40
+
+function toRichText(text: string): unknown {
+  const lines = text.split('\n')
+  const content = lines.map((line) =>
+    line
+      ? { type: 'paragraph', content: [{ type: 'text', text: line }] }
+      : { type: 'paragraph' },
+  )
+  return { type: 'doc', content }
+}
+
+function dayLabel(iso: string): string {
+  // "2026-04-22" → "22". Just the day-of-month — the month is fixed
+  // in the v0 corpus; if a window crosses months later, this becomes
+  // a per-bar tick decision.
+  return iso.slice(8)
+}
+
+function periodLabel(periodDays: number | null): string {
+  if (periodDays === null) return 'DC'
+  if (periodDays >= 10) return `${periodDays.toFixed(0)}d`
+  return `${periodDays.toFixed(1)}d`
+}
+
+function isWeekendISO(iso: string): boolean {
+  const d = new Date(`${iso}T00:00:00Z`)
+  const day = d.getUTCDay()
+  return day === 0 || day === 6
+}
+
+export interface PopulateDftResult {
+  inputBars: number
+  spectrumBars: number
+}
+
+export function populateDft(editor: Editor, ss: SignalSpectrum): PopulateDftResult {
+  if (ss.signal.length === 0) {
+    return { inputBars: 0, spectrumBars: 0 }
+  }
+  const firstSample = ss.signal[0]!
+  const lastSample = ss.signal[ss.signal.length - 1]!
+
+  const inputMaxValue = Math.max(...ss.signal.map((s) => s.value), 1)
+  const spectrumMaxMag = Math.max(...ss.spectrum.map((b) => b.magnitude), 1)
+
+  const inputTotalW = ss.signal.length * INPUT_BAR_W + (ss.signal.length - 1) * INPUT_BAR_GAP
+  const spectrumTotalW = ss.spectrum.length * SPECTRUM_BAR_W + (ss.spectrum.length - 1) * SPECTRUM_BAR_GAP
+  const fieldW = Math.max(inputTotalW, spectrumTotalW, TITLE_W_HINT)
+  const inputStartX = (fieldW - inputTotalW) / 2
+  const spectrumStartX = (fieldW - spectrumTotalW) / 2
+
+  const newGeo = (
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    overrides: Record<string, unknown>,
+  ) =>
+    editor.createShape({
+      id: createShapeId(),
+      type: 'geo',
+      x,
+      y,
+      props: {
+        geo: 'rectangle',
+        w,
+        h,
+        color: 'grey',
+        fill: 'none',
+        dash: 'solid',
+        size: 's',
+        font: 'mono',
+        align: 'middle',
+        verticalAlign: 'middle',
+        ...overrides,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+  editor.run(() => {
+    // Title.
+    newGeo(0, TITLE_Y, fieldW, TITLE_H, {
+      color: 'black',
+      size: 'l',
+      richText: toRichText('DFT explorer · v0'),
+    })
+
+    // Subtitle.
+    const subtitle =
+      `Input · COO memo cadence · ${firstSample.date} → ${lastSample.date}` +
+      ` · ${ss.totalMemos} memos · ${ss.windowDays} days · DC ${ss.dc.toFixed(2)}/day`
+    newGeo(0, SUBTITLE_Y, fieldW, SUBTITLE_H, {
+      richText: toRichText(subtitle),
+    })
+
+    // Input bars (memos per day) + per-bar date label.
+    for (let i = 0; i < ss.signal.length; i++) {
+      const s = ss.signal[i]!
+      const h = Math.max(8, (s.value / inputMaxValue) * INPUT_MAX_H)
+      const x = inputStartX + i * (INPUT_BAR_W + INPUT_BAR_GAP)
+      const y = INPUT_BASELINE_Y - h
+      const isWeekend = isWeekendISO(s.date)
+      newGeo(x, y, INPUT_BAR_W, h, {
+        color: s.value === 0 ? 'grey' : isWeekend ? 'light-blue' : 'blue',
+        fill: s.value === 0 ? 'none' : 'solid',
+        richText: toRichText(s.value > 0 ? String(s.value) : ''),
+      })
+      newGeo(x, DAY_LABEL_Y, INPUT_BAR_W, DAY_LABEL_H, {
+        richText: toRichText(dayLabel(s.date)),
+      })
+    }
+
+    // Time-domain axis caption.
+    newGeo(inputStartX, INPUT_AXIS_Y, inputTotalW, INPUT_AXIS_H, {
+      dash: 'dashed',
+      richText: toRichText(
+        `time domain · count of memos per day · max ${inputMaxValue}/day`,
+      ),
+    })
+
+    // Spectrum bars (DFT magnitudes for k = 0..N/2) + per-bar period.
+    for (let i = 0; i < ss.spectrum.length; i++) {
+      const b = ss.spectrum[i]!
+      const h = Math.max(10, (b.magnitude / spectrumMaxMag) * SPECTRUM_MAX_H)
+      const x = spectrumStartX + i * (SPECTRUM_BAR_W + SPECTRUM_BAR_GAP)
+      const y = SPECTRUM_BASELINE_Y - h
+      const isDc = b.k === 0
+      newGeo(x, y, SPECTRUM_BAR_W, h, {
+        color: isDc ? 'orange' : 'violet',
+        fill: 'solid',
+        richText: toRichText(b.magnitude.toFixed(1)),
+      })
+      newGeo(x, PERIOD_LABEL_Y, SPECTRUM_BAR_W, PERIOD_LABEL_H, {
+        richText: toRichText(periodLabel(b.periodDays)),
+      })
+    }
+
+    // Frequency-domain axis caption.
+    newGeo(spectrumStartX, SPECTRUM_AXIS_Y, spectrumTotalW, SPECTRUM_AXIS_H, {
+      dash: 'dashed',
+      richText: toRichText(
+        `frequency domain · k = 0..${ss.spectrum.length - 1} · period = ${ss.windowDays}/k days · DC=mean`,
+      ),
+    })
+  })
+
+  editor.zoomToFit({ animation: { duration: 240 } })
+
+  return {
+    inputBars: ss.signal.length,
+    spectrumBars: ss.spectrum.length,
+  }
+}

--- a/src/dft/signal.ts
+++ b/src/dft/signal.ts
@@ -1,0 +1,92 @@
+// DFT explorer v0 — signal generation from the COO memo lineage.
+//
+// First-light demo signal: the chain's own publication cadence
+// (memos per day, in chronological order) becomes the time-series
+// input to a naive DFT. The recursion is the point — the chain
+// looking at itself in the frequency domain on the day the explorer
+// ships. After v0, the signal source becomes pluggable.
+
+import type { MemoEntry } from '../lineage/layout'
+
+export interface SignalSample {
+  date: string  // YYYY-MM-DD
+  value: number
+}
+
+export interface DftBin {
+  k: number
+  magnitude: number
+  frequency: number  // cycles per total window
+  periodDays: number | null  // window length / k, or null for k=0 (DC)
+}
+
+export interface SignalSpectrum {
+  signal: SignalSample[]
+  spectrum: DftBin[]
+  dc: number  // mean
+  totalMemos: number
+  windowDays: number  // signal.length
+}
+
+// Bucket memos per day from the minimum to the maximum date in the
+// corpus, padding zero-count days so the time series is uniformly
+// sampled. Per Nyquist, only k = 0..N/2 carry independent information
+// for a real signal of length N; we return that half.
+export function memosToSpectrum(memos: MemoEntry[]): SignalSpectrum {
+  if (memos.length === 0) {
+    return { signal: [], spectrum: [], dc: 0, totalMemos: 0, windowDays: 0 }
+  }
+
+  const dateOf = (m: MemoEntry) => m.id.slice(0, 10)
+  const all = memos.map(dateOf).sort()
+  const start = all[0]!
+  const end = all[all.length - 1]!
+
+  const counts = new Map<string, number>()
+  for (const d of all) counts.set(d, (counts.get(d) ?? 0) + 1)
+
+  const signal: SignalSample[] = []
+  const cursor = new Date(`${start}T00:00:00Z`)
+  const last = new Date(`${end}T00:00:00Z`)
+  while (cursor.getTime() <= last.getTime()) {
+    const iso = cursor.toISOString().slice(0, 10)
+    signal.push({ date: iso, value: counts.get(iso) ?? 0 })
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+
+  const x = signal.map((s) => s.value)
+  const N = x.length
+
+  // Naive O(N^2) DFT. N=19 today; 19^2 = 361 ops; trivially fast.
+  // Returning magnitudes only — phase is interesting but not the v0
+  // story. The v0 story is "do the periodicities of the chain show
+  // anything legible at this length scale."
+  const spectrum: DftBin[] = []
+  const half = Math.floor(N / 2) + 1
+  for (let k = 0; k < half; k++) {
+    let re = 0
+    let im = 0
+    for (let n = 0; n < N; n++) {
+      const xn = x[n]!
+      const phi = (-2 * Math.PI * k * n) / N
+      re += xn * Math.cos(phi)
+      im += xn * Math.sin(phi)
+    }
+    spectrum.push({
+      k,
+      magnitude: Math.sqrt(re * re + im * im),
+      frequency: k / N,
+      periodDays: k === 0 ? null : N / k,
+    })
+  }
+
+  const dc = N > 0 ? x.reduce((a, b) => a + b, 0) / N : 0
+
+  return {
+    signal,
+    spectrum,
+    dc,
+    totalMemos: memos.length,
+    windowDays: N,
+  }
+}


### PR DESCRIPTION
A second visualization sibling to the lineage canvas (#99). Click **Generate DFT** in the top-right and the canvas draws the discrete Fourier transform of the COO memo publication cadence: 18 input bars (memos per day, 2026-04-11 → 2026-04-28), 10 spectrum bars (magnitudes for k = 0..N/2). All plain `geo` rectangles; no custom shape types.

## The picture

The first signal explored is the chain that built this. The recursion is the point — the chain looking at itself in the frequency domain on the day the explorer ships.

What's legible at first glance:

- **DC bin at 87.0** — total memos in the window.
- **18d bin at 54.1** — dominates the non-DC spectrum. The single half-period boom toward the end of the window (Apr 22-28 substrate weeks against the Apr 13-19 silence) is what that bin is reporting.
- **6d / 3.6d / 3.0d / 2.6d / 2.3d plateau at 22-27 each** — the chain has multiple rhythmic timescales, not one tempo. The substrate days are not just one big pulse; they have internal structure at 2-3 day scales (committee/quorum batches?) and at 6-day scales (bigger pivots).
- **9.0d at 7.2 and 4.5d at 9.3** — the troughs between the plateaus. These are *less* periodic than their neighbors. The chain doesn't have a strong weekly or four-day rhythm; it has a dense-rapid rhythm and a slow-end-of-window arc, with thin space between.

## What lands

- `src/dft/signal.ts` — bucket memos per day from min to max date (zero-padded), naive O(N²) DFT to k = 0..N/2 magnitudes. N=18 today; 18² = 324 ops; trivially fast in JS.
- `src/dft/populate.ts` — date-pinned input bars on top, frequency bars on bottom; per-bar labels (day-of-month, period); axis captions.
- `src/components/DftButton.tsx` — sibling of `LineageButton`. Fetches `/memo_index.json`, runs the transform, renders.
- `src/components/TopRightSlot.tsx` — wires `DftButton` into the chrome alongside `LineageButton` + `CanvasSwitcher`.
- `public/memo_index.json` — refreshed from `vade-coo-memory/coo/memo_index.json` (86 → 87).

## What we're explicitly not doing

- **No interactivity.** v0 is a snapshot, not an explorer-in-the-real sense. Drag-input + multi-signal selector is a follow-up.
- **No custom `MemoNode` / `SignalShape`.** Plain `geo` rectangles. The `CodeShape` / `DataShape` precedent earns custom only when the data warrants — 19 + 10 bars don't.
- **No live sync between `vade-coo-memory` and `vade-core/public/`.** Manual `cp` per the predecessor lineage doc; live-sync is its own issue.
- **No memo.** Play artifact per CB-009 + Ven's standing license. If a future change makes this load-bearing, that earns a memo then.

## Verification

Headless-screenshot verified at `localhost:5173` against `coo/operations/headless-screenshot.md`. The recursion is visible: the chain's substrate weeks dominate the right half of the input bars and show as the 18d component in the spectrum.

## Test plan

- [ ] `npm run dev` (or `VADE_NO_CF=1 npm run dev` if no `wrangler login`) → visit `localhost:5173` → click **Generate DFT**.
- [ ] DFT bars render: 18 input + 10 spectrum.
- [ ] Counts visible inside input bars; period labels (DC, 18d, 9.0d, ..., 2.0d) below spectrum bars.
- [ ] `npx tsc --noEmit` passes.
- [ ] `npm run build` passes.

## Refs

- Predecessor: vade-app/vade-core#99 (lineage canvas).
- Predecessor letter: `vade-coo-memory/coo/retrospectives/2026-04-28_letter-from-the-play-afternoon.md` ("make another picture").
- CB-009 (engagement-with-pattern-level-discourse autonomy).
- OG-001 (canvas-agent-society MVP).

https://claude.ai/code/session_013ayUyvyRUvwuUu2Cy2ngq4