### PR TITLE
feat(shell): chip theme tokens + typography module (#180 + #184)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
 import { TopRightSlot } from './components/TopRightSlot'
 import { createVadeAssetStore } from './assets/vade-asset-store'
 import { AppShell } from './shell/AppShell'
+import { fontMono, size } from './shell/typography'
 
 // Inject TopRightSlot into tldraw's top-right SharePanel slot so the
 // chips render inside tldraw's chrome and can't collide with Main Menu
@@ -70,8 +71,8 @@ function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onC
         borderRadius: 12,
         background: 'rgba(30, 30, 46, 0.85)',
         color: colors[status],
-        fontSize: 11,
-        fontFamily: 'ui-monospace, monospace',
+        fontSize: size.sm,
+        fontFamily: fontMono,
         pointerEvents: interactive ? 'auto' : 'none',
         cursor: interactive ? 'pointer' : 'default',
         backdropFilter: 'blur(8px)',
@@ -108,7 +109,7 @@ function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
         justifyContent: 'center',
         background: '#1e1e2e',
         color: '#cdd6f4',
-        fontFamily: 'ui-monospace, monospace',
+        fontFamily: fontMono,
         padding: 24,
       }}
     >
@@ -125,8 +126,8 @@ function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
           maxWidth: 420,
         }}
       >
-        <div style={{ fontSize: 14, fontWeight: 600 }}>VADE</div>
-        <label htmlFor="vade-token" style={{ fontSize: 12, color: '#a6adc8' }}>
+        <div style={{ fontSize: size.xl, fontWeight: 600 }}>VADE</div>
+        <label htmlFor="vade-token" style={{ fontSize: size.md, color: '#a6adc8' }}>
           Paste your operator token to continue
         </label>
         <input
@@ -143,8 +144,8 @@ function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
             border: '1px solid #45475a',
             background: '#181825',
             color: '#cdd6f4',
-            fontFamily: 'ui-monospace, monospace',
-            fontSize: 13,
+            fontFamily: fontMono,
+            fontSize: size.lg,
           }}
         />
         <button
@@ -157,7 +158,7 @@ function TokenGate({ onSubmit }: { onSubmit: (token: string) => void }) {
             background: trimmed ? '#89b4fa' : '#45475a',
             color: '#11111b',
             fontFamily: 'inherit',
-            fontSize: 13,
+            fontSize: size.lg,
             fontWeight: 600,
             cursor: trimmed ? 'pointer' : 'not-allowed',
           }}

--- a/src/catalog/FullPage.tsx
+++ b/src/catalog/FullPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { type EntityMeta, LibraryAuthError, listEntities, slugify } from '../lib/library'
 import { metas as shapeMetas } from '../shapes/registry'
+import { fontSans, size } from '../shell/typography'
 import { ShapeCard } from './ShapeCard'
 
 interface FullPageProps {
@@ -62,7 +63,7 @@ export function FullPage({ onClose }: FullPageProps) {
         color: '#cdd6f4',
         display: 'flex',
         flexDirection: 'column',
-        fontFamily: 'system-ui, sans-serif',
+        fontFamily: fontSans,
       }}
     >
       <header
@@ -74,8 +75,8 @@ export function FullPage({ onClose }: FullPageProps) {
           gap: 12,
         }}
       >
-        <div style={{ fontSize: 14, fontWeight: 600 }}>Shape Catalog</div>
-        <div style={{ fontSize: 12, color: '#7f849c' }}>
+        <div style={{ fontSize: size.xl, fontWeight: 600 }}>Shape Catalog</div>
+        <div style={{ fontSize: size.md, color: '#7f849c' }}>
           {Object.values(shapeMetas).length} shapes · {entities.length} entities · drag onto canvas
         </div>
         <div style={{ flex: 1 }} />
@@ -88,7 +89,7 @@ export function FullPage({ onClose }: FullPageProps) {
             border: 'none',
             color: '#cdd6f4',
             cursor: 'pointer',
-            fontSize: 18,
+            fontSize: 18 /* display */,
             lineHeight: 1,
           }}
         >
@@ -102,7 +103,7 @@ export function FullPage({ onClose }: FullPageProps) {
             padding: '8px 18px',
             background: 'rgba(243, 139, 168, 0.12)',
             color: '#f38ba8',
-            fontSize: 12,
+            fontSize: size.md,
             borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
           }}
         >
