### PR TITLE
feat(catalog): draggable shape + entity tiles, sidebar, fullpage (Pillar 2)

### DIFF
--- a/src/catalog/CanvasDropTarget.tsx
+++ b/src/catalog/CanvasDropTarget.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { type Editor } from 'tldraw'
+import { getEntity } from '../lib/library'
+import { ENTITY_MIME, SHAPE_MIME, type EntityPayload, type ShapePayload } from './ShapeCard'
+
+interface CanvasDropTargetProps {
+  editor: Editor | null
+  onDropError?: (err: unknown) => void
+  children: ReactNode
+}
+
+// Wraps <Tldraw>. tldraw v4.5.x's registerExternalContentHandler union
+// is closed (only embed/excalidraw/files/text/tldraw/url), so we
+// intercept dragenter/dragover/drop in capture phase on the wrapper
+// div. This runs before tldraw's own dragover, lets us call
+// preventDefault() on the unknown MIME (without which the browser
+// refuses the drop), and dispatches createShape / createShapes at
+// the drop point.
+export function CanvasDropTarget({ editor, onDropError, children }: CanvasDropTargetProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const isCatalogDrop = (dt: DataTransfer | null): boolean => {
+      if (!dt) return false
+      return dt.types.includes(SHAPE_MIME) || dt.types.includes(ENTITY_MIME)
+    }
+
+    const onDragOver = (e: DragEvent) => {
+      if (!isCatalogDrop(e.dataTransfer)) return
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+    }
+
+    const onDragEnter = (e: DragEvent) => {
+      if (!isCatalogDrop(e.dataTransfer)) return
+      e.preventDefault()
+      e.stopPropagation()
+    }
+
+    const onDrop = (e: DragEvent) => {
+      if (!editor) return
+      if (!isCatalogDrop(e.dataTransfer)) return
+      e.preventDefault()
+      e.stopPropagation()
+
+      const dt = e.dataTransfer!
+      const point = editor.screenToPage({ x: e.clientX, y: e.clientY })
+
+      try {
+        editor.markHistoryStoppingPoint('catalog-insert')
+      } catch {
+        // older tldraw versions don't have markHistoryStoppingPoint;
+        // okay to ignore — drops still create shapes.
+      }
+
+      const shapeRaw = dt.getData(SHAPE_MIME)
+      if (shapeRaw) {
+        try {
+          const payload = JSON.parse(shapeRaw) as ShapePayload
+          // tldraw's TLShape union only covers built-in types. Custom
+          // shape types (vade-code, vade-data) are registered at
+          // runtime and validated by the editor, but TS can't see
+          // them. Cast to satisfy strict typing.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          editor.createShape({
+            type: payload.id,
+            x: point.x,
+            y: point.y,
+            props: payload.defaultProps,
+          } as any)
+        } catch (err) {
+          onDropError?.(err)
+        }
+        return
+      }
+
+      const entityRaw = dt.getData(ENTITY_MIME)
+      if (entityRaw) {
+        try {
+          const payload = JSON.parse(entityRaw) as EntityPayload
+          getEntity(payload.slug)
+            .then((result) => {
+              if (!result) {
+                onDropError?.(new Error(`Entity "${payload.slug}" not found.`))
+                return
+              }
+              const created = result.shapes.map((raw) => {
+                const s = raw as {
+                  type?: string
+                  x?: number
+                  y?: number
+                  props?: Record<string, unknown>
+                }
+                return {
+                  type: s.type ?? '',
+                  x: (s.x ?? 0) + point.x,
+                  y: (s.y ?? 0) + point.y,
+                  props: s.props ?? {},
+                }
+              })
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              editor.createShapes(created as any)
+            })
+            .catch((err) => onDropError?.(err))
+        } catch (err) {
+          onDropError?.(err)
+        }
+      }
+    }
+
+    node.addEventListener('dragenter', onDragEnter, { capture: true })
+    node.addEventListener('dragover', onDragOver, { capture: true })
+    node.addEventListener('drop', onDrop, { capture: true })
+    return () => {
+      node.removeEventListener('dragenter', onDragEnter, { capture: true })
+      node.removeEventListener('dragover', onDragOver, { capture: true })
+      node.removeEventListener('drop', onDrop, { capture: true })
+    }
+  }, [editor, onDropError])
+
+  return (
+    <div ref={ref} style={{ width: '100%', height: '100%' }}>
+      {children}
+    </div>
+  )
+}

