### PR TITLE
fix(shell): theme tokens cover panels + dialogs (broaden #180 scope)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onC
         gap: 6,
         padding: '4px 10px',
         borderRadius: 12,
-        background: 'rgba(30, 30, 46, 0.85)',
+        background: 'var(--tl-color-panel-overlay)',
         color: colors[status],
         fontSize: size.sm,
         fontFamily: fontMono,

--- a/src/catalog/FullPage.tsx
+++ b/src/catalog/FullPage.tsx
@@ -59,8 +59,8 @@ export function FullPage({ onClose }: FullPageProps) {
         position: 'fixed',
         inset: 0,
         zIndex: 1500,
-        background: 'rgba(17, 17, 27, 0.95)',
-        color: '#cdd6f4',
+        background: 'var(--tl-color-panel-overlay)',
+        color: 'var(--tl-color-text)',
         display: 'flex',
         flexDirection: 'column',
         fontFamily: fontSans,
@@ -69,14 +69,14 @@ export function FullPage({ onClose }: FullPageProps) {
       <header
         style={{
           padding: '12px 18px',
-          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+          borderBottom: '1px solid var(--tl-color-divider)',
           display: 'flex',
           alignItems: 'center',
           gap: 12,
         }}
       >
         <div style={{ fontSize: size.xl, fontWeight: 600 }}>Shape Catalog</div>
-        <div style={{ fontSize: size.md, color: '#7f849c' }}>
+        <div style={{ fontSize: size.md, color: 'var(--tl-color-text-3)' }}>
           {Object.values(shapeMetas).length} shapes · {entities.length} entities · drag onto canvas
         </div>
         <div style={{ flex: 1 }} />
@@ -87,7 +87,7 @@ export function FullPage({ onClose }: FullPageProps) {
           style={{
             background: 'transparent',
             border: 'none',
-            color: '#cdd6f4',
+            color: 'var(--tl-color-text)',
             cursor: 'pointer',
             fontSize: 18 /* display */,
             lineHeight: 1,
@@ -162,7 +162,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
         style={{
           fontSize: size.sm,
           letterSpacing: 1.2,
-          color: '#7f849c',
+          color: 'var(--tl-color-text-3)',
           marginBottom: 10,
         }}
       >
@@ -180,7 +180,7 @@ function CategoryBlock({ title, children }: { title: string; children: React.Rea
         style={{
           fontSize: size.lg,
           fontWeight: 600,
-          color: '#cdd6f4',
+          color: 'var(--tl-color-text)',
           margin: '0 0 8px',
           textTransform: 'capitalize',
         }}

--- a/src/catalog/ShapeCard.tsx
+++ b/src/catalog/ShapeCard.tsx
@@ -60,9 +60,9 @@ export function ShapeCard({
   const baseStyle: CSSProperties = {
     padding: layout === 'tile' ? 14 : 8,
     borderRadius: 8,
-    border: '1px solid rgba(69, 71, 90, 0.6)',
-    background: 'rgba(30, 30, 46, 0.85)',
-    color: '#cdd6f4',
+    border: '1px solid var(--tl-color-divider)',
+    background: 'var(--tl-color-panel-overlay)',
+    color: 'var(--tl-color-text)',
     cursor: 'grab',
     fontFamily: fontSans,
     fontSize: layout === 'tile' ? size.lg : size.md,
@@ -93,7 +93,7 @@ export function ShapeCard({
     >
       <div style={{ fontWeight: 600 }}>{name}</div>
       {category && (
-        <div style={{ fontSize: size.xs, color: '#7f849c' }}>{category}</div>
+        <div style={{ fontSize: size.xs, color: 'var(--tl-color-text-3)' }}>{category}</div>
       )}
       {tags && tags.length > 0 && (
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 4 }}>
@@ -104,8 +104,8 @@ export function ShapeCard({
                 fontSize: size.xs,
                 padding: '1px 5px',
                 borderRadius: 4,
-                background: 'rgba(137, 180, 250, 0.15)',
-                color: '#89b4fa',
+                background: 'var(--tl-color-muted-1)',
+                color: 'var(--tl-color-selected)',
               }}
             >
               {t}

--- a/src/catalog/Sidebar.tsx
+++ b/src/catalog/Sidebar.tsx
@@ -75,9 +75,9 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
       style={{
         width: 220,
         flexShrink: 0,
-        background: '#1e1e2e',
-        color: '#cdd6f4',
-        borderRight: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'var(--tl-color-panel)',
+        color: 'var(--tl-color-text)',
+        borderRight: '1px solid var(--tl-color-divider)',
         display: 'flex',
         flexDirection: 'column',
         fontFamily: fontSans,
@@ -90,10 +90,10 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
           alignItems: 'center',
           gap: 6,
           padding: '10px 12px',
-          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+          borderBottom: '1px solid var(--tl-color-divider)',
         }}
       >
-        <div style={{ flex: 1, fontSize: size.sm, letterSpacing: 1.2, color: '#7f849c' }}>
+        <div style={{ flex: 1, fontSize: size.sm, letterSpacing: 1.2, color: 'var(--tl-color-text-3)' }}>
           CATALOG
         </div>
         {onExpand && (
@@ -118,7 +118,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
         )}
       </header>
 
-      <div style={{ padding: '8px 10px', borderBottom: '1px solid rgba(69, 71, 90, 0.4)' }}>
+      <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--tl-color-divider)' }}>
         <input
           type="text"
           placeholder="Search shapes + entities…"
@@ -127,9 +127,9 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
           style={{
             width: '100%',
             padding: '5px 8px',
-            background: '#181825',
-            border: '1px solid rgba(69, 71, 90, 0.6)',
-            color: '#cdd6f4',
+            background: 'var(--tl-color-background)',
+            border: '1px solid var(--tl-color-divider)',
+            color: 'var(--tl-color-text)',
             borderRadius: 6,
             fontSize: size.md,
             boxSizing: 'border-box',
@@ -146,10 +146,10 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
                   fontSize: size.xs,
                   padding: '1px 6px',
                   borderRadius: 4,
-                  border: '1px solid rgba(137, 180, 250, 0.4)',
+                  border: '1px solid var(--tl-color-selected)',
                   background:
-                    activeTag === t ? 'rgba(137, 180, 250, 0.3)' : 'transparent',
-                  color: '#89b4fa',
+                    activeTag === t ? 'var(--tl-color-muted-1)' : 'transparent',
+                  color: 'var(--tl-color-selected)',
                   cursor: 'pointer',
                 }}
               >
@@ -226,7 +226,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
           padding: '0 12px 6px',
           fontSize: size.xs,
           letterSpacing: 1.2,
-          color: '#6c7086',
+          color: 'var(--tl-color-text-3)',
         }}
       >
         {title}
@@ -246,14 +246,14 @@ function List({ children }: { children: React.ReactNode }) {
 
 function Empty({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ padding: '4px 12px', fontSize: size.md, color: '#6c7086' }}>{children}</div>
+    <div style={{ padding: '4px 12px', fontSize: size.md, color: 'var(--tl-color-text-3)' }}>{children}</div>
   )
 }
 
 const iconButtonStyle = {
   background: 'transparent',
   border: 'none',
-  color: '#7f849c',
+  color: 'var(--tl-color-text-3)',
   cursor: 'pointer',
   fontSize: size.lg,
   lineHeight: 1,

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -222,9 +222,9 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
       style={{
         width: 260,
         flexShrink: 0,
-        background: '#1e1e2e',
-        color: '#cdd6f4',
-        borderLeft: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'var(--tl-color-panel)',
+        color: 'var(--tl-color-text)',
+        borderLeft: '1px solid var(--tl-color-divider)',
         display: 'flex',
         flexDirection: 'column',
         fontFamily: fontSans,
@@ -234,13 +234,13 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
       <header
         style={{
           padding: '10px 12px',
-          borderBottom: '1px solid rgba(69, 71, 90, 0.6)',
+          borderBottom: '1px solid var(--tl-color-divider)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
         }}
       >
-        <div style={{ fontSize: size.sm, letterSpacing: 1.2, color: '#7f849c' }}>LIBRARY</div>
+        <div style={{ fontSize: size.sm, letterSpacing: 1.2, color: 'var(--tl-color-text-3)' }}>LIBRARY</div>
         {onClose && (
           <button
             type="button"
@@ -249,7 +249,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
             style={{
               background: 'transparent',
               border: 'none',
-              color: '#7f849c',
+              color: 'var(--tl-color-text-3)',
               cursor: 'pointer',
               fontSize: 16 /* display */,
               lineHeight: 1,
@@ -265,7 +265,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
           display: 'flex',
           gap: 6,
           padding: '8px 10px',
-          borderBottom: '1px solid rgba(69, 71, 90, 0.4)',
+          borderBottom: '1px solid var(--tl-color-divider)',
         }}
       >
         <ActionButton onClick={() => setDialog('new')}>+ New</ActionButton>
@@ -315,15 +315,15 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
                     width: '100%',
                     textAlign: 'left',
                     padding: '6px 12px',
-                    background: isActive ? 'rgba(137, 180, 250, 0.12)' : 'transparent',
+                    background: isActive ? 'var(--tl-color-muted-1)' : 'transparent',
                     border: 'none',
-                    color: isActive ? '#89b4fa' : '#cdd6f4',
+                    color: isActive ? 'var(--tl-color-selected)' : 'var(--tl-color-text)',
                     cursor: 'pointer',
                     fontSize: size.md,
                   }}
                 >
                   <div style={{ fontWeight: isActive ? 600 : 400 }}>{c.name}</div>
-                  <div style={{ fontSize: size.sm, color: '#6c7086' }}>
+                  <div style={{ fontSize: size.sm, color: 'var(--tl-color-text-3)' }}>
                     {fmtTime(c.modified)}
                     {c.parent_slug && ` · from ${c.parent_slug}`}
                   </div>
@@ -359,7 +359,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
                     >
                       {s.label || '(no label)'}
                     </div>
-                    <div style={{ fontSize: size.xs, color: '#6c7086' }}>{fmtTime(s.created)}</div>
+                    <div style={{ fontSize: size.xs, color: 'var(--tl-color-text-3)' }}>{fmtTime(s.created)}</div>
                   </div>
                   <IconButton
                     title="Restore this snapshot"
@@ -408,7 +408,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
           padding: '0 12px 6px',
           fontSize: size.xs,
           letterSpacing: 1.2,
-          color: '#6c7086',
+          color: 'var(--tl-color-text-3)',
         }}
       >
         {title}
@@ -420,7 +420,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function Empty({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ padding: '4px 12px', fontSize: size.md, color: '#6c7086' }}>{children}</div>
+    <div style={{ padding: '4px 12px', fontSize: size.md, color: 'var(--tl-color-text-3)' }}>{children}</div>
   )
 }
 
@@ -442,9 +442,9 @@ function ActionButton({
         flex: 1,
         padding: '5px 8px',
         borderRadius: 6,
-        border: '1px solid rgba(69, 71, 90, 0.6)',
-        background: 'rgba(30, 30, 46, 0.85)',
-        color: disabled ? '#6c7086' : '#cdd6f4',
+        border: '1px solid var(--tl-color-divider)',
+        background: 'var(--tl-color-panel-overlay)',
+        color: disabled ? 'var(--tl-color-text-3)' : 'var(--tl-color-text)',
         fontSize: size.md,
         cursor: disabled ? 'default' : 'pointer',
       }}
@@ -472,9 +472,9 @@ function IconButton({
         width: 24,
         height: 24,
         borderRadius: 4,
-        border: '1px solid rgba(69, 71, 90, 0.4)',
+        border: '1px solid var(--tl-color-divider)',
         background: 'transparent',
-        color: '#cdd6f4',
+        color: 'var(--tl-color-text)',
         fontSize: size.lg,
         cursor: 'pointer',
         display: 'inline-flex',

--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -56,10 +56,10 @@ export function SaveDialog({
         style={{
           minWidth: 320,
           padding: 16,
-          background: '#1e1e2e',
-          color: '#cdd6f4',
+          background: 'var(--tl-color-panel)',
+          color: 'var(--tl-color-text)',
           borderRadius: 12,
-          border: '1px solid rgba(69, 71, 90, 0.6)',
+          border: '1px solid var(--tl-color-divider)',
           boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
           fontFamily: fontSans,
         }}
@@ -79,9 +79,9 @@ export function SaveDialog({
           style={{
             width: '100%',
             padding: '6px 8px',
-            background: '#181825',
-            border: '1px solid rgba(69, 71, 90, 0.6)',
-            color: '#cdd6f4',
+            background: 'var(--tl-color-background)',
+            border: '1px solid var(--tl-color-divider)',
+            color: 'var(--tl-color-text)',
             borderRadius: 6,
             fontSize: size.lg,
           }}
@@ -94,9 +94,9 @@ export function SaveDialog({
             style={{
               padding: '5px 10px',
               borderRadius: 6,
-              border: '1px solid rgba(69, 71, 90, 0.6)',
+              border: '1px solid var(--tl-color-divider)',
               background: 'transparent',
-              color: '#cdd6f4',
+              color: 'var(--tl-color-text)',
               fontSize: size.md,
               cursor: busy ? 'default' : 'pointer',
             }}
@@ -110,9 +110,9 @@ export function SaveDialog({
             style={{
               padding: '5px 10px',
               borderRadius: 6,
-              border: '1px solid rgba(137, 180, 250, 0.6)',
-              background: 'rgba(137, 180, 250, 0.15)',
-              color: '#cdd6f4',
+              border: '1px solid var(--tl-color-selected)',
+              background: 'var(--tl-color-muted-1)',
+              color: 'var(--tl-color-text)',
               fontSize: size.md,
               cursor: busy ? 'default' : 'pointer',
             }}

--- a/src/shape-panel/ParamForm.tsx
+++ b/src/shape-panel/ParamForm.tsx
@@ -120,10 +120,10 @@ function Row({
         alignItems: stack ? 'stretch' : 'center',
         gap: stack ? 4 : 8,
         fontSize: size.md,
-        color: '#cdd6f4',
+        color: 'var(--tl-color-text)',
       }}
     >
-      <span style={{ minWidth: stack ? 0 : 70, color: '#7f849c', fontSize: size.sm }}>
+      <span style={{ minWidth: stack ? 0 : 70, color: 'var(--tl-color-text-3)', fontSize: size.sm }}>
         {label}
       </span>
       {children}
@@ -134,9 +134,9 @@ function Row({
 const controlStyle: CSSProperties = {
   flex: 1,
   padding: '4px 6px',
-  background: '#181825',
-  border: '1px solid rgba(69, 71, 90, 0.6)',
-  color: '#cdd6f4',
+  background: 'var(--tl-color-background)',
+  border: '1px solid var(--tl-color-divider)',
+  color: 'var(--tl-color-text)',
   borderRadius: 4,
   fontSize: size.md,
   boxSizing: 'border-box',

--- a/src/shape-panel/SelectedShapePanel.tsx
+++ b/src/shape-panel/SelectedShapePanel.tsx
@@ -62,9 +62,9 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
         right: 12,
         width: 240,
         zIndex: 1500,
-        background: '#1e1e2e',
-        color: '#cdd6f4',
-        border: '1px solid rgba(69, 71, 90, 0.6)',
+        background: 'var(--tl-color-panel)',
+        color: 'var(--tl-color-text)',
+        border: '1px solid var(--tl-color-divider)',
         borderRadius: 10,
         padding: 12,
         boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
@@ -76,14 +76,14 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
           style={{
             fontSize: size.sm,
             letterSpacing: 1.2,
-            color: '#7f849c',
+            color: 'var(--tl-color-text-3)',
             textTransform: 'uppercase',
           }}
         >
           {meta.name}
         </div>
         {meta.description && (
-          <div style={{ fontSize: size.sm, color: '#6c7086', marginTop: 2 }}>
+          <div style={{ fontSize: size.sm, color: 'var(--tl-color-text-3)', marginTop: 2 }}>
             {meta.description}
           </div>
         )}

--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Tldraw, type Editor, type TLAssetStore, type TLUiComponents } from 'tldraw'
+import { Tldraw, type Editor, type TLAssetStore, type TLUiComponents, useValue } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { customShapeUtils, version as registryVersion } from '../shapes'
 import { Sidebar } from '../catalog/Sidebar'
@@ -120,10 +120,21 @@ export function AppShell({ assetStore, licenseKey, components, onMount }: AppShe
   // SelectedShapePanel via position:absolute. FullPage stays a
   // viewport-level overlay (sibling of the flex row) so it covers
   // panels too when active. (#183)
+  //
+  // Theme class on the wrapper propagates tldraw's --tl-color-*
+  // CSS custom properties to panels that aren't descendants of
+  // <Tldraw> (Sidebar, LibraryPanel, dialogs). Without this, the
+  // panels' var(--tl-color-*) references don't resolve and they
+  // fall back to defaults. tldraw applies its own theme class
+  // inside its container, so the canvas itself still respects
+  // tldraw's mode toggle. (#180)
+  const isDark = useValue('isDark', () => editor?.user.getIsDarkMode() ?? false, [editor])
+  const themeClass = isDark ? 'tl-theme__dark' : 'tl-theme__light'
+
   return (
     <ShellContext.Provider value={shellState}>
       <>
-        <div style={{ position: 'fixed', inset: 0, display: 'flex' }}>
+        <div className={themeClass} style={{ position: 'fixed', inset: 0, display: 'flex' }}>
           {catalog === 'sidebar' && (
             <Sidebar
               onClose={() => setCatalog('closed')}


### PR DESCRIPTION
## Summary

Fixes a regression Ven flagged on PR #188 verification: chip palette followed tldraw mode after #180, but the catalog Sidebar, LibraryPanel, SaveDialog, SelectedShapePanel, ParamForm, and ConnectionIndicator still hardcoded `#1e1e2e` / `#cdd6f4` / etc., so they read as dark chrome on a light canvas.

This is part of #180's success criterion — "shell affordances are visually coherent with tldraw's own chrome" — that the chips-only first pass underscoped. Filing as a fix on the same parent epic (#179).

Closes #180.

## Changes

**1. Migrate the rest of the shell to var(--tl-color-\*).** Same token mapping as the chip pass, applied across:

- `src/catalog/{Sidebar,FullPage,ShapeCard}.tsx`
- `src/library/{LibraryPanel,SaveDialog}.tsx`
- `src/shape-panel/{SelectedShapePanel,ParamForm}.tsx`
- `src/App.tsx` — ConnectionIndicator only. TokenGate stays hardcoded since tldraw isn't mounted on the pre-auth screen, so var() refs would fall back to defaults.

| Hardcoded value | Token |
|---|---|
| `#1e1e2e` | `var(--tl-color-panel)` |
| `#181825` | `var(--tl-color-background)` |
| `#cdd6f4` | `var(--tl-color-text)` |
| `#7f849c` / `#6c7086` | `var(--tl-color-text-3)` |
| `#89b4fa` | `var(--tl-color-selected)` |
| `#f9e2af` | `var(--tl-color-warning)` |
| `rgba(69,71,90,0.6)` (border) | `var(--tl-color-divider)` |
| `rgba(30,30,46,0.85)` (chip bg) | `var(--tl-color-panel-overlay)` |
| `rgba(137,180,250,0.12-0.18)` (active highlight) | `var(--tl-color-muted-1)` |
| `rgba(17,17,27,0.95)` (FullPage backdrop) | `var(--tl-color-panel-overlay)` |

**2. Apply tldraw's theme class to the AppShell wrapper.** Subtle bug: the panels are siblings of `<Tldraw>`, not descendants, so without an ancestor carrying `.tl-theme__light` or `.tl-theme__dark`, the `var(--tl-color-*)` references fall back to initial values. The wrapper now subscribes to `editor.user.getIsDarkMode()` via tldraw's `useValue` and applies the matching theme class. tldraw's own container still applies its class for the canvas subtree, so the toggle still works for tldraw chrome.

## Test plan

- [x] `npm run build` clean (vite worker + client both pass).
- [ ] **Hosted-deploy visual check:** open https://vade-app.dev — Sidebar, LibraryPanel, SelectedShapePanel, SaveDialog all read as light chrome on a light canvas. Open the catalog (CATALOG chip) → sidebar slides in light, not dark. Open the canvas library (Canvas: chip) → right panel light. Drop a shape → SelectedShapePanel light.
- [ ] **Mode-switch check (optional):** if user toggles dark mode in tldraw's preferences, panels follow. The wrapper subscribes to `getIsDarkMode()` reactively.
- [ ] iPad PWA install: same checks.

## Out of scope

- TokenGate (pre-auth) and the active-status status colors stay hardcoded. The pre-auth screen has no tldraw mounted; the status indicator colors are intentional palette (red=offline, etc.).
- The remaining sub-issues of #179: #182 chrome integration, #186 sign-out affordance.

## References

- Parent epic: #179
- Predecessor merged this session: #188 (#180 chips + #184 typography). This PR closes the underscoped portion of #180 by extending the migration to non-chip panels.
- Chrome wrapper precedent: tldraw applies `.tl-theme__light/dark` to its own container; this PR mirrors that on the AppShell wrapper for non-tldraw-descendant panels.

https://claude.ai/code/session_01JNbNdxXHkP1avVeoTBmGUp