@@ -159,7 +160,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     <div style={{ marginBottom: 24 }}>
       <div
         style={{
-          fontSize: 11,
+          fontSize: size.sm,
           letterSpacing: 1.2,
           color: '#7f849c',
           marginBottom: 10,
@@ -177,7 +178,7 @@ function CategoryBlock({ title, children }: { title: string; children: React.Rea
     <div style={{ marginBottom: 18 }}>
       <h2
         style={{
-          fontSize: 13,
+          fontSize: size.lg,
           fontWeight: 600,
           color: '#cdd6f4',
           margin: '0 0 8px',

--- a/src/catalog/ShapeCard.tsx
+++ b/src/catalog/ShapeCard.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react'
+import { fontSans, size } from '../shell/typography'
 
 export const SHAPE_MIME = 'application/x-vade-canvas-shape'
 export const ENTITY_MIME = 'application/x-vade-canvas-entity'
@@ -63,8 +64,8 @@ export function ShapeCard({
     background: 'rgba(30, 30, 46, 0.85)',
     color: '#cdd6f4',
     cursor: 'grab',
-    fontFamily: 'system-ui, sans-serif',
-    fontSize: layout === 'tile' ? 13 : 12,
+    fontFamily: fontSans,
+    fontSize: layout === 'tile' ? size.lg : size.md,
     userSelect: 'none',
   }
 
@@ -92,7 +93,7 @@ export function ShapeCard({
     >
       <div style={{ fontWeight: 600 }}>{name}</div>
       {category && (
-        <div style={{ fontSize: 10, color: '#7f849c' }}>{category}</div>
+        <div style={{ fontSize: size.xs, color: '#7f849c' }}>{category}</div>
       )}
       {tags && tags.length > 0 && (
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 4 }}>
@@ -100,7 +101,7 @@ export function ShapeCard({
             <span
               key={t}
               style={{
-                fontSize: 10,
+                fontSize: size.xs,
                 padding: '1px 5px',
                 borderRadius: 4,
                 background: 'rgba(137, 180, 250, 0.15)',

--- a/src/catalog/Sidebar.tsx
+++ b/src/catalog/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { type EntityMeta, LibraryAuthError, listEntities, slugify } from '../lib/library'
 import { metas as shapeMetas } from '../shapes/registry'
+import { fontSans, size } from '../shell/typography'
 import { ShapeCard } from './ShapeCard'
 
 interface SidebarProps {
@@ -79,8 +80,8 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
         borderRight: '1px solid rgba(69, 71, 90, 0.6)',
         display: 'flex',
         flexDirection: 'column',
-        fontFamily: 'system-ui, sans-serif',
-        fontSize: 13,
+        fontFamily: fontSans,
+        fontSize: size.lg,
       }}
     >
       <header
@@ -92,7 +93,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
           borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
         }}
       >
-        <div style={{ flex: 1, fontSize: 11, letterSpacing: 1.2, color: '#7f849c' }}>
+        <div style={{ flex: 1, fontSize: size.sm, letterSpacing: 1.2, color: '#7f849c' }}>
           CATALOG
         </div>
         {onExpand && (
@@ -130,7 +131,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
             border: '1px solid rgba(69, 71, 90, 0.6)',
             color: '#cdd6f4',
             borderRadius: 6,
-            fontSize: 12,
+            fontSize: size.md,
             boxSizing: 'border-box',
           }}
         />
@@ -142,7 +143,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
                 type="button"
                 onClick={() => setActiveTag(activeTag === t ? null : t)}
                 style={{
-                  fontSize: 10,
+                  fontSize: size.xs,
                   padding: '1px 6px',
                   borderRadius: 4,
                   border: '1px solid rgba(137, 180, 250, 0.4)',
@@ -165,7 +166,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
             padding: '6px 10px',
             background: 'rgba(243, 139, 168, 0.12)',
             color: '#f38ba8',
-            fontSize: 12,
+            fontSize: size.md,
             borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
           }}
         >
@@ -223,7 +224,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
       <div
         style={{
           padding: '0 12px 6px',
-          fontSize: 10,
+          fontSize: size.xs,
           letterSpacing: 1.2,
           color: '#6c7086',
         }}
@@ -245,7 +246,7 @@ function List({ children }: { children: React.ReactNode }) {
 
 function Empty({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ padding: '4px 12px', fontSize: 12, color: '#6c7086' }}>{children}</div>
+    <div style={{ padding: '4px 12px', fontSize: size.md, color: '#6c7086' }}>{children}</div>
   )
 }
 
@@ -254,7 +255,7 @@ const iconButtonStyle = {
   border: 'none',
   color: '#7f849c',
   cursor: 'pointer',
-  fontSize: 13,
+  fontSize: size.lg,
   lineHeight: 1,
   padding: 2,
 } as const

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -13,6 +13,7 @@ import {
   saveSnapshot,
   slugify,
 } from '../lib/library'
+import { fontSans, size } from '../shell/typography'
 import { SaveDialog } from './SaveDialog'
 
 export interface ActiveCanvas {
@@ -226,8 +227,8 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
         borderLeft: '1px solid rgba(69, 71, 90, 0.6)',
         display: 'flex',
         flexDirection: 'column',
-        fontFamily: 'system-ui, sans-serif',
-        fontSize: 13,
+        fontFamily: fontSans,
+        fontSize: size.lg,
       }}
     >
       <header
@@ -239,7 +240,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
           justifyContent: 'space-between',
         }}
       >
-        <div style={{ fontSize: 11, letterSpacing: 1.2, color: '#7f849c' }}>LIBRARY</div>
+        <div style={{ fontSize: size.sm, letterSpacing: 1.2, color: '#7f849c' }}>LIBRARY</div>
         {onClose && (
           <button
             type="button"
@@ -250,7 +251,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
               border: 'none',
               color: '#7f849c',
               cursor: 'pointer',
-              fontSize: 16,
+              fontSize: 16 /* display */,
               lineHeight: 1,
             }}
           >
@@ -288,7 +289,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
             padding: '6px 10px',
             background: 'rgba(243, 139, 168, 0.12)',
             color: '#f38ba8',
-            fontSize: 12,
+            fontSize: size.md,
             borderBottom: '1px solid rgba(243, 139, 168, 0.3)',
           }}
         >
@@ -318,11 +319,11 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
                     border: 'none',
                     color: isActive ? '#89b4fa' : '#cdd6f4',
                     cursor: 'pointer',
-                    fontSize: 12,
+                    fontSize: size.md,
                   }}
                 >
                   <div style={{ fontWeight: isActive ? 600 : 400 }}>{c.name}</div>
-                  <div style={{ fontSize: 11, color: '#6c7086' }}>
+                  <div style={{ fontSize: size.sm, color: '#6c7086' }}>
                     {fmtTime(c.modified)}
                     {c.parent_slug && ` · from ${c.parent_slug}`}
                   </div>
@@ -345,7 +346,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
                     alignItems: 'center',
                     gap: 6,
                     padding: '4px 12px',
-                    fontSize: 12,
+                    fontSize: size.md,
                   }}
                 >
                   <div style={{ flex: 1, minWidth: 0 }}>