--- a/src/catalog/FullPage.tsx
+++ b/src/catalog/FullPage.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type EntityMeta, LibraryAuthError, listEntities, slugify } from '../lib/library'
+import { metas as shapeMetas } from '../shapes/registry'
+import { ShapeCard } from './ShapeCard'
+
+interface FullPageProps {
+  onClose: () => void
+}
+
+// Full-screen overlay catalogue. Grid layout, grouped by `meta.category`
+// for shapes and by tag for entities. Wired into the AppShell as the
+// level-2 view in Pillar 5.
+export function FullPage({ onClose }: FullPageProps) {
+  const [entities, setEntities] = useState<EntityMeta[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const surface = useCallback((err: unknown): string => {
+    if (err instanceof LibraryAuthError) {
+      return 'Library unavailable (401). Worker needs OPERATOR_TOKENS.'
+    }
+    if (err instanceof Error) return err.message
+    return String(err)
+  }, [])
+
+  useEffect(() => {
+    listEntities().then(setEntities).catch((err) => setError(surface(err)))
+  }, [surface])
+
+  const shapesByCategory = useMemo(() => {
+    const buckets = new Map<string, typeof shapeMetas[string][]>()
+    for (const s of Object.values(shapeMetas)) {
+      const key = s.category ?? 'other'
+      const list = buckets.get(key) ?? []
+      list.push(s)
+      buckets.set(key, list)
+    }
+    return [...buckets.entries()]
+      .map(([k, list]) => [k, list.sort((a, b) => a.name.localeCompare(b.name))] as const)
+      .sort(([a], [b]) => a.localeCompare(b))
+  }, [])
+
+  const entitiesByTag = useMemo(() => {
+    const buckets = new Map<string, EntityMeta[]>()
+    for (const e of entities) {
+      const keys = e.tags.length > 0 ? e.tags : ['untagged']
+      for (const k of keys) {
+        const list = buckets.get(k) ?? []
+        list.push(e)
+        buckets.set(k, list)
+      }
+    }
+    return [...buckets.entries()].sort(([a], [b]) => a.localeCompare(b))
+  }, [entities])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1500,
+        background: 'rgba(17, 17, 27, 0.95)',
+        color: '#cdd6f4',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <header
+        style={{
+          padding: '12px 18px',
+          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600 }}>Shape Catalog</div>
+        <div style={{ fontSize: 12, color: '#7f849c' }}>
+          {Object.values(shapeMetas).length} shapes · {entities.length} entities · drag onto canvas
+        </div>
+        <div style={{ flex: 1 }} />
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close catalog"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#cdd6f4',
+            cursor: 'pointer',
+            fontSize: 18,
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      </header>
+
+      {error && (
+        <div
+          style={{
+            padding: '8px 18px',
+            background: 'rgba(243, 139, 168, 0.12)',
+            color: '#f38ba8',
+            fontSize: 12,
+            borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: 18 }}>
+        <Section title="SHAPES">
+          {shapesByCategory.map(([category, list]) => (
+            <CategoryBlock key={category} title={category}>
+              {list.map((s) => (
+                <ShapeCard
+                  key={s.id}
+                  kind="shape"
+                  id={s.id}
+                  name={s.name}
+                  description={s.description}
+                  category={s.category}
+                  defaultProps={s.defaultProps}
+                  layout="tile"
+                />
+              ))}
+            </CategoryBlock>
+          ))}
+        </Section>
+
+        {entities.length > 0 && (
+          <Section title="ENTITIES">
+            {entitiesByTag.map(([tag, list]) => (
+              <CategoryBlock key={tag} title={tag}>
+                {list.map((e) => (
+                  <ShapeCard
+                    key={e.name}
+                    kind="entity"
+                    id={slugify(e.name)}
+                    name={e.name}
+                    description={e.description}
+                    tags={e.tags}
+                    layout="tile"
+                  />
+                ))}
+              </CategoryBlock>
+            ))}
+          </Section>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <div
+        style={{
+          fontSize: 11,
+          letterSpacing: 1.2,
+          color: '#7f849c',
+          marginBottom: 10,
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function CategoryBlock({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <h2
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: '#cdd6f4',
+          margin: '0 0 8px',
+          textTransform: 'capitalize',
+        }}
+      >
+        {title}
+      </h2>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          gap: 12,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/catalog/ShapeCard.tsx
+++ b/src/catalog/ShapeCard.tsx
@@ -1,0 +1,117 @@
+import type { CSSProperties } from 'react'
+
+export const SHAPE_MIME = 'application/x-vade-canvas-shape'
+export const ENTITY_MIME = 'application/x-vade-canvas-entity'
+
+export type ShapePayload = {
+  kind: 'shape'
+  id: string
+  defaultProps: Record<string, unknown>
+}
+
+export type EntityPayload = {
+  kind: 'entity'
+  slug: string
+}
+
+export type CardKind = 'shape' | 'entity'
+
+interface ShapeCardProps {
+  kind: CardKind
+  id: string
+  name: string
+  description?: string
+  category?: string
+  tags?: string[]
+  defaultProps?: Record<string, unknown>
+  layout?: 'row' | 'tile'
+}
+
+// Draggable catalogue tile. Sets a custom MIME on dragstart so the
+// CanvasDropTarget wrapper around <Tldraw> can hit-test and create the
+// shape or entity at the drop point. Used by both Sidebar (compact row
+// layout) and FullPage (square tile layout).
+export function ShapeCard({
+  kind,
+  id,
+  name,
+  description,
+  category,
+  tags,
+  defaultProps,
+  layout = 'row',
+}: ShapeCardProps) {
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    if (kind === 'shape') {
+      const payload: ShapePayload = {
+        kind: 'shape',
+        id,
+        defaultProps: defaultProps ?? {},
+      }
+      e.dataTransfer.setData(SHAPE_MIME, JSON.stringify(payload))
+    } else {
+      const payload: EntityPayload = { kind: 'entity', slug: id }
+      e.dataTransfer.setData(ENTITY_MIME, JSON.stringify(payload))
+    }
+    e.dataTransfer.effectAllowed = 'copy'
+  }
+
+  const baseStyle: CSSProperties = {
+    padding: layout === 'tile' ? 14 : 8,
+    borderRadius: 8,
+    border: '1px solid rgba(69, 71, 90, 0.6)',
+    background: 'rgba(30, 30, 46, 0.85)',
+    color: '#cdd6f4',
+    cursor: 'grab',
+    fontFamily: 'system-ui, sans-serif',
+    fontSize: layout === 'tile' ? 13 : 12,
+    userSelect: 'none',
+  }
+
+  const tileStyle: CSSProperties = {
+    ...baseStyle,
+    minHeight: 80,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+  }
+
+  const rowStyle: CSSProperties = {
+    ...baseStyle,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  }
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      title={description}
+      style={layout === 'tile' ? tileStyle : rowStyle}
+    >
+      <div style={{ fontWeight: 600 }}>{name}</div>
+      {category && (
+        <div style={{ fontSize: 10, color: '#7f849c' }}>{category}</div>
+      )}
+      {tags && tags.length > 0 && (
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 4 }}>
+          {tags.slice(0, 4).map((t) => (
+            <span
+              key={t}
+              style={{
+                fontSize: 10,
+                padding: '1px 5px',
+                borderRadius: 4,
+                background: 'rgba(137, 180, 250, 0.15)',
+                color: '#89b4fa',
+              }}
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/catalog/Sidebar.tsx
+++ b/src/catalog/Sidebar.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type EntityMeta, LibraryAuthError, listEntities, slugify } from '../lib/library'
+import { metas as shapeMetas } from '../shapes/registry'
+import { ShapeCard } from './ShapeCard'
+
+interface SidebarProps {
+  onClose?: () => void
+  onExpand?: () => void
+}
+
+// 220px left sidebar. Two sections — built-in SHAPES from the registry,
+// and saved ENTITIES fetched from /library/entities. Search box at the
+// top filters both kinds; tag chips on entity rows are clickable to
+// pin a tag filter. Wired into the AppShell in Pillar 5; usable as a
+// standalone panel for now.
+export function Sidebar({ onClose, onExpand }: SidebarProps) {
+  const [entities, setEntities] = useState<EntityMeta[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+
+  const surface = useCallback((err: unknown): string => {
+    if (err instanceof LibraryAuthError) {
+      return 'Library unavailable (401). Worker needs OPERATOR_TOKENS — see docs/auth.md.'
+    }
+    if (err instanceof Error) return err.message
+    return String(err)
+  }, [])
+
+  useEffect(() => {
+    listEntities().then(setEntities).catch((err) => setError(surface(err)))
+  }, [surface])
+
+  const shapeMetaList = useMemo(
+    () => Object.values(shapeMetas).sort((a, b) => a.name.localeCompare(b.name)),
+    [],
+  )
+
+  const filteredShapes = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q && !activeTag) return shapeMetaList
+    return shapeMetaList.filter((s) => {
+      if (activeTag) return false // shapes have no tags surface today
+      return (
+        s.name.toLowerCase().includes(q) ||
+        s.id.toLowerCase().includes(q) ||
+        (s.description?.toLowerCase().includes(q) ?? false) ||
+        (s.category?.toLowerCase().includes(q) ?? false)
+      )
+    })
+  }, [query, activeTag, shapeMetaList])
+
+  const filteredEntities = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return entities.filter((e) => {
+      if (activeTag && !e.tags.includes(activeTag)) return false
+      if (!q) return true
+      return (
+        e.name.toLowerCase().includes(q) ||
+        e.description.toLowerCase().includes(q) ||
+        e.tags.some((t) => t.toLowerCase().includes(q))
+      )
+    })
+  }, [query, activeTag, entities])
+
+  const allTags = useMemo(() => {
+    const s = new Set<string>()
+    for (const e of entities) for (const t of e.tags) s.add(t)
+    return [...s].sort()
+  }, [entities])
+
+  return (
+    <aside
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        width: 220,
+        zIndex: 1400,
+        background: '#1e1e2e',
+        color: '#cdd6f4',
+        borderRight: '1px solid rgba(69, 71, 90, 0.6)',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: 13,
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '10px 12px',
+          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+        }}
+      >
+        <div style={{ flex: 1, fontSize: 11, letterSpacing: 1.2, color: '#7f849c' }}>
+          CATALOG
+        </div>
+        {onExpand && (
+          <button
+            type="button"
+            onClick={onExpand}
+            title="Expand to full page"
+            style={iconButtonStyle}
+          >
+            ⤢
+          </button>
+        )}
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close catalog"
+            style={iconButtonStyle}
+          >
+            ‹
+          </button>
+        )}
+      </header>
+
+      <div style={{ padding: '8px 10px', borderBottom: '1px solid rgba(69, 71, 90, 0.4)' }}>
+        <input
+          type="text"
+          placeholder="Search shapes + entities…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          style={{
+            width: '100%',
+            padding: '5px 8px',
+            background: '#181825',
+            border: '1px solid rgba(69, 71, 90, 0.6)',
+            color: '#cdd6f4',
+            borderRadius: 6,
+            fontSize: 12,
+            boxSizing: 'border-box',
+          }}
+        />
+        {allTags.length > 0 && (
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 6 }}>
+            {allTags.map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setActiveTag(activeTag === t ? null : t)}
+                style={{
+                  fontSize: 10,
+                  padding: '1px 6px',
+                  borderRadius: 4,
+                  border: '1px solid rgba(137, 180, 250, 0.4)',
+                  background:
+                    activeTag === t ? 'rgba(137, 180, 250, 0.3)' : 'transparent',
+                  color: '#89b4fa',
+                  cursor: 'pointer',
+                }}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: '6px 10px',
+            background: 'rgba(243, 139, 168, 0.12)',
+            color: '#f38ba8',
+            fontSize: 12,
+            borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <Section title="SHAPES">
+          {filteredShapes.length === 0 ? (
+            <Empty>No matches.</Empty>
+          ) : (
+            <List>
+              {filteredShapes.map((s) => (
+                <ShapeCard
+                  key={s.id}
+                  kind="shape"
+                  id={s.id}
+                  name={s.name}
+                  description={s.description}
+                  category={s.category}
+                  defaultProps={s.defaultProps}
+                />
+              ))}
+            </List>
+          )}
+        </Section>
+
+        <Section title="ENTITIES">
+          {filteredEntities.length === 0 ? (
+            <Empty>No saved entities.</Empty>
+          ) : (
+            <List>
+              {filteredEntities.map((e) => (
+                <ShapeCard
+                  key={e.name}
+                  kind="entity"
+                  id={slugify(e.name)}
+                  name={e.name}
+                  description={e.description}
+                  tags={e.tags}
+                />
+              ))}
+            </List>
+          )}
+        </Section>
+      </div>
+    </aside>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '8px 0' }}>
+      <div
+        style={{
+          padding: '0 12px 6px',
+          fontSize: 10,
+          letterSpacing: 1.2,
+          color: '#6c7086',
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function List({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '0 10px' }}>
+      {children}
+    </div>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '4px 12px', fontSize: 12, color: '#6c7086' }}>{children}</div>
+  )
+}
+
+const iconButtonStyle = {
+  background: 'transparent',
+  border: 'none',
+  color: '#7f849c',
+  cursor: 'pointer',
+  fontSize: 13,
+  lineHeight: 1,
+  padding: 2,
+} as const

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -20,6 +20,17 @@ export interface SnapshotMeta {
   created: string
 }
 
