### PR TITLE
feat(shell): push canvas + chrome aside instead of overlap

### DIFF
--- a/src/catalog/Sidebar.tsx
+++ b/src/catalog/Sidebar.tsx
@@ -72,12 +72,8 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
   return (
     <aside
       style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        bottom: 0,
         width: 220,
-        zIndex: 1400,
+        flexShrink: 0,
         background: '#1e1e2e',
         color: '#cdd6f4',
         borderRight: '1px solid rgba(69, 71, 90, 0.6)',

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -219,12 +219,8 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
   return (
     <aside
       style={{
-        position: 'fixed',
-        top: 0,
-        right: 0,
-        bottom: 0,
         width: 260,
-        zIndex: 1400,
+        flexShrink: 0,
         background: '#1e1e2e',
         color: '#cdd6f4',
         borderLeft: '1px solid rgba(69, 71, 90, 0.6)',

--- a/src/shape-panel/SelectedShapePanel.tsx
+++ b/src/shape-panel/SelectedShapePanel.tsx
@@ -56,7 +56,7 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
   return (
     <aside
       style={{
-        position: 'fixed',
+        position: 'absolute',
         top: 60,
         right: 12,
         width: 240,

--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -113,41 +113,52 @@ export function AppShell({ assetStore, licenseKey, components, onMount }: AppShe
     [catalog, library, active, dirty],
   )
 
+  // Flex shell so panels push canvas + chrome aside instead of
+  // overlapping. Sidebar and LibraryPanel are flex children;
+  // canvas + SelectedShapePanel + (fullpage cover) live in a
+  // flex:1 column whose position:relative anchors the floating
+  // SelectedShapePanel via position:absolute. FullPage stays a
+  // viewport-level overlay (sibling of the flex row) so it covers
+  // panels too when active. (#183)
   return (
     <ShellContext.Provider value={shellState}>
-      <div style={{ position: 'fixed', inset: 0 }}>
-        <CanvasDropTarget editor={editor}>
-          <Tldraw
-            key={registryVersion}
-            persistenceKey={persistenceKey}
-            shapeUtils={customShapeUtils}
-            assets={assetStore}
-            {...(components ? { components } : {})}
-            {...(licenseKey ? { licenseKey } : {})}
-            onMount={handleMount}
-          />
-        </CanvasDropTarget>
+      <>
+        <div style={{ position: 'fixed', inset: 0, display: 'flex' }}>
+          {catalog === 'sidebar' && (
+            <Sidebar
+              onClose={() => setCatalog('closed')}
+              onExpand={() => setCatalog('fullpage')}
+            />
+          )}
 
-        {catalog === 'sidebar' && (
-          <Sidebar
-            onClose={() => setCatalog('closed')}
-            onExpand={() => setCatalog('fullpage')}
-          />
-        )}
+          <div style={{ flex: 1, position: 'relative', minWidth: 0 }}>
+            <CanvasDropTarget editor={editor}>
+              <Tldraw
+                key={registryVersion}
+                persistenceKey={persistenceKey}
+                shapeUtils={customShapeUtils}
+                assets={assetStore}
+                {...(components ? { components } : {})}
+                {...(licenseKey ? { licenseKey } : {})}
+                onMount={handleMount}
+              />
+            </CanvasDropTarget>
+
+            <SelectedShapePanel editor={editor} />
+          </div>
+
+          {library === 'open' && editor && (
+            <LibraryPanel
+              editor={editor}
+              active={active}
+              onActiveChange={(next) => setActive(next)}
+              onClose={() => setLibrary('closed')}
+            />
+          )}
+        </div>
 
         {catalog === 'fullpage' && <FullPage onClose={() => setCatalog('sidebar')} />}
-
-        {library === 'open' && editor && (
-          <LibraryPanel
-            editor={editor}
-            active={active}
-            onActiveChange={(next) => setActive(next)}
-            onClose={() => setLibrary('closed')}
-          />
-        )}
-
-        <SelectedShapePanel editor={editor} />
-      </div>
+      </>
     </ShellContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary

Restructures `AppShell` to a flex row so opening the catalog sidebar or library panel narrows the canvas viewport rather than overlaying it. tldraw reflows to its container, so its style panel / toolbar / share panel stay visible inside the canvas column.

Closes #183 (parent #179).

## Layout

Before: panels were `position: fixed` overlays sitting on top of the canvas (Sidebar over the left chrome, LibraryPanel over the right chrome).

After:

```
+-----------------------------------------------------------+
| [Sidebar 220]  [canvas (flex:1, position:relative)]  [Lib]|
|                       <Tldraw />                          |
|                       <SelectedShapePanel position:abs>   |
+-----------------------------------------------------------+
```

`FullPage` (level-2 catalog) stays a viewport-level overlay (sibling of the flex row) so it covers panels too when active.

## Changes

- `src/shell/AppShell.tsx` — wrap the canvas in a `flex:1` column with `position:relative`. Sidebar + LibraryPanel become flex children. FullPage moved outside the flex row to retain full-screen overlay behavior.
- `src/catalog/Sidebar.tsx` — drop `position:fixed/top/left/bottom/zIndex`; add `flexShrink: 0` so the 220px column stays fixed-width when the canvas resizes.
- `src/library/LibraryPanel.tsx` — same drop-and-`flexShrink:0` for the right-side 260px column.
- `src/shape-panel/SelectedShapePanel.tsx` — `position: fixed` → `position: absolute`. Anchored to the canvas column's relative parent at the same `top:60 right:12` offset. Per the #179 design call, the selected-panel rides inside the canvas region rather than the viewport so it never collides with LibraryPanel.

## Test plan

- [x] `npm run build` clean (vite worker + client both pass).
- [ ] **Hosted-deploy smoke test:** drop a shape from the catalog onto the canvas with Sidebar open. tldraw's `screenToPage` uses `getBoundingClientRect` internally so an offset container should compute correctly, but verify in the browser. (Identified by the agent research dispatch as the one residual risk; cannot validate inside CI.)
- [ ] Open Sidebar + LibraryPanel together — canvas viewport should narrow correctly; tldraw's style panel / toolbar / share panel reflow into the canvas column without clipping.
- [ ] Selected-shape param panel sits at top-right of the canvas column, not the viewport. Visible when a parameterized shape is selected; not occluded by LibraryPanel.
- [ ] iPad PWA install: layout still loads and is usable in landscape. (Portrait min-width fallback deferred — see follow-ups.)

## Out of scope / follow-ups

- **Small-viewport (< ~600px) fallback to overlay mode.** When both panels are open, `100vw - 480px` collapses below usable on narrow iPad portrait or phone. Not regressing prior behavior (panels were already hard to use that small). File a follow-up issue if this matters in practice.
- The remaining four #179 children — #180 theme, #182 chrome integration, #184 typography, #186 logout — separate PRs follow.

## References

- Parent epic: #179
- Predecessor cohort PR: #185 (#181 retire generate buttons, merged).
- Design decisions taken on session 2026-05-08 turn: SelectedShapePanel becomes absolute-in-canvas-column; chip light-mode follows tldraw; both chips move to TopPanel together (separate PRs).

https://claude.ai/code/session_01JNbNdxXHkP1avVeoTBmGUp