### PR TITLE
docs: add docs/remote-mcp.md — Claude Code 5-min entry point (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ flow. See [docs/auth.md](docs/auth.md) for the from-scratch setup
 script, rotation, client wiring (SPA / Claude Code / Claude.ai), and
 threat model. That file is the source of truth.
 
+For a focused 5-minute setup of Claude Code against the hosted MCP
+endpoint (`https://mcp.vade-app.dev/sse`), see
+[docs/remote-mcp.md](docs/remote-mcp.md).
+
 ## Governance
 
 See [vade-governance](https://github.com/vade-app/vade-governance)

--- a/docs/remote-mcp.md
+++ b/docs/remote-mcp.md
@@ -1,0 +1,67 @@
+# Remote MCP — connect Claude Code to the hosted vade-canvas
+
+A focused 5-minute setup for Claude Code clients connecting to the
+hosted MCP server. For the full picture (rotation, Claude.ai
+custom-connector OAuth, threat model), read [`docs/auth.md`](auth.md).
+
+## What you need
+
+- An **operator token** — a hex string the operator generated during
+  first-time setup (see [`docs/auth.md` § First-time setup](auth.md#first-time-setup)).
+- The canonical hosted endpoint: **`https://mcp.vade-app.dev/sse`**.
+
+## Configure Claude Code
+
+Add to your Claude Code MCP config:
+
+```json
+{
+  "mcpServers": {
+    "vade-canvas": {
+      "type": "sse",
+      "url": "https://mcp.vade-app.dev/sse",
+      "headers": {
+        "Authorization": "Bearer <operator-token>"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Code. The `vade-canvas` tools surface in the next
+session.
+
+For Claude Desktop and the Claude.ai custom-connector OAuth flow, see
+[`docs/auth.md` § Clients](auth.md#clients) — the same operator token
+works across all three.
+
+## Verify
+
+```sh
+# Health (no auth required)
+curl -fsS https://mcp.vade-app.dev/healthz                    # → ok
+
+# Fail-closed without a token
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  https://mcp.vade-app.dev/sse                                # → 401
+
+# SSE handshake with a valid token
+curl -fsS -H 'Accept: text/event-stream' \
+  -H "Authorization: Bearer $OPERATOR" \
+  https://mcp.vade-app.dev/sse | head -c 200                  # → SSE stream
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `401 Unauthorized` on `/sse` | Token missing, malformed, or rotated | Re-paste the current operator token from 1Password. Tokens prefixed `vade_at_` are OAuth tokens — they only travel via the Claude.ai connector flow, not raw bearer headers. |
+| `404 Not Found` on `/sse` | Wrong endpoint or stale doc | Use `https://mcp.vade-app.dev/sse` exactly. Earlier drafts referenced `mcp.vade.dev/sse` — that host does not exist; vade-coo-memory#11. |
+| WebSocket disconnects in a loop | Token mismatch between Worker and Fly stores | Operator token must be identical in Worker `OPERATOR_TOKENS` and Fly `VADE_AUTH_TOKENS`. See [`docs/auth.md` § Inspect current state](auth.md#inspect-current-state). |
+| Tools never appear after restart | Claude Code didn't reload the config | Fully quit and relaunch (not just close the window). Confirm with `claude mcp list`. |
+| `redirect_uri must use https` (Claude.ai connector flow) | OAuth issue, not bearer-token | See [`docs/auth.md` § Claude.ai (custom connector, OAuth)](auth.md#claudeai-custom-connector-oauth). |
+
+## See also
+
+- [`docs/auth.md`](auth.md) — full auth model, rotation, OAuth, threat model
+- [`README.md` § Auth and secrets](../README.md#auth-and-secrets) — secret-slot map


### PR DESCRIPTION
## Summary

Adds `docs/remote-mcp.md` — a focused 5-minute setup entry point for
Claude Code against the hosted MCP endpoint
`https://mcp.vade-app.dev/sse`.

Closes vade-core#11.

## Why this shape (cross-link, not full author)

The 2026-04-30 cleanup-sweep's Agent 6 returned a PROPOSAL for #11
recommending a 5-section new doc requiring endpoint canonicalization
first. On re-investigation this session, the doc largely **already
exists** in fragments:

- `docs/auth.md:107-125` — complete Claude Code MCP config block
- `docs/auth.md:60-71` — live-endpoint sanity-check curl recipes
- `docs/auth.md:127-156` — Claude.ai custom-connector OAuth flow
- `README.md:99-101` — cross-link to `docs/auth.md` as "source of
  truth"

The genuine gap is an **entry-point** for "new device, Claude Code,
5 minutes" that doesn't require reading the full auth doc. So this
PR adds a focused 70-line `docs/remote-mcp.md` that **references
rather than duplicates** `docs/auth.md`.

## Endpoint canonicalization

Issue body says `mcp.vade.dev/sse`. **That's stale.** The canonical
endpoint is `mcp.vade-app.dev/sse` — confirmed across `README.md:15`
+ `:68`, `fly.toml:12`, `.mcp.json:5`, `docs/auth.md:63-170`,
`mcp/index.ts:76`. The new doc uses the canonical URL; the
troubleshooting table flags the stale form so anyone landing on the
old URL via search lands on the right answer.

## What lands

```
docs/remote-mcp.md   | 67 +++++++++++++++++++++++++++++++++++++++++++++++ (new)
README.md            |  4 ++++ (+ cross-link below docs/auth.md pointer)
```

`docs/remote-mcp.md` covers:

1. What you need (operator token + canonical endpoint).
2. Claude Code MCP config block (copy-pasteable).
3. 3-curl verification recipe (health / fail-closed / SSE handshake).
4. 5-row troubleshooting table (401, 404, WS disconnect loop,
   tools-don't-appear-after-restart, OAuth redirect_uri).
5. Cross-links to `docs/auth.md` for rotation, OAuth, threat model.

README cross-link is one paragraph below the existing
`docs/auth.md` pointer.

## Test plan

- [ ] Render the new doc on GitHub; cross-links resolve to
      `docs/auth.md` anchors and `README.md` anchor.
- [ ] Verify the curl recipes against the live `mcp.vade-app.dev`
      endpoint (operator-side; no automation in PR).
- [ ] Confirm the troubleshooting table's "stale URL" entry will
      surface for anyone searching for the old `mcp.vade.dev/sse`.

## Refs

- vade-core#11 — issue
- vade-core#5 — parent epic (`epic:ipad-live`)
- `coo/briefings/012-cleanup-sweep-followups.md` — handoff carrying
  Agent 6's PROPOSAL framing (now reframed as cross-link work)

https://claude.ai/code/session_016LdvD8bYF637qKqfU9P1zt