+export interface EntityMeta {
+  name: string
+  tags: string[]
+  description: string
+}
+
+export interface SearchResults {
+  canvases: CanvasMeta[]
+  entities: EntityMeta[]
+}
+
 export class LibraryAuthError extends Error {
   constructor(message = 'Unauthorized') {
     super(message)
@@ -166,4 +177,49 @@ export async function branchCanvas(
   })
   if (!res.ok) throw new LibraryError(await res.text(), res.status)
   return (await res.json()) as CanvasMeta
+}
+
+export async function listEntities(): Promise<EntityMeta[]> {
+  const res = await request('/library/entities')
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as EntityMeta[]
+}
+
+export async function getEntity(
+  slug: string,
+): Promise<{ shapes: unknown[]; meta: EntityMeta } | null> {
+  const res = await request(`/library/entities/${encodeURIComponent(slug)}`)
+  if (res.status === 404) return null
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as { shapes: unknown[]; meta: EntityMeta }
+}
+
+export async function saveEntity(
+  name: string,
+  shapes: unknown[],
+  tags: string[] = [],
+  description = '',
+): Promise<EntityMeta> {
+  const slug = slugify(name)
+  const res = await request(`/library/entities/${encodeURIComponent(slug)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ name, shapes, tags, description }),
+  })
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as EntityMeta
+}
+
+export async function deleteEntity(slug: string): Promise<boolean> {
+  const res = await request(`/library/entities/${encodeURIComponent(slug)}`, {
+    method: 'DELETE',
+  })
+  if (res.status === 404) return false
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return true
+}
+
+export async function searchLibrary(query: string): Promise<SearchResults> {
+  const res = await request(`/library/search?q=${encodeURIComponent(query)}`)
+  if (!res.ok) throw new LibraryError(await res.text(), res.status)
+  return (await res.json()) as SearchResults
 }


### PR DESCRIPTION
## Summary

Pillar 2 of the canvas-library + object-catalogue UX uplift (#163).
Builds on PR1's shape registry (in main as of #165) and the entity
endpoints already on \`/library/entities/*\`.

- **\`src/lib/library.ts\`** gains \`EntityMeta\`, \`SearchResults\`,
  \`listEntities\`, \`getEntity\`, \`saveEntity\`, \`deleteEntity\`,
  \`searchLibrary\`. Mirrors existing canvas helpers; reuses the
  \`request()\` helper for bearer auth + 401 surfacing.
- **\`src/catalog/ShapeCard.tsx\`** — draggable tile, row + tile
  layouts. Custom MIMEs:
  \`application/x-vade-canvas-shape\` and
  \`application/x-vade-canvas-entity\`.
- **\`src/catalog/Sidebar.tsx\`** — 220px left panel. SHAPES (from
  registry) + ENTITIES (from \`/library/entities\`). Search box,
  tag-chip filter for entities, optional expand-to-fullpage and
  close callbacks.
- **\`src/catalog/FullPage.tsx\`** — fullscreen overlay; grid
  layout; shapes grouped by category, entities grouped by tag.
- **\`src/catalog/CanvasDropTarget.tsx\`** — wraps \`<Tldraw>\`,
  capture-phase native HTML5 drop listeners. Required because
  tldraw v4.5.x's \`registerExternalContentHandler\` union is closed
  (embed/excalidraw/files/text/tldraw/url only) — confirmed in
  science-canvas reference. Hit-tests via \`editor.screenToPage\`,
  marks a history boundary, dispatches \`createShape\` (shape) or
  \`getEntity\` + \`createShapes\` (entity).

\`src/App.tsx\` is unchanged. Catalogue components ship unwired —
Pillar 5 integrates them. Tree-shaking keeps the bundle lean
(remained at 2104.67 kB after this PR).

Closes #169. Refs #163 (epic), #160 (Shiffrin demo readiness).

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run typecheck:worker\` clean
- [x] \`npm run typecheck:mcp\` clean
- [ ] (post-PR5) Drag a CodeShape tile onto canvas → new shape at
      drop point with default props
- [ ] (post-PR5) Save a multi-shape selection as entity (via MCP) →
      reappears in ENTITIES section
- [ ] (post-PR5) Drag entity tile → multi-shape group appears with
      offsets preserved relative to drop point
- [ ] (post-PR5) Search box filters both kinds; tag chip filters
      entities
- [ ] (post-PR5) 401 from \`/library/entities\` shows the same
      auth-config message CanvasSwitcher / LibraryPanel show

https://claude.ai/code/session_01BQpCL6Rnzo6vhQB5KRzsd2