### PR TITLE
feat(library): snapshot history, branching, LibraryPanel (Pillar 3)

### DIFF
--- a/mcp/library.ts
+++ b/mcp/library.ts
@@ -4,12 +4,21 @@ export interface CanvasMeta {
   description: string
   created: string
   modified: string
+  parent_slug?: string
+  parent_snapshot?: string
 }
 
 export interface EntityMeta {
   name: string
   tags: string[]
   description: string
+}
+
+export interface SnapshotMeta {
+  snapshot_id: string
+  canvas_slug: string
+  label: string
+  created: string
 }
 
 export interface LibraryStore {
@@ -22,6 +31,10 @@ export interface LibraryStore {
   listEntities(): Promise<EntityMeta[]>
   deleteEntity(name: string): Promise<boolean>
   searchLibrary(query: string): Promise<{ canvases: CanvasMeta[]; entities: EntityMeta[] }>
+  saveSnapshot(canvasName: string, label?: string): Promise<SnapshotMeta>
+  listSnapshots(canvasName: string): Promise<SnapshotMeta[]>
+  restoreSnapshot(canvasName: string, snapshotId: string): Promise<{ snapshot: unknown; meta: CanvasMeta } | null>
+  branchCanvas(parentName: string, newName: string, fromSnapshot?: string): Promise<CanvasMeta>
 }
 
 export function slugify(name: string): string {

--- a/mcp/stores/cloud.ts
+++ b/mcp/stores/cloud.ts
@@ -1,4 +1,4 @@
-import type { CanvasMeta, EntityMeta, LibraryStore } from '../library.js'
+import type { CanvasMeta, EntityMeta, LibraryStore, SnapshotMeta } from '../library.js'
 import { slugify } from '../library.js'
 
 export class CloudLibraryStore implements LibraryStore {
@@ -81,5 +81,40 @@ export class CloudLibraryStore implements LibraryStore {
 
   async searchLibrary(query: string): Promise<{ canvases: CanvasMeta[]; entities: EntityMeta[] }> {
     return this.json('GET', `/search?q=${encodeURIComponent(query)}`)
+  }
+
+  async saveSnapshot(canvasName: string, label?: string): Promise<SnapshotMeta> {
+    return this.json<SnapshotMeta>(
+      'POST',
+      `/canvases/${slugify(canvasName)}/snapshots`,
+      { label: label ?? '' },
+    )
+  }
+
+  async listSnapshots(canvasName: string): Promise<SnapshotMeta[]> {
+    return this.json<SnapshotMeta[]>('GET', `/canvases/${slugify(canvasName)}/snapshots`)
+  }
+
+  async restoreSnapshot(
+    canvasName: string,
+    snapshotId: string,
+  ): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+    const res = await this.req('POST', `/canvases/${slugify(canvasName)}/restore`, {
+      snapshot_id: snapshotId,
+    })
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`Cloud library restoreSnapshot failed: ${res.status}`)
+    return (await res.json()) as { snapshot: unknown; meta: CanvasMeta }
+  }
+
+  async branchCanvas(
+    parentName: string,
+    newName: string,
+    fromSnapshot?: string,
+  ): Promise<CanvasMeta> {
+    return this.json<CanvasMeta>('POST', `/canvases/${slugify(parentName)}/branch`, {
+      name: newName,
+      ...(fromSnapshot ? { from_snapshot: fromSnapshot } : {}),
+    })
   }
 }

--- a/mcp/stores/fs.ts
+++ b/mcp/stores/fs.ts
@@ -1,8 +1,15 @@
-import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'fs'
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, rmSync, copyFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import type { CanvasMeta, EntityMeta, LibraryStore } from '../library.js'
+import type { CanvasMeta, EntityMeta, LibraryStore, SnapshotMeta } from '../library.js'
 import { slugify } from '../library.js'
+
+function generateSnapshotId(label: string | undefined): string {
+  const iso = new Date().toISOString().replace(/[:.]/g, '-')
+  if (!label) return iso
+  const slug = slugify(label)
+  return slug ? `${iso}-${slug}` : iso
+}
 
 export class FsLibraryStore implements LibraryStore {
   private readonly root: string
@@ -144,5 +151,105 @@ export class FsLibraryStore implements LibraryStore {
       e.description.toLowerCase().includes(q),
     )
     return { canvases, entities }
+  }
+
+  async saveSnapshot(canvasName: string, label?: string): Promise<SnapshotMeta> {
+    const slug = slugify(canvasName)
+    const dir = join(this.canvasesDir, slug)
+    const head = join(dir, 'snapshot.tldr')
+    if (!existsSync(head)) {
+      throw new Error(`Canvas "${canvasName}" has no head snapshot`)
+    }
+    const historyDir = join(dir, 'history')
+    mkdirSync(historyDir, { recursive: true })
+    const snapshotId = generateSnapshotId(label || undefined)
+    copyFileSync(head, join(historyDir, `${snapshotId}.tldr`))
+    const created = new Date().toISOString()
+
+    const indexPath = join(dir, 'history.json')
+    const index: SnapshotMeta[] = (() => {
+      try {
+        return JSON.parse(readFileSync(indexPath, 'utf-8')) as SnapshotMeta[]
+      } catch {
+        return []
+      }
+    })()
+    const meta: SnapshotMeta = {
+      snapshot_id: snapshotId,
+      canvas_slug: slug,
+      label: label ?? '',
+      created,
+    }
+    index.push(meta)
+    writeFileSync(indexPath, JSON.stringify(index, null, 2))
+    return meta
+  }
+
+  async listSnapshots(canvasName: string): Promise<SnapshotMeta[]> {
+    const slug = slugify(canvasName)
+    const indexPath = join(this.canvasesDir, slug, 'history.json')
+    if (!existsSync(indexPath)) return []
+    try {
+      const all = JSON.parse(readFileSync(indexPath, 'utf-8')) as SnapshotMeta[]
+      return all.sort((a, b) => (a.created < b.created ? 1 : -1))
+    } catch {
+      return []
+    }
+  }
+
+  async restoreSnapshot(
+    canvasName: string,
+    snapshotId: string,
+  ): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+    const slug = slugify(canvasName)
+    const dir = join(this.canvasesDir, slug)
+    const snapPath = join(dir, 'history', `${snapshotId}.tldr`)
+    if (!existsSync(snapPath)) return null
+    const head = join(dir, 'snapshot.tldr')
+    copyFileSync(snapPath, head)
+
+    const metaPath = join(dir, 'metadata.json')
+    if (!existsSync(metaPath)) return null
+    const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as CanvasMeta
+    meta.modified = new Date().toISOString()
+    writeFileSync(metaPath, JSON.stringify(meta, null, 2))
+
+    const snapshot = JSON.parse(readFileSync(head, 'utf-8'))
+    return { snapshot, meta }
+  }
+
+  async branchCanvas(
+    parentName: string,
+    newName: string,
+    fromSnapshot?: string,
+  ): Promise<CanvasMeta> {
+    const parentSlug = slugify(parentName)
+    const newSlug = slugify(newName)
+    if (!newSlug) throw new Error(`name produced empty slug`)
+    const parentDir = join(this.canvasesDir, parentSlug)
+    const newDir = join(this.canvasesDir, newSlug)
+    if (existsSync(newDir)) throw new Error(`Canvas "${newName}" already exists`)
+
+    const sourcePath = fromSnapshot
+      ? join(parentDir, 'history', `${fromSnapshot}.tldr`)
+      : join(parentDir, 'snapshot.tldr')
+    if (!existsSync(sourcePath)) {
+      throw new Error(fromSnapshot ? 'from_snapshot not found on parent' : 'parent has no head snapshot')
+    }
+
+    mkdirSync(newDir, { recursive: true })
+    copyFileSync(sourcePath, join(newDir, 'snapshot.tldr'))
+    const now = new Date().toISOString()
+    const meta: CanvasMeta = {
+      name: newName,
+      tags: [],
+      description: '',
+      created: now,
+      modified: now,
+      parent_slug: parentSlug,
+      ...(fromSnapshot ? { parent_snapshot: fromSnapshot } : {}),
+    }
+    writeFileSync(join(newDir, 'metadata.json'), JSON.stringify(meta, null, 2))
+    return meta
   }
 }

