### PR TITLE
feat(shape-panel): zod-driven param editor for selected shape (Pillar 4)

### DIFF
--- a/src/shape-panel/ParamForm.tsx
+++ b/src/shape-panel/ParamForm.tsx
@@ -1,0 +1,194 @@
+import type { CSSProperties } from 'react'
+import { z } from 'zod'
+
+interface ParamFormProps {
+  schema: z.ZodObject<z.ZodRawShape>
+  value: Record<string, unknown>
+  onChange: (next: Record<string, unknown>) => void
+}
+
+// Renders form controls auto-generated from a zod paramSchema. Dispatch
+// is primarily on runtime value type (number → number input, boolean →
+// checkbox, string → text input); a schema sniff catches ZodEnum (inc.
+// wrapped via .default()/.optional()) and renders <select>. Skips
+// arrays / objects / nulls — not enough fidelity in the schema to
+// generate a useful editor for those.
+export function ParamForm({ schema, value, onChange }: ParamFormProps) {
+  const fields = Object.entries(schema.shape)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {fields.map(([key, fieldSchema]) => {
+        const current = value[key]
+        const enumValues = sniffEnumValues(fieldSchema)
+        if (enumValues) {
+          return (
+            <Row key={key} label={key}>
+              <select
+                value={String(current ?? '')}
+                onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+                style={controlStyle}
+              >
+                {enumValues.map((v) => (
+                  <option key={v} value={v}>{v}</option>
+                ))}
+              </select>
+            </Row>
+          )
+        }
+
+        if (typeof current === 'number') {
+          const range = sniffNumberRange(fieldSchema)
+          return (
+            <Row key={key} label={key}>
+              <input
+                type="number"
+                value={current}
+                min={range?.min}
+                max={range?.max}
+                onChange={(e) => {
+                  const n = e.target.value === '' ? 0 : Number(e.target.value)
+                  if (Number.isFinite(n)) onChange({ ...value, [key]: n })
+                }}
+                style={controlStyle}
+              />
+            </Row>
+          )
+        }
+
+        if (typeof current === 'boolean') {
+          return (
+            <Row key={key} label={key}>
+              <input
+                type="checkbox"
+                checked={current}
+                onChange={(e) => onChange({ ...value, [key]: e.target.checked })}
+                style={{ ...controlStyle, width: 16, height: 16 }}
+              />
+            </Row>
+          )
+        }
+
+        if (typeof current === 'string') {
+          // Multi-line for any string longer than 60 chars or
+          // containing a newline; simple heuristic that maps cleanly
+          // onto CodeShape `code` (long) vs `language` (short).
+          const multiline = current.length > 60 || current.includes('\n')
+          return (
+            <Row key={key} label={key} stack={multiline}>
+              {multiline ? (
+                <textarea
+                  value={current}
+                  onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+                  rows={Math.min(8, Math.max(3, current.split('\n').length + 1))}
+                  style={{ ...controlStyle, fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace', resize: 'vertical' }}
+                />
+              ) : (
+                <input
+                  type="text"
+                  value={current}
+                  onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+                  style={controlStyle}
+                />
+              )}
+            </Row>
+          )
+        }
+
+        // Skip arrays/objects/null — no good universal editor.
+        return null
+      })}
+    </div>
+  )
+}
+
+function Row({
+  label,
+  children,
+  stack = false,
+}: {
+  label: string
+  children: React.ReactNode
+  stack?: boolean
+}) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        flexDirection: stack ? 'column' : 'row',
+        alignItems: stack ? 'stretch' : 'center',
+        gap: stack ? 4 : 8,
+        fontSize: 12,
+        color: '#cdd6f4',
+      }}
+    >
+      <span style={{ minWidth: stack ? 0 : 70, color: '#7f849c', fontSize: 11 }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+const controlStyle: CSSProperties = {
+  flex: 1,
+  padding: '4px 6px',
+  background: '#181825',
+  border: '1px solid rgba(69, 71, 90, 0.6)',
+  color: '#cdd6f4',
+  borderRadius: 4,
+  fontSize: 12,
+  boxSizing: 'border-box',
+  minWidth: 0,
+}
+
+// zod v4 schemas wrap inner types via `.default()`, `.optional()`,
+// `.nullable()`. We unwrap to find the underlying type for enum
+// detection and number-range extraction. Best-effort with a
+// generous `unknown` cast — the property isn't part of zod's public
+// type surface but the runtime shape is stable across v4 patches.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function unwrap(schema: any): any {
+  let s = schema
+  for (let i = 0; i < 8 && s; i++) {
+    const def = s?._def ?? s?.def
+    if (!def) return s
+    if (def.type === 'default' || def.type === 'optional' || def.type === 'nullable' || def.type === 'readonly') {
+      s = def.innerType ?? def.schema ?? s
+      continue
+    }
+    return s
+  }
+  return s
+}
+
+function sniffEnumValues(schema: unknown): string[] | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = unwrap(schema as any)
+  const def = inner?._def ?? inner?.def
+  if (def?.type !== 'enum') return null
+  const entries = def.entries
+  if (!entries || typeof entries !== 'object') return null
+  return Object.values(entries as Record<string, unknown>)
+    .filter((v): v is string => typeof v === 'string')
+}
+
+function sniffNumberRange(schema: unknown): { min?: number; max?: number } | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inner = unwrap(schema as any)
+  const def = inner?._def ?? inner?.def
+  if (def?.type !== 'number') return null
+  const checks = (def.checks as Array<Record<string, unknown>> | undefined) ?? []
+  let min: number | undefined
+  let max: number | undefined
+  for (const c of checks) {
+    const cdef = (c as { _zod?: { def?: { check?: string; value?: number } } })._zod?.def
+    if (cdef?.check === 'greater_than' || cdef?.check === 'min_length') {
+      if (typeof cdef.value === 'number') min = cdef.value
+    } else if (cdef?.check === 'less_than' || cdef?.check === 'max_length') {
+      if (typeof cdef.value === 'number') max = cdef.value
+    }
+  }
+  return { min, max }
+}

