### PR TITLE
fix(canvas): use asset:vade-<hash> src so tldraw schema accepts it

### DIFF
--- a/src/assets/vade-asset-store.ts
+++ b/src/assets/vade-asset-store.ts
@@ -2,11 +2,14 @@ import type { TLAsset, TLAssetStore } from 'tldraw'
 import { fetchAssetBlob, uploadAsset } from '../lib/assets'
 
 // Custom asset URL scheme that round-trips through canvas snapshots.
-// `props.src` carries `vade-asset:<sha256>` — a stable, content-addressed
+// `props.src` carries `asset:vade-<sha256>` — a stable, content-addressed
 // reference. resolve() turns that into a fetchable blob URL on demand.
 // Foreign URLs (default tldraw bookmarks, http(s) thumbnails) pass through
-// untouched.
-const SCHEME = 'vade-asset:'
+// untouched. The `asset:` scheme is one of tldraw's allowlisted srcUrl
+// protocols ({http:, https:, data:, asset:} per @tldraw/validate); we
+// sub-namespace under it with `vade-` so our records are distinguishable
+// from legacy / default-store ones.
+const SCHEME = 'asset:vade-'
 
 function parseHash(src: string | null | undefined): string | null {
   if (!src || !src.startsWith(SCHEME)) return null


### PR DESCRIPTION
## Summary

#119 stored asset srcs as \`vade-asset:<sha256>\`. tldraw v4's \`srcUrl\` validator rejects custom protocols on canvas load:

> At asset(type = image).props.src: Expected a valid url, got \"vade-asset:...\" (invalid protocol)

The allowlist in \`@tldraw/validate\` is \`{http:, https:, data:, asset:}\`. Sub-namespace under the permitted \`asset:\` scheme by emitting \`asset:vade-<hash>\` instead. Records remain distinguishable from legacy / default-store srcs (\`asset:<numericId>\`); \`resolve()\` detection in \`vade-asset-store.ts\` is structurally unchanged — only the prefix string moves.

I migrated the live \`coo-8-play\` srcs out-of-band via REST so the canvas loads on the currently-deployed binary. This PR aligns the client so \`resolve()\` recognises the new prefix and produces the blob URL on render.

Closes: n/a (follow-up to #119; bug surfaced post-merge)

## Test plan

- [x] \`npm run build\` clean.
- [ ] After auto-deploy: hard-reload \`vade-app.dev\`, open \`coo-8-play\`, confirm Eight strands & Concurrence / Citation graph / Voice drain / The Epistemic Spine pages render with images.

https://claude.ai/code/session_01KFakcGrYwGupdEyP6BGAhs