### PR TITLE
fix(shell): single persistenceKey to unblock R2 canvas loads

### DIFF
--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -91,12 +91,15 @@ export function AppShell({ assetStore, licenseKey, components, onMount }: AppShe
     [onMount],
   )
 
-  // Per-canvas persistenceKey isolates IndexedDB session state
-  // (camera, selection, current page) per active canvas. Switching
-  // active forces a Tldraw remount via the key change, which is
-  // also what loads the just-restored / just-branched document
-  // cleanly — no stale shapes leak across canvases.
-  const persistenceKey = active ? `vade-canvas-${active.slug}` : 'vade-canvas-main'
+  // Single persistenceKey across canvases. Per-canvas persistenceKey
+  // looked attractive (isolated camera/zoom per canvas) but conflicts
+  // with R2-backed canvas switching: loadStoreSnapshot applies the
+  // R2 snapshot to the in-memory tldraw, then setActive flips
+  // persistenceKey, then Tldraw remounts and hydrates from the new
+  // (empty) IndexedDB key, blanking the just-loaded canvas. Stick
+  // with one bucket; loadStoreSnapshot is the single source of truth
+  // on canvas switch.
+  const persistenceKey = 'vade-main'
 
   const shellState = useMemo<ShellState>(
     () => ({
@@ -115,7 +118,7 @@ export function AppShell({ assetStore, licenseKey, components, onMount }: AppShe
       <div style={{ position: 'fixed', inset: 0 }}>
         <CanvasDropTarget editor={editor}>
           <Tldraw
-            key={`${registryVersion}:${persistenceKey}`}
+            key={registryVersion}
             persistenceKey={persistenceKey}
             shapeUtils={customShapeUtils}
             assets={assetStore}


### PR DESCRIPTION
## Summary

Hot fix following vade-core#174 (Pillar 5 of canvas UX uplift).
Loading a saved canvas via the LibraryPanel rendered an empty
canvas — the saved shapes never appeared.

Race condition: per-canvas \`persistenceKey = vade-canvas-\${slug}\`
caused Tldraw to remount on canvas switch, hydrating from the
new (empty) IndexedDB key and discarding the just-loaded
\`loadSnapshot\` result.

Fix: single static \`persistenceKey = 'vade-main'\`. Drop
\`persistenceKey\` from the Tldraw \`key\` so canvas switches
don't remount. \`loadSnapshot\` becomes the single source of
truth on switch; document content lives in R2 and round-trips
through \`getCanvas\` / \`saveCanvas\`.

Cost: camera/zoom/current-page no longer isolate per-canvas.
That was the pre-Pillar-5 behavior under
\`persistenceKey="vade-main"\`, so no regression vs before the
uplift. The only correct way to make per-canvas keys work with
R2 loads would be to fire \`loadSnapshot\` inside the new
Tldraw's \`onMount\` (after the remount); significant complexity
for a small UX win, deferred.

Closes #177. Refs #174 (Pillar 5), #163 (canvas UX uplift epic).

## Test plan

- [x] \`npm run build\` clean (bundle 2131.66 → 2131.61 kB)
- [x] \`npm run typecheck:worker\` clean
- [x] \`npm run typecheck:mcp\` clean
- [ ] (post-merge) Click a saved canvas in LibraryPanel → shapes
      appear correctly
- [ ] (post-merge) Switch between two saved canvases → both
      load their saved content
- [ ] (post-merge) Save a snapshot, restore it → shapes match
- [ ] (post-merge) Branch a canvas → branch loads with parent's
      content

https://claude.ai/code/session_01BQpCL6Rnzo6vhQB5KRzsd2