### PR TITLE
feat(shapes): zod-schema registry + folder-per-shape (Pillar 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Tldraw, type TLUiComponents } from 'tldraw'
 import 'tldraw/tldraw.css'
-import { customShapeUtils } from './shapes'
+import { customShapeUtils, version as registryVersion } from './shapes'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
 import { TopRightSlot } from './components/TopRightSlot'
 import { createVadeAssetStore } from './assets/vade-asset-store'
@@ -209,6 +209,7 @@ export default function App() {
   return (
     <div style={{ position: 'fixed', inset: 0 }}>
       <Tldraw
+        key={registryVersion}
         persistenceKey="vade-main"
         shapeUtils={customShapeUtils}
         components={tldrawComponents}

--- a/src/shapes/_types.ts
+++ b/src/shapes/_types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+import type { TLAnyShapeUtilConstructor } from '@tldraw/editor'
+import type { z } from 'zod'
+
+export interface ShapeMeta {
+  id: string
+  name: string
+  description?: string
+  category?: string
+  defaultProps: Record<string, unknown>
+  paramSchema: z.ZodObject<z.ZodRawShape>
+  util: TLAnyShapeUtilConstructor
+  icon?: ReactNode
+}

--- a/src/shapes/code/index.ts
+++ b/src/shapes/code/index.ts
@@ -1,0 +1,3 @@
+export { CodeShapeUtil, type CodeShape } from './util'
+export { meta } from './meta'
+export { paramSchema, defaultProps, type CodeShapeProps } from './params'

--- a/src/shapes/code/meta.ts
+++ b/src/shapes/code/meta.ts
@@ -1,0 +1,13 @@
+import type { ShapeMeta } from '../_types'
+import { CodeShapeUtil } from './util'
+import { defaultProps, paramSchema } from './params'
+
+export const meta: ShapeMeta = {
+  id: 'vade-code',
+  name: 'Code',
+  description: 'Syntax-highlighted code block with optional output.',
+  category: 'computation',
+  defaultProps,
+  paramSchema,
+  util: CodeShapeUtil,
+}

--- a/src/shapes/code/params.ts
+++ b/src/shapes/code/params.ts
@@ -1,0 +1,32 @@
+import { T } from '@tldraw/editor'
+import { z } from 'zod'
+
+// Zod schema drives ParamForm + defaultProps. tldraw `T.*` validators
+// drive the editor's record schema. Both live here so the duplication
+// stays scoped to one file per shape (architecture decision #2).
+
+export const paramSchema = z.object({
+  w: z.number().positive().default(320),
+  h: z.number().positive().default(200),
+  code: z.string().default(''),
+  language: z.string().default('typescript'),
+  output: z.string().default(''),
+})
+
+export type CodeShapeProps = z.infer<typeof paramSchema>
+
+export const tldrawProps = {
+  w: T.nonZeroNumber,
+  h: T.nonZeroNumber,
+  code: T.string,
+  language: T.string,
+  output: T.string,
+}
+
+export const defaultProps: CodeShapeProps = {
+  w: 320,
+  h: 200,
+  code: '',
+  language: 'typescript',
+  output: '',
+}

--- a/src/shapes/code/util.tsx
+++ b/src/shapes/code/util.tsx
@@ -1,16 +1,5 @@
-import {
-  BaseBoxShapeUtil,
-  HTMLContainer,
-  T,
-} from '@tldraw/editor'
-
-type CodeShapeProps = {
-  w: number
-  h: number
-  code: string
-  language: string
-  output: string
-}
+import { BaseBoxShapeUtil, HTMLContainer } from '@tldraw/editor'
+import { defaultProps, tldrawProps, type CodeShapeProps } from './params'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CodeShape = any
@@ -19,22 +8,10 @@ export type { CodeShape }
 
 export class CodeShapeUtil extends BaseBoxShapeUtil<CodeShape> {
   static override type = 'vade-code' as const
-  static override props = {
-    w: T.nonZeroNumber,
-    h: T.nonZeroNumber,
-    code: T.string,
-    language: T.string,
-    output: T.string,
-  }
+  static override props = tldrawProps
 
   getDefaultProps(): CodeShapeProps {
-    return {
-      w: 320,
-      h: 200,
-      code: '',
-      language: 'typescript',
-      output: '',
-    }
+    return { ...defaultProps }
   }
 
   component(shape: { props: CodeShapeProps }) {

--- a/src/shapes/data/index.ts
+++ b/src/shapes/data/index.ts
@@ -1,0 +1,3 @@
+export { DataShapeUtil, type DataShape } from './util'
+export { meta } from './meta'
+export { paramSchema, defaultProps, type DataShapeProps } from './params'

--- a/src/shapes/data/meta.ts
+++ b/src/shapes/data/meta.ts
@@ -1,0 +1,13 @@
+import type { ShapeMeta } from '../_types'
+import { DataShapeUtil } from './util'
+import { defaultProps, paramSchema } from './params'
+
+export const meta: ShapeMeta = {
+  id: 'vade-data',
+  name: 'Data',
+  description: 'Structured JSON data viewer with type-aware rendering.',
+  category: 'computation',
+  defaultProps,
+  paramSchema,
+  util: DataShapeUtil,
+}

--- a/src/shapes/data/params.ts
+++ b/src/shapes/data/params.ts
@@ -1,0 +1,25 @@
+import { T } from '@tldraw/editor'
+import { z } from 'zod'
+
+export const paramSchema = z.object({
+  w: z.number().positive().default(280),
+  h: z.number().positive().default(180),
+  data: z.string().default('{}'),
+  label: z.string().default('Data'),
+})
+
+export type DataShapeProps = z.infer<typeof paramSchema>
+
+export const tldrawProps = {
+  w: T.nonZeroNumber,
+  h: T.nonZeroNumber,
+  data: T.string,
+  label: T.string,
+}
+
+export const defaultProps: DataShapeProps = {
+  w: 280,
+  h: 180,
+  data: '{}',
+  label: 'Data',
+}

--- a/src/shapes/data/util.tsx
+++ b/src/shapes/data/util.tsx
@@ -1,15 +1,5 @@
-import {
-  BaseBoxShapeUtil,
-  HTMLContainer,
-  T,
-} from '@tldraw/editor'
-
-type DataShapeProps = {
-  w: number
-  h: number
-  data: string
-  label: string
-}
+import { BaseBoxShapeUtil, HTMLContainer } from '@tldraw/editor'
+import { defaultProps, tldrawProps, type DataShapeProps } from './params'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DataShape = any
@@ -64,20 +54,10 @@ function renderValue(value: unknown, depth: number): JSX.Element {
 
 export class DataShapeUtil extends BaseBoxShapeUtil<DataShape> {
   static override type = 'vade-data' as const
-  static override props = {
-    w: T.nonZeroNumber,
-    h: T.nonZeroNumber,
-    data: T.string,
-    label: T.string,
-  }
+  static override props = tldrawProps
 
   getDefaultProps(): DataShapeProps {
-    return {
-      w: 280,
-      h: 180,
-      data: '{}',
-      label: 'Data',
-    }
+    return { ...defaultProps }
   }
 
   component(shape: { props: DataShapeProps }) {

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -1,7 +1,5 @@
-import { CodeShapeUtil } from './CodeShape'
-import { DataShapeUtil } from './DataShape'
+export { utils as customShapeUtils, metas, version } from './registry'
+export type { ShapeMeta } from './_types'
 
-export const customShapeUtils = [CodeShapeUtil, DataShapeUtil]
-
-export { CodeShapeUtil, type CodeShape } from './CodeShape'
-export { DataShapeUtil, type DataShape } from './DataShape'
+export { CodeShapeUtil, type CodeShape } from './code'
+export { DataShapeUtil, type DataShape } from './data'

--- a/src/shapes/registry.ts
+++ b/src/shapes/registry.ts
@@ -1,0 +1,26 @@
+/// <reference types="vite/client" />
+import type { TLAnyShapeUtilConstructor } from '@tldraw/editor'
+import type { ShapeMeta } from './_types'
+
+const modules = import.meta.glob<{ meta: ShapeMeta }>(
+  './*/index.ts',
+  { eager: true },
+)
+
+const metaList: ShapeMeta[] = Object.values(modules)
+  .map((m) => m.meta)
+  .filter((m): m is ShapeMeta => Boolean(m))
+  .sort((a, b) => a.id.localeCompare(b.id))
+
+export const metas: Record<string, ShapeMeta> = Object.fromEntries(
+  metaList.map((m) => [m.id, m]),
+)
+
+export const utils: TLAnyShapeUtilConstructor[] = metaList.map((m) => m.util)
+
+function computeVersion(ids: string[]): string {
+  if (typeof btoa === 'function') return btoa(ids.join('|')).slice(0, 8)
+  return ids.join('|').slice(0, 8)
+}
+
+export const version: string = computeVersion(metaList.map((m) => m.id))


### PR DESCRIPTION
## Summary

Pillar 1 of the canvas-library + object-catalogue UX uplift planned in
\`/root/.claude/plans/peppy-wandering-dijkstra.md\`. Foundation work
that unblocks Pillars 2 (catalogue UI) and 4 (selected-shape param
panel).

- Splits \`src/shapes/CodeShape.tsx\` and \`DataShape.tsx\` into
  folder-per-shape units: \`src/shapes/{code,data}/\{params, util, meta, index\}\`.
- Co-locates a zod \`paramSchema\` with each shape (drives the future
  ParamForm + default props). The existing tldraw \`T.*\` validators
  stay alongside in \`params.ts\`. Per-shape duplication is scoped to
  one file.
- New \`src/shapes/registry.ts\` uses \`import.meta.glob\` to
  auto-discover any folder exporting a \`ShapeMeta\` and exposes
  \`{ utils, metas, version }\`. Adding a folder under \`src/shapes/\`
  with an \`index.ts\` exporting \`meta\` registers a shape automatically.
- \`App.tsx\` wires \`key={registryVersion}\` on \`<Tldraw>\` so adding
  a shape type remounts cleanly under HMR (science-canvas pattern).

No wire-format changes: tldraw shape types \`vade-code\` and \`vade-data\`
are preserved verbatim, so existing canvases at \`vade-app.dev\` load
unchanged.

Closes #164. Refs #163 (epic), #160 (Shiffrin demo readiness).

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run typecheck:worker\` clean
- [x] \`npm run typecheck:mcp\` clean
- [ ] (post-merge) \`npm run dev\`, drop a CodeShape via MCP, verify it
      renders with the same Catppuccin styling
- [ ] (post-merge) Existing \`~/.vade/library/\` and R2-backed canvases
      load and round-trip through save/load

https://claude.ai/code/session_01BQpCL6Rnzo6vhQB5KRzsd2