--- a/mcp/tools/canvas.ts
+++ b/mcp/tools/canvas.ts
@@ -45,6 +45,72 @@ export function registerCanvasTools(server: McpServer, bridge: CanvasBridge) {
     return { content: [{ type: 'text' as const, text: JSON.stringify(canvases, null, 2) }] }
   })
 
+  server.registerTool('listEntities', {
+    description: 'List all saved entities (reusable shape groups) in the library.',
+  }, async () => {
+    const store = await getStore()
+    const entities = await store.listEntities()
+    if (entities.length === 0) {
+      return { content: [{ type: 'text' as const, text: 'No entities saved yet.' }] }
+    }
+    return { content: [{ type: 'text' as const, text: JSON.stringify(entities, null, 2) }] }
+  })
+
+  server.registerTool('saveSnapshot', {
+    description: 'Capture the current head of a saved canvas as a named snapshot in its history.',
+    inputSchema: {
+      canvasName: z.string().describe('Name of the canvas to snapshot'),
+      label: z.string().optional().describe('Optional label appended to the snapshot id'),
+    },
+  }, async ({ canvasName, label }) => {
+    const store = await getStore()
+    const meta = await store.saveSnapshot(canvasName, label)
+    return { content: [{ type: 'text' as const, text: `Saved snapshot of "${canvasName}"\n${JSON.stringify(meta, null, 2)}` }] }
+  })
+
+  server.registerTool('listSnapshots', {
+    description: 'List the named snapshots stored in a canvas\'s history, newest first.',
+    inputSchema: {
+      canvasName: z.string().describe('Name of the canvas'),
+    },
+  }, async ({ canvasName }) => {
+    const store = await getStore()
+    const snapshots = await store.listSnapshots(canvasName)
+    if (snapshots.length === 0) {
+      return { content: [{ type: 'text' as const, text: `No snapshots for canvas "${canvasName}".` }] }
+    }
+    return { content: [{ type: 'text' as const, text: JSON.stringify(snapshots, null, 2) }] }
+  })
+
+  server.registerTool('restoreSnapshot', {
+    description: 'Restore a canvas to a previously named snapshot. Replaces the head; the live canvas re-loads.',
+    inputSchema: {
+      canvasName: z.string().describe('Name of the canvas to restore'),
+      snapshotId: z.string().describe('Snapshot id from listSnapshots'),
+    },
+  }, async ({ canvasName, snapshotId }) => {
+    const store = await getStore()
+    const result = await store.restoreSnapshot(canvasName, snapshotId)
+    if (!result) {
+      return { content: [{ type: 'text' as const, text: `Snapshot "${snapshotId}" not found on "${canvasName}".` }] }
+    }
+    await bridge.send({ type: 'loadSnapshot', id: makeId(), snapshot: result.snapshot })
+    return { content: [{ type: 'text' as const, text: `Restored "${canvasName}" to snapshot "${snapshotId}"\n${JSON.stringify(result.meta, null, 2)}` }] }
+  })
+
+  server.registerTool('branchCanvas', {
+    description: 'Fork a canvas into a new canvas. Optionally branches from a named snapshot instead of the current head.',
+    inputSchema: {
+      parentName: z.string().describe('Name of the canvas to branch from'),
+      newName: z.string().describe('Name for the new branched canvas'),
+      fromSnapshot: z.string().optional().describe('Snapshot id to branch from (default: head)'),
+    },
+  }, async ({ parentName, newName, fromSnapshot }) => {
+    const store = await getStore()
+    const meta = await store.branchCanvas(parentName, newName, fromSnapshot)
+    return { content: [{ type: 'text' as const, text: `Branched "${parentName}" → "${newName}"\n${JSON.stringify(meta, null, 2)}` }] }
+  })
+
   server.registerTool('deleteCanvas', {
     description: 'Delete a saved canvas from the library by name.',
     inputSchema: {

--- a/migrations/0002_snapshots_and_lineage.sql
+++ b/migrations/0002_snapshots_and_lineage.sql
@@ -1,0 +1,24 @@
+-- Pillar 3 of the canvas library + object catalogue UX uplift.
+-- Adds named snapshot history per canvas + parent pointers for branched
+-- canvases. The current head pointer at canvases/<slug>/snapshot.tldr
+-- is unchanged; named snapshots live alongside as
+-- canvases/<slug>/history/<snapshot_id>.tldr in R2.
+
+CREATE TABLE IF NOT EXISTS canvas_snapshots (
+  snapshot_id  TEXT PRIMARY KEY,
+  canvas_slug  TEXT NOT NULL,
+  label        TEXT NOT NULL DEFAULT '',
+  created      TEXT NOT NULL,
+  FOREIGN KEY (canvas_slug) REFERENCES canvases(slug) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS canvas_snapshots_slug_created_idx
+  ON canvas_snapshots (canvas_slug, created DESC);
+
+-- Branch lineage: when a canvas is forked from another, parent_slug
+-- points at the parent and parent_snapshot at the named snapshot the
+-- branch was rooted at (NULL = branched from head). NULL on both means
+-- root canvas. ALTER TABLE ADD COLUMN is irreversible in D1; back up
+-- before applying to production.
+ALTER TABLE canvases ADD COLUMN parent_slug TEXT NULL;
+ALTER TABLE canvases ADD COLUMN parent_snapshot TEXT NULL;

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -9,6 +9,15 @@ export interface CanvasMeta {
   description: string
   created: string
   modified: string
+  parent_slug?: string
+  parent_snapshot?: string
+}
+
+export interface SnapshotMeta {
+  snapshot_id: string
+  canvas_slug: string
+  label: string
+  created: string
 }
 
 export class LibraryAuthError extends Error {
@@ -102,4 +111,59 @@ export async function deleteCanvas(slug: string): Promise<boolean> {
   if (res.status === 404) return false
   if (!res.ok) throw new LibraryError(await res.text(), res.status)
   return true
+}
+
+export async function listSnapshots(slug: string): Promise<SnapshotMeta[]> {
+  const res = await request(`/library/canvases/${encodeURIComponent(slug)}/snapshots`)
+  if (res.status === 404) return []
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as SnapshotMeta[]
+}
+
+export async function saveSnapshot(slug: string, label = ''): Promise<SnapshotMeta> {
+  const res = await request(`/library/canvases/${encodeURIComponent(slug)}/snapshots`, {
+    method: 'POST',
+    body: JSON.stringify({ label }),
+  })
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as SnapshotMeta
+}
+
+export async function deleteSnapshot(slug: string, snapshotId: string): Promise<boolean> {
+  const res = await request(
+    `/library/canvases/${encodeURIComponent(slug)}/snapshots/${encodeURIComponent(snapshotId)}`,
+    { method: 'DELETE' },
+  )
+  if (res.status === 404) return false
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return true
+}
+
+export async function restoreSnapshot(
+  slug: string,
+  snapshotId: string,
+): Promise<{ snapshot: unknown; meta: CanvasMeta } | null> {
+  const res = await request(`/library/canvases/${encodeURIComponent(slug)}/restore`, {
+    method: 'POST',
+    body: JSON.stringify({ snapshot_id: snapshotId }),
+  })
+  if (res.status === 404) return null
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as { snapshot: unknown; meta: CanvasMeta }
+}
+
+export async function branchCanvas(
+  parentSlug: string,
+  newName: string,
+  fromSnapshot?: string,
+): Promise<CanvasMeta> {
+  const res = await request(`/library/canvases/${encodeURIComponent(parentSlug)}/branch`, {
+    method: 'POST',
+    body: JSON.stringify({
+      name: newName,
+      ...(fromSnapshot ? { from_snapshot: fromSnapshot } : {}),
+    }),
+  })
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as CanvasMeta
 }

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -1,0 +1,491 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type Editor, getSnapshot, loadSnapshot } from 'tldraw'
+import {
+  type CanvasMeta,
+  type SnapshotMeta,
+  LibraryAuthError,
+  branchCanvas,
+  getCanvas,
+  listCanvases,
+  listSnapshots,
+  restoreSnapshot,
+  saveCanvas,
+  saveSnapshot,
+  slugify,
+} from '../lib/library'
+import { SaveDialog } from './SaveDialog'
+
+export interface ActiveCanvas {
+  slug: string
+  name: string
+}
+
+interface LibraryPanelProps {
+  editor: Editor
+  active: ActiveCanvas | null
+  onActiveChange: (next: ActiveCanvas | null) => void
+  onClose?: () => void
+}
+
+type DialogMode = 'snapshot' | 'branch' | 'new' | null
+
+function fmtTime(iso: string): string {
+  try {
+    const d = new Date(iso)
+    const diff = Date.now() - d.getTime()
+    const day = 24 * 60 * 60 * 1000
+    if (diff < day) return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    if (diff < 7 * day) return d.toLocaleDateString([], { weekday: 'short' })
+    return d.toLocaleDateString()
+  } catch {
+    return iso
+  }
+}
+
+// Right-side library panel. Three sections: canvases list (click to
+// load), snapshots list for the active canvas (restore + branch
+// actions), action buttons (+ New, Save…, Branch). Width 260px,
+// fixed positioning, z-index above the canvas. Wired into the AppShell
+// in Pillar 5.
+export function LibraryPanel({ editor, active, onActiveChange, onClose }: LibraryPanelProps) {
+  const [canvases, setCanvases] = useState<CanvasMeta[]>([])
+  const [snapshots, setSnapshots] = useState<SnapshotMeta[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [dialog, setDialog] = useState<DialogMode>(null)
+  const [busy, setBusy] = useState(false)
+
+  const surface = useCallback((err: unknown): string => {
+    if (err instanceof LibraryAuthError) {
+      return 'Library unavailable (401). Worker needs OPERATOR_TOKENS — see docs/auth.md.'
+    }
+    if (err instanceof Error) return err.message
+    return String(err)
+  }, [])
+
+  const refreshCanvases = useCallback(async () => {
+    try {
+      setCanvases(await listCanvases())
+    } catch (err) {
+      setError(surface(err))
+    }
+  }, [surface])
+
+  const refreshSnapshots = useCallback(async () => {
+    if (!active) {
+      setSnapshots([])
+      return
+    }
+    try {
+      setSnapshots(await listSnapshots(active.slug))
+    } catch (err) {
+      setError(surface(err))
+    }
+  }, [active, surface])
+
+  useEffect(() => {
+    refreshCanvases()
+  }, [refreshCanvases])
+
+  useEffect(() => {
+    refreshSnapshots()
+  }, [refreshSnapshots])
+
+  const sortedCanvases = useMemo(
+    () => [...canvases].sort((a, b) => (a.modified < b.modified ? 1 : -1)),
+    [canvases],
+  )
+
+  const onLoad = async (meta: CanvasMeta) => {
+    setError(null)
+    try {
+      const slug = slugify(meta.name)
+      const result = await getCanvas(slug)
+      if (!result) {
+        setError(`"${meta.name}" not found.`)
+        return
+      }
+      loadSnapshot(editor.store, result.snapshot as Parameters<typeof loadSnapshot>[1])
+      onActiveChange({ slug, name: meta.name })
+    } catch (err) {
+      setError(surface(err))
+    }
+  }
+
+  const onSaveSnapshot = async (label: string) => {
+    if (!active) return
+    setBusy(true)
+    try {
+      // Make sure the head reflects current editor state before we
+      // capture a snapshot. saveCanvas writes head; saveSnapshot then
+      // copies head into history.
+      const snapshot = getSnapshot(editor.store)
+      await saveCanvas(active.name, snapshot, [], '')
+      await saveSnapshot(active.slug, label)
+      await Promise.all([refreshCanvases(), refreshSnapshots()])
+      setDialog(null)
+    } catch (err) {
+      setError(surface(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onBranchFromSnapshot = async (snapshotId: string | null, name: string) => {
+    if (!active) return
+    setBusy(true)
+    try {
+      const meta = await branchCanvas(active.slug, name, snapshotId ?? undefined)
+      const newSlug = slugify(meta.name)
+      // Load the just-branched canvas into the editor.
+      const result = await getCanvas(newSlug)
+      if (result) {
+        loadSnapshot(editor.store, result.snapshot as Parameters<typeof loadSnapshot>[1])
+        onActiveChange({ slug: newSlug, name: meta.name })
+      }
+      await refreshCanvases()
+      setDialog(null)
+    } catch (err) {
+      setError(surface(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onNewCanvas = async (name: string) => {
+    setBusy(true)
+    try {
+      // Empty new canvas: clear shapes, save head under the new name.
+      editor.selectAll()
+      editor.deleteShapes(editor.getSelectedShapeIds())
+      const snapshot = getSnapshot(editor.store)
+      await saveCanvas(name, snapshot, [], '')
+      const slug = slugify(name)
+      onActiveChange({ slug, name })
+      await refreshCanvases()
+      setDialog(null)
+    } catch (err) {
+      setError(surface(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onRestore = async (snap: SnapshotMeta) => {
+    if (!active) return
+    setError(null)
+    try {
+      const result = await restoreSnapshot(active.slug, snap.snapshot_id)
+      if (!result) {
+        setError(`Snapshot "${snap.snapshot_id}" not found.`)
+        return
+      }
+      loadSnapshot(editor.store, result.snapshot as Parameters<typeof loadSnapshot>[1])
+      await refreshCanvases()
+    } catch (err) {
+      setError(surface(err))
+    }
+  }
+
+  const [pendingBranchSnap, setPendingBranchSnap] = useState<string | null>(null)
+
+  const handleDialogSubmit = (value: string) => {
+    if (dialog === 'snapshot') return onSaveSnapshot(value)
+    if (dialog === 'new') return value ? onNewCanvas(value) : setDialog(null)
+    if (dialog === 'branch') {
+      if (!value) {
+        setDialog(null)
+        return
+      }
+      return onBranchFromSnapshot(pendingBranchSnap, value)
+    }
+  }
+
+  const dialogConfig = useMemo(() => {
+    switch (dialog) {
+      case 'snapshot':
+        return { title: 'Save snapshot', placeholder: 'Tag (optional)' }
+      case 'new':
+        return { title: 'New canvas', placeholder: 'Canvas name' }
+      case 'branch':
+        return {
+          title: pendingBranchSnap ? 'Branch from snapshot' : 'Branch from head',
+          placeholder: 'New canvas name',
+        }
+      default:
+        return null
+    }
+  }, [dialog, pendingBranchSnap])
+
+  return (
+    <aside
+      style={{
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 260,
+        zIndex: 1400,
+        background: '#1e1e2e',
+        color: '#cdd6f4',
+        borderLeft: '1px solid rgba(69, 71, 90, 0.6)',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: 13,
+      }}
+    >
+      <header
+        style={{
+          padding: '10px 12px',
+          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div style={{ fontSize: 11, letterSpacing: 1.2, color: '#7f849c' }}>LIBRARY</div>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close library panel"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: '#7f849c',
+              cursor: 'pointer',
+              fontSize: 16,
+              lineHeight: 1,
+            }}
+          >
+            ›
+          </button>
+        )}
+      </header>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 6,
+          padding: '8px 10px',
+          borderBottom: '1px solid rgba(69, 71, 90, 0.4)',
+        }}
+      >
+        <ActionButton onClick={() => setDialog('new')}>+ New</ActionButton>
+        <ActionButton onClick={() => setDialog('snapshot')} disabled={!active}>
+          Save…
+        </ActionButton>
+        <ActionButton
+          onClick={() => {
+            setPendingBranchSnap(null)
+            setDialog('branch')
+          }}
+          disabled={!active}
+        >
+          Branch
+        </ActionButton>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: '6px 10px',
+            background: 'rgba(243, 139, 168, 0.12)',
+            color: '#f38ba8',
+            fontSize: 12,
+            borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <Section title="CANVASES">
+          {sortedCanvases.length === 0 ? (
+            <Empty>No canvases yet.</Empty>
+          ) : (
+            sortedCanvases.map((c) => {
+              const slug = slugify(c.name)
+              const isActive = active?.slug === slug
+              return (
+                <button
+                  key={slug}
+                  type="button"
+                  onClick={() => onLoad(c)}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '6px 12px',
+                    background: isActive ? 'rgba(137, 180, 250, 0.12)' : 'transparent',
+                    border: 'none',
+                    color: isActive ? '#89b4fa' : '#cdd6f4',
+                    cursor: 'pointer',
+                    fontSize: 12,
+                  }}
+                >
+                  <div style={{ fontWeight: isActive ? 600 : 400 }}>{c.name}</div>
+                  <div style={{ fontSize: 11, color: '#6c7086' }}>
+                    {fmtTime(c.modified)}
+                    {c.parent_slug && ` · from ${c.parent_slug}`}
+                  </div>
+                </button>
+              )
+            })
+          )}
+        </Section>
+
+        {active && (
+          <Section title="SNAPSHOTS">
+            {snapshots.length === 0 ? (
+              <Empty>No snapshots yet.</Empty>
+            ) : (
+              snapshots.map((s) => (
+                <div
+                  key={s.snapshot_id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '4px 12px',
+                    fontSize: 12,
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {s.label || '(no label)'}
+                    </div>
+                    <div style={{ fontSize: 10, color: '#6c7086' }}>{fmtTime(s.created)}</div>
+                  </div>
+                  <IconButton
+                    title="Restore this snapshot"
+                    onClick={() => onRestore(s)}
+                  >
+                    ↺
+                  </IconButton>
+                  <IconButton
+                    title="Branch from this snapshot"
+                    onClick={() => {
+                      setPendingBranchSnap(s.snapshot_id)
+                      setDialog('branch')
+                    }}
+                  >
+                    ⑂
+                  </IconButton>
+                </div>
+              ))
+            )}
+          </Section>
+        )}
+      </div>
+
+      {dialogConfig && (
+        <SaveDialog
+          open={Boolean(dialog)}
+          title={dialogConfig.title}
+          placeholder={dialogConfig.placeholder}
+          busy={busy}
+          onCancel={() => {
+            setDialog(null)
+            setPendingBranchSnap(null)
+          }}
+          onSubmit={handleDialogSubmit}
+        />
+      )}
+    </aside>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '8px 0' }}>
+      <div
+        style={{
+          padding: '0 12px 6px',
+          fontSize: 10,
+          letterSpacing: 1.2,
+          color: '#6c7086',
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '4px 12px', fontSize: 12, color: '#6c7086' }}>{children}</div>
+  )
+}
+
+function ActionButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        flex: 1,
+        padding: '5px 8px',
+        borderRadius: 6,
+        border: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'rgba(30, 30, 46, 0.85)',
+        color: disabled ? '#6c7086' : '#cdd6f4',
+        fontSize: 12,
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function IconButton({
+  children,
+  title,
+  onClick,
+}: {
+  children: React.ReactNode
+  title: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: 4,
+        border: '1px solid rgba(69, 71, 90, 0.4)',
+        background: 'transparent',
+        color: '#cdd6f4',
+        fontSize: 13,
+        cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+interface SaveDialogProps {
+  open: boolean
+  title?: string
+  placeholder?: string
+  busy?: boolean
+  onCancel: () => void
+  onSubmit: (label: string) => void
+}
+
+// Modal dialog for collecting an optional label (snapshot tag, branch
+// name, etc.). Portals to document.body so it escapes any tldraw
+// stacking context. Enter submits, ESC cancels.
+export function SaveDialog({
+  open,
+  title = 'Save snapshot',
+  placeholder = 'Tag (optional)',
+  busy = false,
+  onCancel,
+  onSubmit,
+}: SaveDialogProps) {
+  const [label, setLabel] = useState('')
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setLabel('')
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [open])
+
+  if (!open) return null
+
+  const submit = () => {
+    if (busy) return
+    onSubmit(label.trim())
+  }
+
+  return createPortal(
+    <div
+      onClick={onCancel}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.35)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 2000,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          minWidth: 320,
+          padding: 16,
+          background: '#1e1e2e',
+          color: '#cdd6f4',
+          borderRadius: 12,
+          border: '1px solid rgba(69, 71, 90, 0.6)',
+          boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+          fontFamily: 'system-ui, sans-serif',
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 12 }}>{title}</div>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder={placeholder}
+          value={label}
+          disabled={busy}
+          onChange={(e) => setLabel(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit()
+            if (e.key === 'Escape') onCancel()
+          }}
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            background: '#181825',
+            border: '1px solid rgba(69, 71, 90, 0.6)',
+            color: '#cdd6f4',
+            borderRadius: 6,
+            fontSize: 13,
+          }}
+        />
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              padding: '5px 10px',
+              borderRadius: 6,
+              border: '1px solid rgba(69, 71, 90, 0.6)',
+              background: 'transparent',
+              color: '#cdd6f4',
+              fontSize: 12,
+              cursor: busy ? 'default' : 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={busy}
+            style={{
+              padding: '5px 10px',
+              borderRadius: 6,
+              border: '1px solid rgba(137, 180, 250, 0.6)',
+              background: 'rgba(137, 180, 250, 0.15)',
+              color: '#cdd6f4',
+              fontSize: 12,
+              cursor: busy ? 'default' : 'pointer',
+            }}
+          >
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/library/useAutosave.ts
+++ b/src/library/useAutosave.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react'
+import { type Editor, getSnapshot } from 'tldraw'
+import { saveCanvas } from '../lib/library'
+
+interface ActiveCanvas {
+  slug: string
+  name: string
+  tags?: string[]
+  description?: string
+}
+
+interface AutosaveOptions {
+  debounceMs?: number
+  onError?: (err: unknown) => void
+  onSaved?: () => void
+}
+
+// Subscribes to user-initiated document-scope changes on the tldraw
+// editor and debounces a saveCanvas call for the active canvas. No-op
+// when active is null. The debounce is per-instance — switching the
+// active canvas drops in-flight timers (cancelled on cleanup).
+//
+// Persistence model: continuous autosave writes the canvas's HEAD only
+// (canvases/<slug>/snapshot.tldr). Named snapshots are explicit
+// (saveSnapshot route + SaveDialog).
+export function useAutosave(
+  editor: Editor | null,
+  active: ActiveCanvas | null,
+  options: AutosaveOptions = {},
+): void {
+  const debounceMs = options.debounceMs ?? 800
+  const optsRef = useRef(options)
+  optsRef.current = options
+
+  useEffect(() => {
+    if (!editor || !active) return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let cancelled = false
+
+    const flush = () => {
+      if (cancelled) return
+      const snapshot = getSnapshot(editor.store)
+      saveCanvas(
+        active.name,
+        snapshot,
+        active.tags ?? [],
+        active.description ?? '',
+      )
+        .then(() => optsRef.current.onSaved?.())
+        .catch((err) => optsRef.current.onError?.(err))
+    }
+
+    const off = editor.store.listen(
+      () => {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(flush, debounceMs)
+      },
+      { scope: 'document', source: 'user' },
+    )
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+      off()
+    }
+  }, [editor, active, debounceMs])
+}

--- a/worker/library.ts
+++ b/worker/library.ts
@@ -6,12 +6,21 @@ type CanvasMeta = {
   description: string
   created: string
   modified: string
+  parent_slug?: string
+  parent_snapshot?: string
 }
 
 type EntityMeta = {
   name: string
   tags: string[]
   description: string
+}
+
+type SnapshotMeta = {
+  snapshot_id: string
+  canvas_slug: string
+  label: string
+  created: string
 }
 
 type CanvasRow = {
@@ -21,6 +30,8 @@ type CanvasRow = {
   description: string
   created: string
   modified: string
+  parent_slug: string | null
+  parent_snapshot: string | null
 }
 
 type EntityRow = {
@@ -28,6 +39,13 @@ type EntityRow = {
   name: string
   tags: string
   description: string
+}
+
+type SnapshotRow = {
+  snapshot_id: string
+  canvas_slug: string
+  label: string
+  created: string
 }
 
 const json = (data: unknown, status = 200): Response =>
@@ -40,12 +58,24 @@ const text = (body: string, status: number): Response =>
   new Response(body, { status, headers: { 'Content-Type': 'text/plain' } })
 
 function canvasMetaFromRow(row: CanvasRow): CanvasMeta {
-  return {
+  const meta: CanvasMeta = {
     name: row.name,
     tags: JSON.parse(row.tags) as string[],
     description: row.description,
     created: row.created,
     modified: row.modified,
+  }
+  if (row.parent_slug) meta.parent_slug = row.parent_slug
+  if (row.parent_snapshot) meta.parent_snapshot = row.parent_snapshot
+  return meta
+}
+
+function snapshotMetaFromRow(row: SnapshotRow): SnapshotMeta {
+  return {
+    snapshot_id: row.snapshot_id,
+    canvas_slug: row.canvas_slug,
+    label: row.label,
+    created: row.created,
   }
 }
 
@@ -61,8 +91,30 @@ function canvasKey(slug: string): string {
   return `canvases/${slug}/snapshot.tldr`
 }
 
+function historyKey(slug: string, snapshotId: string): string {
+  return `canvases/${slug}/history/${snapshotId}.tldr`
+}
+
+function historyPrefix(slug: string): string {
+  return `canvases/${slug}/history/`
+}
+
 function assetKey(hash: string): string {
   return `assets/${hash}`
+}
+
+// snapshot_id = `${cleanIso}${label ? '-' + slug : ''}` where cleanIso
+// replaces `:` and `.` (ISO timestamp delimiters) with `-` so the value
+// is safe to use as a URL path segment without escaping.
+function generateSnapshotId(label: string | undefined): string {
+  const iso = new Date().toISOString().replace(/[:.]/g, '-')
+  if (!label) return iso
+  const slug = label.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
+  return slug ? `${iso}-${slug}` : iso
+}
+
+function slugifyName(raw: string): string {
+  return raw.replace(/[^a-z0-9_-]/gi, '-').toLowerCase()
 }
 
 const ASSET_HASH_RE = /^[0-9a-f]{64}$/
@@ -136,9 +188,11 @@ export async function handleLibrary(req: Request, env: Env, url: URL): Promise<R
   }
 
   const parts = url.pathname.split('/').filter(Boolean)
-  // [ 'library', <resource>, <slug?> ]
+  // [ 'library', <resource>, <slug?>, <action?>, <action_arg?> ]
   const resource = parts[1]
   const slug = parts[2]
+  const action = parts[3]
+  const actionArg = parts[4]
 
   try {
     if (resource === 'canvases') {
@@ -146,6 +200,25 @@ export async function handleLibrary(req: Request, env: Env, url: URL): Promise<R
         if (req.method === 'GET') return listCanvases(env)
         return text('Method not allowed', 405)
       }
+      // Per-canvas action routes: /library/canvases/<slug>/<action>[/<arg>]
+      if (action === 'snapshots') {
+        if (!actionArg) {
+          if (req.method === 'GET') return listSnapshots(env, slug)
+          if (req.method === 'POST') return saveSnapshot(env, slug, await req.json())
+          return text('Method not allowed', 405)
+        }
+        if (req.method === 'DELETE') return deleteSnapshot(env, slug, actionArg)
+        return text('Method not allowed', 405)
+      }
+      if (action === 'restore') {
+        if (req.method === 'POST') return restoreSnapshot(env, slug, await req.json())
+        return text('Method not allowed', 405)
+      }
+      if (action === 'branch') {
+        if (req.method === 'POST') return branchCanvas(env, slug, await req.json())
+        return text('Method not allowed', 405)
+      }
+      if (action) return text('Not found', 404)
       if (req.method === 'GET') return getCanvas(env, slug)
       if (req.method === 'PUT') return putCanvas(env, slug, await req.json())
       if (req.method === 'DELETE') return deleteCanvas(env, slug)
@@ -185,14 +258,14 @@ export async function handleLibrary(req: Request, env: Env, url: URL): Promise<R
 
 async function listCanvases(env: Env): Promise<Response> {
   const { results } = await env.vade_library
-    .prepare('SELECT slug, name, tags, description, created, modified FROM canvases ORDER BY modified DESC')
+    .prepare('SELECT slug, name, tags, description, created, modified, parent_slug, parent_snapshot FROM canvases ORDER BY modified DESC')
     .all<CanvasRow>()
   return json(results.map(canvasMetaFromRow))
 }
 
 async function getCanvas(env: Env, slug: string): Promise<Response> {
   const row = await env.vade_library
-    .prepare('SELECT slug, name, tags, description, created, modified FROM canvases WHERE slug = ?')
+    .prepare('SELECT slug, name, tags, description, created, modified, parent_slug, parent_snapshot FROM canvases WHERE slug = ?')
     .bind(slug)
     .first<CanvasRow>()
   if (!row) return text('Not found', 404)
@@ -240,9 +313,180 @@ async function deleteCanvas(env: Env, slug: string): Promise<Response> {
     .first<{ slug: string }>()
   if (!existing) return text('Not found', 404)
 
+  // Cascade R2 deletes for the head and every named snapshot under
+  // history/. D1's FK ON DELETE CASCADE removes canvas_snapshots rows.
   await env.LIBRARY_R2.delete(canvasKey(slug))
+  await deleteHistoryPrefix(env, slug)
   await env.vade_library.prepare('DELETE FROM canvases WHERE slug = ?').bind(slug).run()
   return new Response(null, { status: 204 })
+}
+
+async function deleteHistoryPrefix(env: Env, slug: string): Promise<void> {
+  const prefix = historyPrefix(slug)
+  let cursor: string | undefined
+  do {
+    const listed = await env.LIBRARY_R2.list({ prefix, cursor })
+    if (listed.objects.length === 0) break
+    await env.LIBRARY_R2.delete(listed.objects.map((o) => o.key))
+    cursor = listed.truncated ? listed.cursor : undefined
+  } while (cursor)
+}
+
+async function listSnapshots(env: Env, slug: string): Promise<Response> {
+  const canvas = await env.vade_library
+    .prepare('SELECT slug FROM canvases WHERE slug = ?')
+    .bind(slug)
+    .first<{ slug: string }>()
+  if (!canvas) return text('Not found', 404)
+  const { results } = await env.vade_library
+    .prepare(
+      `SELECT snapshot_id, canvas_slug, label, created FROM canvas_snapshots
+       WHERE canvas_slug = ? ORDER BY created DESC`,
+    )
+    .bind(slug)
+    .all<SnapshotRow>()
+  return json(results.map(snapshotMetaFromRow))
+}
+
+async function saveSnapshot(env: Env, slug: string, body: unknown): Promise<Response> {
+  const b = body as { label?: unknown }
+  const label = typeof b.label === 'string' ? b.label : ''
+
+  const canvas = await env.vade_library
+    .prepare('SELECT slug FROM canvases WHERE slug = ?')
+    .bind(slug)
+    .first<{ slug: string }>()
+  if (!canvas) return text('Not found', 404)
+
+  const head = await env.LIBRARY_R2.get(canvasKey(slug))
+  if (!head) return text('No head snapshot to capture', 409)
+
+  const snapshotId = generateSnapshotId(label || undefined)
+  const created = new Date().toISOString()
+
+  // Round-trip the bytes through the isolate (R2 has no server-side
+  // copy primitive). Snapshot bodies stay small because asset bytes
+  // are referenced by hash, not embedded.
+  const bytes = await head.arrayBuffer()
+  await env.LIBRARY_R2.put(historyKey(slug, snapshotId), bytes)
+
+  await env.vade_library
+    .prepare(
+      `INSERT INTO canvas_snapshots (snapshot_id, canvas_slug, label, created)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .bind(snapshotId, slug, label, created)
+    .run()
+
+  return json({
+    snapshot_id: snapshotId,
+    canvas_slug: slug,
+    label,
+    created,
+  } satisfies SnapshotMeta)
+}
+
+async function deleteSnapshot(env: Env, slug: string, snapshotId: string): Promise<Response> {
+  const row = await env.vade_library
+    .prepare('SELECT snapshot_id FROM canvas_snapshots WHERE snapshot_id = ? AND canvas_slug = ?')
+    .bind(snapshotId, slug)
+    .first<{ snapshot_id: string }>()
+  if (!row) return text('Not found', 404)
+
+  await env.LIBRARY_R2.delete(historyKey(slug, snapshotId))
+  await env.vade_library
+    .prepare('DELETE FROM canvas_snapshots WHERE snapshot_id = ? AND canvas_slug = ?')
+    .bind(snapshotId, slug)
+    .run()
+  return new Response(null, { status: 204 })
+}
+
+async function restoreSnapshot(env: Env, slug: string, body: unknown): Promise<Response> {
+  const b = body as { snapshot_id?: unknown }
+  if (typeof b.snapshot_id !== 'string') return text('snapshot_id required', 400)
+  const snapshotId = b.snapshot_id
+
+  const row = await env.vade_library
+    .prepare('SELECT snapshot_id FROM canvas_snapshots WHERE snapshot_id = ? AND canvas_slug = ?')
+    .bind(snapshotId, slug)
+    .first<{ snapshot_id: string }>()
+  if (!row) return text('Snapshot not found', 404)
+
+  const obj = await env.LIBRARY_R2.get(historyKey(slug, snapshotId))
+  if (!obj) return text('Snapshot body missing', 404)
+
+  // Copy snapshot bytes back to head, then bump modified.
+  const bytes = await obj.arrayBuffer()
+  await env.LIBRARY_R2.put(canvasKey(slug), bytes)
+  const now = new Date().toISOString()
+  await env.vade_library
+    .prepare('UPDATE canvases SET modified = ? WHERE slug = ?')
+    .bind(now, slug)
+    .run()
+
+  // Return the same shape as getCanvas so clients can reuse loadSnapshot.
+  const meta = await env.vade_library
+    .prepare(
+      'SELECT slug, name, tags, description, created, modified, parent_slug, parent_snapshot FROM canvases WHERE slug = ?',
+    )
+    .bind(slug)
+    .first<CanvasRow>()
+  if (!meta) return text('Not found', 404)
+  const snapshot = JSON.parse(new TextDecoder().decode(bytes))
+  return json({ snapshot, meta: canvasMetaFromRow(meta) })
+}
+
+async function branchCanvas(env: Env, parentSlug: string, body: unknown): Promise<Response> {
+  const b = body as { name?: unknown; from_snapshot?: unknown }
+  if (typeof b.name !== 'string') return text('name required', 400)
+  const newSlug = slugifyName(b.name)
+  if (!newSlug) return text('name produced empty slug', 400)
+  const fromSnapshot = typeof b.from_snapshot === 'string' ? b.from_snapshot : null
+
+  // Refuse if the target slug already exists — branching is "clean fork
+  // into new namespace" not "overwrite".
+  const clash = await env.vade_library
+    .prepare('SELECT slug FROM canvases WHERE slug = ?')
+    .bind(newSlug)
+    .first<{ slug: string }>()
+  if (clash) return text(`Canvas "${newSlug}" already exists`, 409)
+
+  // Source bytes: from named snapshot history or the parent's head.
+  let sourceBytes: ArrayBuffer
+  if (fromSnapshot) {
+    const snapRow = await env.vade_library
+      .prepare('SELECT snapshot_id FROM canvas_snapshots WHERE snapshot_id = ? AND canvas_slug = ?')
+      .bind(fromSnapshot, parentSlug)
+      .first<{ snapshot_id: string }>()
+    if (!snapRow) return text('from_snapshot not found on parent', 404)
+    const obj = await env.LIBRARY_R2.get(historyKey(parentSlug, fromSnapshot))
+    if (!obj) return text('Snapshot body missing', 404)
+    sourceBytes = await obj.arrayBuffer()
+  } else {
+    const head = await env.LIBRARY_R2.get(canvasKey(parentSlug))
+    if (!head) return text('Parent canvas has no head snapshot', 404)
+    sourceBytes = await head.arrayBuffer()
+  }
+
+  const now = new Date().toISOString()
+  await env.LIBRARY_R2.put(canvasKey(newSlug), sourceBytes)
+  await env.vade_library
+    .prepare(
+      `INSERT INTO canvases (slug, name, tags, description, created, modified, parent_slug, parent_snapshot)
+       VALUES (?, ?, '[]', '', ?, ?, ?, ?)`,
+    )
+    .bind(newSlug, b.name, now, now, parentSlug, fromSnapshot)
+    .run()
+
+  return json({
+    name: b.name,
+    tags: [],
+    description: '',
+    created: now,
+    modified: now,
+    parent_slug: parentSlug,
+    ...(fromSnapshot ? { parent_snapshot: fromSnapshot } : {}),
+  } satisfies CanvasMeta)
 }
 
 // Content-addressed binary assets (uploaded images, etc.) referenced from
@@ -339,7 +583,7 @@ async function search(env: Env, query: string): Promise<Response> {
   const q = `%${query.toLowerCase()}%`
   const canvasQ = env.vade_library
     .prepare(
-      `SELECT slug, name, tags, description, created, modified FROM canvases
+      `SELECT slug, name, tags, description, created, modified, parent_slug, parent_snapshot FROM canvases
        WHERE lower(name) LIKE ? OR lower(description) LIKE ? OR lower(tags) LIKE ?
        ORDER BY modified DESC`,
     )


### PR DESCRIPTION
## Summary

Pillar 3 of the canvas-library + object-catalogue UX uplift (#163).
Lands in parallel with Pillar 1 (#165) — no overlap in files.

- **D1 migration 0002**: \`canvas_snapshots\` table + \`parent_slug\` /
  \`parent_snapshot\` columns on \`canvases\`.
- **Worker routes**: \`POST/GET /library/canvases/:slug/snapshots\`,
  \`DELETE /snapshots/:id\`, \`POST /restore\`, \`POST /branch\`.
  \`deleteCanvas\` extended to cascade R2 \`history/\` prefix.
- **MCP tools**: \`saveSnapshot\`, \`listSnapshots\`, \`restoreSnapshot\`
  (pushes loaded state through bridge to live canvas),
  \`branchCanvas\`, \`listEntities\` (closes the entity-enumeration
  gap from the current-state report).
- **LibraryStore** + cloud + fs drivers all implement the new methods.
- **SPA client**: matching helpers in \`src/lib/library.ts\` plus the
  new \`SnapshotMeta\` type. \`CanvasMeta\` extended with
  \`parent_slug\` / \`parent_snapshot\` (optional).
- **LibraryPanel UI** (\`src/library/{LibraryPanel,SaveDialog,useAutosave}\`):
  right sidebar, canvases + snapshots lists, restore/branch actions,
  + New / Save… / Branch buttons. **Not yet wired into App.tsx** —
  that's Pillar 5's integration job.

snapshot_id format: ISO timestamp with \`:\`/\`.\` → \`-\`,
optionally suffixed with \`-<slugified-label>\`. Path-safe without
escaping.

Backwards compatible: head pointer unchanged. Existing canvases at
\`vade-app.dev\` keep working; \`parent_slug\` is NULL = root canvas.

Closes #166. Refs #163 (epic), #160 (Shiffrin demo readiness).

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run typecheck:worker\` clean
- [x] \`npm run typecheck:mcp\` clean
- [ ] (post-merge) Apply migration on staging D1:
      \`wrangler d1 execute vade-library --file migrations/0002_snapshots_and_lineage.sql\`
- [ ] (post-merge) Save snapshot of a canvas with label
      "before-experiment"; modify; restore; verify state matches
- [ ] (post-merge) Branch canvas A → "A-fork": head copies + parent
      pointers populated + history empty
- [ ] (post-merge) Delete canvas: D1 rows cascade + R2 \`history/\`
      prefix gone
- [ ] (post-merge) MCP \`listSnapshots\` returns same data SPA does

https://claude.ai/code/session_01BQpCL6Rnzo6vhQB5KRzsd2