### PR TITLE
fix(canvas): persist uploaded image assets across devices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import 'tldraw/tldraw.css'
 import { customShapeUtils } from './shapes'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
 import { TopRightSlot } from './components/TopRightSlot'
+import { createVadeAssetStore } from './assets/vade-asset-store'
 
 // Inject TopRightSlot into tldraw's top-right SharePanel slot so the
 // chips render inside tldraw's chrome and can't collide with Main Menu
@@ -175,6 +176,11 @@ export default function App() {
   const bridgeRef = useRef(bridge)
   bridgeRef.current = bridge
 
+  // Asset store is per-mount: image bytes go through /library/assets and
+  // are addressed by sha256 in the snapshot, so canvases round-trip across
+  // devices instead of dangling at the source device's local IndexedDB.
+  const assetStore = useMemo(() => createVadeAssetStore(), [])
+
   if (requiresAuth && !token) {
     return (
       <TokenGate
@@ -206,6 +212,7 @@ export default function App() {
         persistenceKey="vade-main"
         shapeUtils={customShapeUtils}
         components={tldrawComponents}
+        assets={assetStore}
         licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
         onMount={(editor) => {
           bridgeRef.current.connect(editor)

--- a/src/assets/vade-asset-store.ts
+++ b/src/assets/vade-asset-store.ts
@@ -1,0 +1,46 @@
+import type { TLAsset, TLAssetStore } from 'tldraw'
+import { fetchAssetBlob, uploadAsset } from '../lib/assets'
+
+// Custom asset URL scheme that round-trips through canvas snapshots.
+// `props.src` carries `vade-asset:<sha256>` — a stable, content-addressed
+// reference. resolve() turns that into a fetchable blob URL on demand.
+// Foreign URLs (default tldraw bookmarks, http(s) thumbnails) pass through
+// untouched.
+const SCHEME = 'vade-asset:'
+
+function parseHash(src: string | null | undefined): string | null {
+  if (!src || !src.startsWith(SCHEME)) return null
+  const hash = src.slice(SCHEME.length)
+  return /^[0-9a-f]{64}$/.test(hash) ? hash : null
+}
+
+export function createVadeAssetStore(): TLAssetStore {
+  // Per-session cache of resolved object URLs. Keyed by hash so the same
+  // image referenced from multiple shapes / pages only fetches once. The
+  // value is a Promise so concurrent resolves coalesce.
+  const cache = new Map<string, Promise<string>>()
+
+  return {
+    async upload(_asset: TLAsset, file: File) {
+      const hash = await uploadAsset(file)
+      return { src: `${SCHEME}${hash}` }
+    },
+
+    resolve(asset, _ctx) {
+      const src = asset.props && 'src' in asset.props ? (asset.props.src as string | null) : null
+      const hash = parseHash(src)
+      if (!hash) return src ?? null
+      let entry = cache.get(hash)
+      if (!entry) {
+        entry = fetchAssetBlob(hash)
+          .then((blob) => URL.createObjectURL(blob))
+          .catch((err) => {
+            cache.delete(hash)
+            throw err
+          })
+        cache.set(hash, entry)
+      }
+      return entry
+    },
+  }
+}

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,0 +1,51 @@
+// SPA-side client for the Worker's /library/assets/* endpoints.
+// Mirrors src/lib/library.ts. Assets are content-addressed by SHA-256
+// computed server-side; the client just POSTs bytes and receives a hash.
+
+import { LibraryAuthError, LibraryError } from './library'
+
+const TOKEN_STORAGE_KEY = 'vade-auth-token'
+
+function readToken(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const v = window.localStorage.getItem(TOKEN_STORAGE_KEY)
+    return v && v.trim() ? v.trim() : null
+  } catch {
+    return null
+  }
+}
+
+function baseUrl(): string {
+  const override = import.meta.env.VITE_LIBRARY_URL as string | undefined
+  if (override && override.trim()) return override.replace(/\/+$/, '')
+  return ''
+}
+
+export async function uploadAsset(file: Blob): Promise<string> {
+  const token = readToken()
+  const headers = new Headers()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  headers.set('Content-Type', file.type || 'application/octet-stream')
+  const res = await fetch(`${baseUrl()}/library/assets`, {
+    method: 'POST',
+    headers,
+    body: file,
+  })
+  if (res.status === 401) throw new LibraryAuthError()
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  const body = (await res.json()) as { hash: string }
+  return body.hash
+}
+
+export async function fetchAssetBlob(hash: string): Promise<Blob> {
+  const token = readToken()
+  const headers = new Headers()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  const res = await fetch(`${baseUrl()}/library/assets/${encodeURIComponent(hash)}`, {
+    headers,
+  })
+  if (res.status === 401) throw new LibraryAuthError()
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return await res.blob()
+}

--- a/worker/library.ts
+++ b/worker/library.ts
@@ -61,6 +61,19 @@ function canvasKey(slug: string): string {
   return `canvases/${slug}/snapshot.tldr`
 }
 
+function assetKey(hash: string): string {
+  return `assets/${hash}`
+}
+
+const ASSET_HASH_RE = /^[0-9a-f]{64}$/
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
 // Per-isolate cache of the parsed OPERATOR_TOKENS JSON. Keyed off the raw
 // env value so a secret rotation (which spawns a new isolate with a fresh
 // env) naturally invalidates without explicit reset. The parse cost is
@@ -150,6 +163,15 @@ export async function handleLibrary(req: Request, env: Env, url: URL): Promise<R
       return text('Method not allowed', 405)
     }
 
+    if (resource === 'assets') {
+      if (!slug) {
+        if (req.method === 'POST') return putAsset(req, env)
+        return text('Method not allowed', 405)
+      }
+      if (req.method === 'GET') return getAsset(env, slug)
+      return text('Method not allowed', 405)
+    }
+
     if (resource === 'search' && req.method === 'GET') {
       return search(env, url.searchParams.get('q') ?? '')
     }
@@ -221,6 +243,39 @@ async function deleteCanvas(env: Env, slug: string): Promise<Response> {
   await env.LIBRARY_R2.delete(canvasKey(slug))
   await env.vade_library.prepare('DELETE FROM canvases WHERE slug = ?').bind(slug).run()
   return new Response(null, { status: 204 })
+}
+
+// Content-addressed binary assets (uploaded images, etc.) referenced from
+// canvas snapshots. Hash is the SHA-256 of the bytes, computed server-side
+// so a misbehaving client can't poison the store under a wrong key. The
+// content-type is preserved on the R2 object's httpMetadata so GETs serve
+// the correct MIME without a separate D1 row. See src/assets/vade-asset-store.ts
+// for the matching client side.
+async function putAsset(req: Request, env: Env): Promise<Response> {
+  const contentType = req.headers.get('Content-Type') ?? 'application/octet-stream'
+  const bytes = await req.arrayBuffer()
+  if (bytes.byteLength === 0) return text('empty body', 400)
+  const hash = await sha256Hex(bytes)
+  const key = assetKey(hash)
+  const existing = await env.LIBRARY_R2.head(key)
+  if (!existing) {
+    await env.LIBRARY_R2.put(key, bytes, {
+      httpMetadata: { contentType },
+    })
+  }
+  return json({ hash })
+}
+
+async function getAsset(env: Env, hash: string): Promise<Response> {
+  if (!ASSET_HASH_RE.test(hash)) return text('Not found', 404)
+  const obj = await env.LIBRARY_R2.get(assetKey(hash))
+  if (!obj) return text('Not found', 404)
+  const headers = new Headers()
+  headers.set('Content-Type', obj.httpMetadata?.contentType ?? 'application/octet-stream')
+  // Content-addressed: bytes are immutable for a given hash, so cache
+  // aggressively. Browsers and CF's edge cache will both honor this.
+  headers.set('Cache-Control', 'public, max-age=31536000, immutable')
+  return new Response(obj.body, { headers })
 }
 
 async function listEntities(env: Env): Promise<Response> {


### PR DESCRIPTION
## Summary

The default `<Tldraw>` mount used `inlineBase64AssetStore`, which pins image bytes to the originating device (an in-memory `Map` without `persistenceKey`, or IndexedDB with one). `getStoreSnapshot()` captured the asset *records* but their `props.src` pointed at device-local state, so canvases saved on Device A loaded on Device B with shapes intact and images broken — exactly the symptom reported on `coo-8-play` (Eight Strands, Concurrence).

This wires up a content-addressed `TLAssetStore` backed by the existing `LIBRARY_R2` bucket so image bytes round-trip with the snapshot.

- `worker/library.ts` — `POST /library/assets` reads the body, hashes it server-side (SHA-256), writes to R2 under `assets/<hash>`; `GET /library/assets/:hash` serves with the original `Content-Type` and immutable cache headers. Both sit behind the existing operator-bearer auth (`isAuthorized`).
- `src/lib/assets.ts` — thin client mirror of `src/lib/library.ts` (`uploadAsset`, `fetchAssetBlob`).
- `src/assets/vade-asset-store.ts` — `TLAssetStore` impl. `upload()` POSTs the file and stores `vade-asset:<hash>` in `props.src`; `resolve()` authed-fetches the blob and returns a per-session object URL, cached by hash so repeated/concurrent resolves coalesce. Foreign URLs (default tldraw bookmarks, http(s) thumbnails) pass through untouched.
- `src/App.tsx` — passes the store to `<Tldraw assets={...}>`.

## Caveats

- **Existing canvases are not retroactively healed.** `coo-8-play` (and any other pre-fix save) still carries asset records whose `src` predates this scheme; my `resolve()` falls through to the original src so behavior is unchanged for those. Recovering Eight Strands / Concurrence requires re-uploading those images once on the device that still has the bytes in its tldraw IndexedDB. New canvases — and re-uploads on existing canvases — round-trip correctly from this point on.
- **MCP-driven shape creation isn't routed through this store yet.** Agents don't currently create image shapes, so deferring.
- **No size cap or quota enforcement.** Workers' default 100 MB body limit is the implicit ceiling. Single-operator scale today; can revisit if it becomes interesting.

## Test plan

- [x] \`npm run build\` — \`tsc -b\` and Vite both clean.
- [ ] After deploy: upload a new image to a canvas, save, hard-reload in a different browser/device, confirm image renders.
- [ ] Confirm an existing image-bearing canvas (post-fix re-upload) round-trips on second device.
- [ ] Spot-check \`GET /library/assets/<hash>\` returns \`Cache-Control: public, max-age=31536000, immutable\` and the right Content-Type (curl with operator bearer).
- [ ] Confirm a non-image canvas (text/geo/arrows only) loads with no regression.

## Out of scope

- Healing pre-fix asset records. Could be done as a one-shot migration that walks each saved canvas, finds image-shape asset records with non-\`vade-asset:\` src, and re-uploads on the user's behalf — but only the originating device has the bytes, so it'd still need device-side cooperation. Filing as a follow-up if needed.
- Garbage collection of orphaned R2 assets when shapes are deleted. Punt until storage cost becomes visible.

https://claude.ai/code/session_01KFakcGrYwGupdEyP6BGAhs


Closes: n/a (bug surfaced verbally; no pre-existing issue)