@@ -358,7 +359,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
                     >
                       {s.label || '(no label)'}
                     </div>
-                    <div style={{ fontSize: 10, color: '#6c7086' }}>{fmtTime(s.created)}</div>
+                    <div style={{ fontSize: size.xs, color: '#6c7086' }}>{fmtTime(s.created)}</div>
                   </div>
                   <IconButton
                     title="Restore this snapshot"
@@ -405,7 +406,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
       <div
         style={{
           padding: '0 12px 6px',
-          fontSize: 10,
+          fontSize: size.xs,
           letterSpacing: 1.2,
           color: '#6c7086',
         }}
@@ -419,7 +420,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function Empty({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ padding: '4px 12px', fontSize: 12, color: '#6c7086' }}>{children}</div>
+    <div style={{ padding: '4px 12px', fontSize: size.md, color: '#6c7086' }}>{children}</div>
   )
 }
 
@@ -444,7 +445,7 @@ function ActionButton({
         border: '1px solid rgba(69, 71, 90, 0.6)',
         background: 'rgba(30, 30, 46, 0.85)',
         color: disabled ? '#6c7086' : '#cdd6f4',
-        fontSize: 12,
+        fontSize: size.md,
         cursor: disabled ? 'default' : 'pointer',
       }}
     >
@@ -474,7 +475,7 @@ function IconButton({
         border: '1px solid rgba(69, 71, 90, 0.4)',
         background: 'transparent',
         color: '#cdd6f4',
-        fontSize: 13,
+        fontSize: size.lg,
         cursor: 'pointer',
         display: 'inline-flex',
         alignItems: 'center',

--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { fontSans, size } from '../shell/typography'
 
 interface SaveDialogProps {
   open: boolean
@@ -60,10 +61,10 @@ export function SaveDialog({
           borderRadius: 12,
           border: '1px solid rgba(69, 71, 90, 0.6)',
           boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
-          fontFamily: 'system-ui, sans-serif',
+          fontFamily: fontSans,
         }}
       >
-        <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 12 }}>{title}</div>
+        <div style={{ fontSize: size.xl, fontWeight: 600, marginBottom: 12 }}>{title}</div>
         <input
           ref={inputRef}
           type="text"
@@ -82,7 +83,7 @@ export function SaveDialog({
             border: '1px solid rgba(69, 71, 90, 0.6)',
             color: '#cdd6f4',
             borderRadius: 6,
-            fontSize: 13,
+            fontSize: size.lg,
           }}
         />
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
@@ -96,7 +97,7 @@ export function SaveDialog({
               border: '1px solid rgba(69, 71, 90, 0.6)',
               background: 'transparent',
               color: '#cdd6f4',
-              fontSize: 12,
+              fontSize: size.md,
               cursor: busy ? 'default' : 'pointer',
             }}
           >
@@ -112,7 +113,7 @@ export function SaveDialog({
               border: '1px solid rgba(137, 180, 250, 0.6)',
               background: 'rgba(137, 180, 250, 0.15)',
               color: '#cdd6f4',
-              fontSize: 12,
+              fontSize: size.md,
               cursor: busy ? 'default' : 'pointer',
             }}
           >

--- a/src/shape-panel/ParamForm.tsx
+++ b/src/shape-panel/ParamForm.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import { z } from 'zod'
+import { fontMono, size } from '../shell/typography'
 
 interface ParamFormProps {
   schema: z.ZodObject<z.ZodRawShape>
@@ -81,7 +82,7 @@ export function ParamForm({ schema, value, onChange }: ParamFormProps) {
                   value={current}
                   onChange={(e) => onChange({ ...value, [key]: e.target.value })}
                   rows={Math.min(8, Math.max(3, current.split('\n').length + 1))}
-                  style={{ ...controlStyle, fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace', resize: 'vertical' }}
+                  style={{ ...controlStyle, fontFamily: fontMono, resize: 'vertical' }}
                 />
               ) : (
                 <input
@@ -118,11 +119,11 @@ function Row({
         flexDirection: stack ? 'column' : 'row',
         alignItems: stack ? 'stretch' : 'center',
         gap: stack ? 4 : 8,
-        fontSize: 12,
+        fontSize: size.md,
         color: '#cdd6f4',
       }}
     >
-      <span style={{ minWidth: stack ? 0 : 70, color: '#7f849c', fontSize: 11 }}>
+      <span style={{ minWidth: stack ? 0 : 70, color: '#7f849c', fontSize: size.sm }}>
         {label}
       </span>
       {children}
@@ -137,7 +138,7 @@ const controlStyle: CSSProperties = {
   border: '1px solid rgba(69, 71, 90, 0.6)',
   color: '#cdd6f4',
   borderRadius: 4,
-  fontSize: 12,
+  fontSize: size.md,
   boxSizing: 'border-box',
   minWidth: 0,
 }

--- a/src/shape-panel/SelectedShapePanel.tsx
+++ b/src/shape-panel/SelectedShapePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { type Editor, useValue } from 'tldraw'
 import { metas as shapeMetas } from '../shapes/registry'
+import { fontSans, size } from '../shell/typography'
 import { ParamForm } from './ParamForm'
 
 interface SelectedShapePanelProps {
@@ -67,13 +68,13 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
         borderRadius: 10,
         padding: 12,
         boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
-        fontFamily: 'system-ui, sans-serif',
+        fontFamily: fontSans,
       }}
     >
       <header style={{ marginBottom: 10 }}>
         <div
           style={{
-            fontSize: 11,
+            fontSize: size.sm,
             letterSpacing: 1.2,
             color: '#7f849c',
             textTransform: 'uppercase',
@@ -82,7 +83,7 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
           {meta.name}
         </div>
         {meta.description && (
-          <div style={{ fontSize: 11, color: '#6c7086', marginTop: 2 }}>
+          <div style={{ fontSize: size.sm, color: '#6c7086', marginTop: 2 }}>
             {meta.description}
           </div>
         )}

--- a/src/shell/CatalogChip.tsx
+++ b/src/shell/CatalogChip.tsx
@@ -1,4 +1,5 @@
 import { useShell } from './ShellContext'
+import { fontMono, size } from './typography'
 
 // Toggle chip for the catalog sidebar/fullpage. Renders inside
 // tldraw's SharePanel slot via TopRightSlot. Style is the inline
@@ -23,8 +24,8 @@ export function CatalogChip() {
         border: '1px solid var(--tl-color-divider)',
         background: open ? 'var(--tl-color-muted-1)' : 'var(--tl-color-panel-overlay)',
         color: 'var(--tl-color-text)',
-        fontFamily: 'ui-monospace, monospace',
-        fontSize: 11,
+        fontFamily: fontMono,
+        fontSize: size.sm,
         cursor: 'pointer',
         backdropFilter: 'blur(8px)',
       }}

--- a/src/shell/CatalogChip.tsx
+++ b/src/shell/CatalogChip.tsx
@@ -19,17 +19,17 @@ export function CatalogChip() {
         alignItems: 'center',
         gap: 6,
         padding: '5px 10px',
-        borderRadius: 10,
-        border: '1px solid rgba(69, 71, 90, 0.6)',
-        background: open ? 'rgba(137, 180, 250, 0.18)' : 'rgba(30, 30, 46, 0.85)',
-        color: '#cdd6f4',
+        borderRadius: 'var(--tl-radius-4)',
+        border: '1px solid var(--tl-color-divider)',
+        background: open ? 'var(--tl-color-muted-1)' : 'var(--tl-color-panel-overlay)',
+        color: 'var(--tl-color-text)',
         fontFamily: 'ui-monospace, monospace',
         fontSize: 11,
         cursor: 'pointer',
         backdropFilter: 'blur(8px)',
       }}
     >
-      <span style={{ color: '#6c7086' }}>▤</span>
+      <span style={{ color: 'var(--tl-color-text-3)' }}>▤</span>
       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         Catalog
       </span>

--- a/src/shell/LibraryChip.tsx
+++ b/src/shell/LibraryChip.tsx
@@ -1,4 +1,5 @@
 import { useShell } from './ShellContext'
+import { fontMono, size } from './typography'
 
 // Toggle chip for the library panel. Carries active canvas name +
 // dirty dot for at-a-glance status. Renders inside tldraw's
@@ -24,8 +25,8 @@ export function LibraryChip() {
         border: '1px solid var(--tl-color-divider)',
         background: open ? 'var(--tl-color-muted-1)' : 'var(--tl-color-panel-overlay)',
         color: 'var(--tl-color-text)',
-        fontFamily: 'ui-monospace, monospace',
-        fontSize: 11,
+        fontFamily: fontMono,
+        fontSize: size.sm,
         cursor: 'pointer',
         backdropFilter: 'blur(8px)',
       }}

--- a/src/shell/LibraryChip.tsx
+++ b/src/shell/LibraryChip.tsx
@@ -20,18 +20,18 @@ export function LibraryChip() {
         gap: 6,
         padding: '5px 10px',
         maxWidth: 240,
-        borderRadius: 10,
-        border: '1px solid rgba(69, 71, 90, 0.6)',
-        background: open ? 'rgba(137, 180, 250, 0.18)' : 'rgba(30, 30, 46, 0.85)',
-        color: '#cdd6f4',
+        borderRadius: 'var(--tl-radius-4)',
+        border: '1px solid var(--tl-color-divider)',
+        background: open ? 'var(--tl-color-muted-1)' : 'var(--tl-color-panel-overlay)',
+        color: 'var(--tl-color-text)',
         fontFamily: 'ui-monospace, monospace',
         fontSize: 11,
         cursor: 'pointer',
         backdropFilter: 'blur(8px)',
       }}
     >
-      <span style={{ color: '#6c7086' }}>≡</span>
-      <span style={{ color: '#6c7086' }}>Canvas:</span>
+      <span style={{ color: 'var(--tl-color-text-3)' }}>≡</span>
+      <span style={{ color: 'var(--tl-color-text-3)' }}>Canvas:</span>
       <span
         style={{
           overflow: 'hidden',
@@ -49,7 +49,7 @@ export function LibraryChip() {
             width: 6,
             height: 6,
             borderRadius: '50%',
-            background: '#f9e2af',
+            background: 'var(--tl-color-warning)',
             flexShrink: 0,
           }}
         />

--- a/src/shell/typography.ts
+++ b/src/shell/typography.ts
@@ -1,0 +1,23 @@
+// Typography scale for the VADE shell. System-stack only — no
+// webfont download. tldraw 4.5.10's UI uses font-family: inherit
+// from the host document, so its chrome stays visually consistent
+// with whatever fontSans we pick. Mono stack matches what already
+// shipped in ParamForm + code/data shape utilities.
+//
+// Outliers: 16/18px display sizes in FullPage and LibraryPanel are
+// kept as inline literals with a `/* display */` comment rather
+// than added to the scale. See #184.
+
+export const fontSans = 'system-ui, -apple-system, sans-serif'
+
+export const fontMono = 'ui-monospace, "SF Mono", Menlo, Consolas, monospace'
+
+// Renamed `size` (not `fontSize`) to avoid shadowing the CSS
+// property name when used inline as `fontSize: size.sm`.
+export const size = {
+  xs: 10,
+  sm: 11,
+  md: 12,
+  lg: 13,
+  xl: 14,
+} as const


### PR DESCRIPTION
## Summary

Two sub-issues of #179 landing together because they touch the same chip files:

- **(a) #180 — chip palette follows tldraw theme tokens.** Drops the hardcoded Catppuccin-Mocha palette in favor of `var(--tl-color-*)` and `var(--tl-radius-*)`. Light/dark follow is automatic via tldraw's `.tl-theme__light`/`.tl-theme__dark` cascade.
- **(e) #184 — typography module + scale.** Introduces `src/shell/typography.ts` with `fontSans` (system stack), `fontMono` (extended ui-mono), and `size` (xs/sm/md/lg/xl = 10/11/12/13/14). Migrates ~10 shell files to consume them.

Closes #180. Closes #184.

## Commit walk

1. **`feat(shell): chip palette follows tldraw theme tokens`** — CatalogChip and LibraryChip swap `#cdd6f4`, `rgba(30,30,46,0.85)`, `rgba(137,180,250,0.18)`, `rgba(69,71,90,0.6)`, `#6c7086`, `#f9e2af`, `borderRadius: 10` for `var(--tl-color-text)`, `var(--tl-color-panel-overlay)`, `var(--tl-color-muted-1)`, `var(--tl-color-divider)`, `var(--tl-color-text-3)`, `var(--tl-color-warning)`, `var(--tl-radius-4)` respectively. `backdrop-filter: blur(8px)` retained — no SDK token; the blur is the chip's visual identity.

2. **`feat(shell): typography module + scale across shell surface`** — new `src/shell/typography.ts`; migrates `src/{App,shell/CatalogChip,shell/LibraryChip,catalog/Sidebar,catalog/FullPage,catalog/ShapeCard,library/LibraryPanel,library/SaveDialog,shape-panel/SelectedShapePanel,shape-panel/ParamForm}.tsx`. Two display-size outliers (16px on LibraryPanel close button, 18px on FullPage close button) retained as inline literals with `/* display */` comment.

## Test plan

- [x] `npm run build` clean (vite worker + client both pass).
- [ ] Hosted-deploy visual check on https://vade-app.dev: chips read as part of tldraw chrome (not a foreign palette overlay) in default light theme. Same in dark mode if toggled. Dirty-dot still visible on LibraryChip.
- [ ] Typography parity check: panel headers, body text, and form controls render with the new sans/mono stacks. No layout shifts vs prior look.
- [ ] iPad PWA: chip + panel rendering still legible; no webfont download cost (system stack only).

## Out of scope

- The remaining sub-issues of #179: #182 chrome integration (TopPanel slot move), #186 sign-out affordance.
- `src/shapes/{code,data}/util.tsx` — those render canvas shape content; treat as a separate pass if needed.

## References

- Parent epic: #179
- Predecessors merged this session: #185 (#181 retire), and the squash-merge of #183 (push-not-overlap).
- Design call taken on session 2026-05-08: chip light-mode follows tldraw tokens (theme-coherent over project-owned palette); both chips eventually move together to TopPanel (separate PR for #182).

https://claude.ai/code/session_01JNbNdxXHkP1avVeoTBmGUp