--- a/src/shape-panel/SelectedShapePanel.tsx
+++ b/src/shape-panel/SelectedShapePanel.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { type Editor, useEditor, useValue } from 'tldraw'
+import { metas as shapeMetas } from '../shapes/registry'
+import { ParamForm } from './ParamForm'
+
+// Floating top-right panel. Renders a ParamForm for the single
+// selected shape when (and only when) that shape's type has a meta
+// with a paramSchema in the registry. Edits dispatch
+// editor.updateShape, which triggers the document/user store
+// listener used by autosave + dirty-tracking elsewhere — so the
+// param panel stays in sync with the rest of the library/save state
+// without explicit wiring.
+//
+// Wired into the AppShell in Pillar 5. Rendered as a sibling of
+// <Tldraw> with absolute positioning so it sits above the canvas
+// regardless of three-level state.
+export function SelectedShapePanel() {
+  const editor = useEditor()
+  return <SelectedShapePanelInner editor={editor} />
+}
+
+function SelectedShapePanelInner({ editor }: { editor: Editor }) {
+  const selectedIds = useValue('selected ids', () => editor.getSelectedShapeIds(), [editor])
+  const [, forceTick] = useState(0)
+
+  // Re-render when the selected shape's props change so the form
+  // reflects updates from MCP, undo/redo, etc.
+  useEffect(() => {
+    if (selectedIds.length !== 1) return
+    const off = editor.store.listen(() => forceTick((t) => t + 1), {
+      scope: 'document',
+    })
+    return off
+  }, [editor, selectedIds])
+
+  if (selectedIds.length !== 1) return null
+  const id = selectedIds[0]
+  if (!id) return null
+
+  const shape = editor.getShape(id) as
+    | {
+        id: string
+        type: string
+        props: Record<string, unknown>
+      }
+    | undefined
+  if (!shape) return null
+
+  const meta = shapeMetas[shape.type]
+  if (!meta) return null
+
+  return (
+    <aside
+      style={{
+        position: 'fixed',
+        top: 60,
+        right: 12,
+        width: 240,
+        zIndex: 1500,
+        background: '#1e1e2e',
+        color: '#cdd6f4',
+        border: '1px solid rgba(69, 71, 90, 0.6)',
+        borderRadius: 10,
+        padding: 12,
+        boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <header style={{ marginBottom: 10 }}>
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: 1.2,
+            color: '#7f849c',
+            textTransform: 'uppercase',
+          }}
+        >
+          {meta.name}
+        </div>
+        {meta.description && (
+          <div style={{ fontSize: 11, color: '#6c7086', marginTop: 2 }}>
+            {meta.description}
+          </div>
+        )}
+      </header>
+      <ParamForm
+        schema={meta.paramSchema}
+        value={shape.props}
+        onChange={(next) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          editor.updateShape({ id: shape.id, type: shape.type, props: next } as any)
+        }}
+      />
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary

Pillar 4 of the canvas-library + object-catalogue UX uplift (#163).
Builds on PR1's zod \`paramSchema\` (in main as of #165). Components
ship unwired — Pillar 5 will integrate them.

- **\`src/shape-panel/ParamForm.tsx\`** — pure form generator.
  Takes \`{ schema: z.ZodObject; value; onChange }\`. Dispatch is
  primarily on runtime value type:
  - number → \`<input type="number">\` (min/max sniffed from
    \`def.checks\`)
  - boolean → \`<input type="checkbox">\`
  - string short (≤60, no \\n) → text input
  - string long → \`<textarea>\`, mono font, vertical resize
  - schema-detected enum → \`<select>\` with \`def.entries\`
    (handles wrapped via \`.default()\`/\`.optional()\`/
    \`.nullable()\`)
  - arrays / objects / null → skipped
- **\`src/shape-panel/SelectedShapePanel.tsx\`** — floating top-right
  card. Subscribes to selected ids via tldraw's \`useValue\`,
  re-renders on document-scope store changes (so MCP / undo
  updates reflect). Renders ParamForm only when exactly one shape
  is selected AND its type has a meta with \`paramSchema\` in the
  registry.

\`onChange\` dispatches \`editor.updateShape\`, which triggers the
same \`document/user\` store listener that LibraryPanel's
\`useAutosave\` and CanvasSwitcher's dirty-dot already use. The
param panel stays in sync with library + autosave without
explicit wiring.

\`src/App.tsx\` is unchanged; tree-shaking keeps unused components
out of the bundle.

Closes #171. Refs #163 (epic), #160 (Shiffrin demo readiness).

## zod v4 introspection note

v4 uses \`def.type\` (string discriminator like \`"number"\`,
\`"enum"\`, \`"default"\`) rather than v3's \`_def.typeName\`.
Wrappers like \`.default()\`/\`.optional()\`/\`.nullable()\`/
\`.readonly()\` produce \`def.type === 'default' | ...\` with the
inner schema at \`def.innerType\`. ParamForm unwraps up to 8 levels
before sniffing — best-effort on a not-strictly-public type
surface, but the runtime shape is stable across v4 patches and
runtime value type stays the primary discriminant.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run typecheck:worker\` clean
- [x] \`npm run typecheck:mcp\` clean
- [ ] (post-PR5) Select a CodeShape → panel renders with \`code\`,
      \`language\`, \`output\`, \`w\`, \`h\` fields
- [ ] (post-PR5) Edit \`code\` → shape re-renders
- [ ] (post-PR5) Edit \`w\` to 600 → shape resizes
- [ ] (post-PR5) Multi-select → panel hides
- [ ] (post-PR5) Select a built-in tldraw shape → panel hides
- [ ] (post-PR5) Edits trigger LibraryPanel autosave debounce

https://claude.ai/code/session_01BQpCL6Rnzo6vhQB5KRzsd2