### PR TITLE
feat(shell): grayer panel tone + sign-out menu item (#186)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,21 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { type TLUiComponents } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
+import { MainMenu } from './components/MainMenu'
 import { TopRightSlot } from './components/TopRightSlot'
 import { createVadeAssetStore } from './assets/vade-asset-store'
 import { AppShell } from './shell/AppShell'
+import { AuthContext } from './shell/AuthContext'
 import { fontMono, size } from './shell/typography'
 
 // Inject TopRightSlot into tldraw's top-right SharePanel slot so the
 // chips render inside tldraw's chrome and can't collide with Main Menu
 // popovers or the style panel. TopRightSlot composes the Catalog and
-// Library toggles.
+// Library toggles. MainMenu adds a Sign-out item to tldraw's default
+// menu (#186).
 const tldrawComponents: TLUiComponents = {
   SharePanel: TopRightSlot,
+  MainMenu,
 }
 
 const TOKEN_STORAGE_KEY = 'vade-auth-token'
@@ -208,7 +212,7 @@ export default function App() {
   }
 
   return (
-    <>
+    <AuthContext.Provider value={{ signOut: clearToken }}>
       <AppShell
         assetStore={assetStore}
         licenseKey={import.meta.env.VITE_TLDRAW_LICENSE_KEY}
@@ -218,6 +222,6 @@ export default function App() {
         }}
       />
       <ConnectionIndicator bridge={bridge} onClearToken={clearToken} />
-    </>
+    </AuthContext.Provider>
   )
 }

--- a/src/catalog/Sidebar.tsx
+++ b/src/catalog/Sidebar.tsx
@@ -75,7 +75,7 @@ export function Sidebar({ onClose, onExpand }: SidebarProps) {
       style={{
         width: 220,
         flexShrink: 0,
-        background: 'var(--tl-color-panel)',
+        background: 'var(--tl-color-low)',
         color: 'var(--tl-color-text)',
         borderRight: '1px solid var(--tl-color-divider)',
         display: 'flex',

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,0 +1,58 @@
+import type { FC, ReactNode } from 'react'
+import {
+  DefaultMainMenu,
+  DefaultMainMenuContent,
+  TldrawUiMenuGroup as _TldrawUiMenuGroup,
+  TldrawUiMenuItem as _TldrawUiMenuItem,
+} from 'tldraw'
+import { useAuth } from '../shell/AuthContext'
+
+// React 18's ReactNode doesn't include bigint; tldraw's components
+// are typed against a newer React whose ReactNode does. Cast through
+// unknown so the JSX type-check passes; runtime contract is unchanged.
+const TldrawUiMenuGroup = _TldrawUiMenuGroup as unknown as FC<{
+  id: string
+  children?: ReactNode
+}>
+const TldrawUiMenuItem = _TldrawUiMenuItem as unknown as FC<{
+  id: string
+  label: string
+  icon?: string
+  readonlyOk?: boolean
+  onSelect: () => void
+}>
+
+// Custom MainMenu wrapping tldraw's default content + a VADE
+// auth group with a Sign-out item. Wired into tldrawComponents
+// in App.tsx. Closes vade-core#186.
+//
+// The Sign-out item triggers AuthContext.signOut() which clears
+// localStorage, disconnects the bridge, and returns the user to
+// the TokenGate. window.confirm gates the destructive action;
+// canvas autosave is continuous so unsaved-loss is bounded.
+export function MainMenu() {
+  const { signOut } = useAuth()
+
+  const handleSignOut = () => {
+    const ok = window.confirm(
+      "Sign out? You'll need to re-paste your operator token to return. " +
+      'Canvas changes are autosaved continuously.',
+    )
+    if (ok) signOut()
+  }
+
+  return (
+    <DefaultMainMenu>
+      <DefaultMainMenuContent />
+      <TldrawUiMenuGroup id="vade-auth">
+        <TldrawUiMenuItem
+          id="sign-out"
+          label="Sign out"
+          icon="exit"
+          readonlyOk
+          onSelect={handleSignOut}
+        />
+      </TldrawUiMenuGroup>
+    </DefaultMainMenu>
+  )
+}

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -222,7 +222,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
       style={{
         width: 260,
         flexShrink: 0,
-        background: 'var(--tl-color-panel)',
+        background: 'var(--tl-color-low)',
         color: 'var(--tl-color-text)',
         borderLeft: '1px solid var(--tl-color-divider)',
         display: 'flex',

--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -56,7 +56,7 @@ export function SaveDialog({
         style={{
           minWidth: 320,
           padding: 16,
-          background: 'var(--tl-color-panel)',
+          background: 'var(--tl-color-low)',
           color: 'var(--tl-color-text)',
           borderRadius: 12,
           border: '1px solid var(--tl-color-divider)',

--- a/src/shape-panel/SelectedShapePanel.tsx
+++ b/src/shape-panel/SelectedShapePanel.tsx
@@ -62,7 +62,7 @@ function SelectedShapePanelInner({ editor }: { editor: Editor }) {
         right: 12,
         width: 240,
         zIndex: 1500,
-        background: 'var(--tl-color-panel)',
+        background: 'var(--tl-color-low)',
         color: 'var(--tl-color-text)',
         border: '1px solid var(--tl-color-divider)',
         borderRadius: 10,

--- a/src/shell/AuthContext.ts
+++ b/src/shell/AuthContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react'
+
+// Auth surface exposed to tldraw chrome components (MainMenu, etc.).
+// App.tsx provides the value; consumers call signOut() from a menu
+// item or button without needing to know about token storage or the
+// bridge connection.
+export interface AuthContextValue {
+  signOut: () => void
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error('useAuth must be used inside an AuthContext.Provider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary

Two follow-ups Ven asked for after browser-verifying PR #189:

1. **Panels go grayer.** Swap `var(--tl-color-panel)` (≈ white in light mode) for `var(--tl-color-low)` (≈ `hsl(204, 16%, 94%)` — the lightly grayish tone tldraw uses for menu zones, button-low, navigation panel chrome). Catalog Sidebar, LibraryPanel, SelectedShapePanel, SaveDialog all migrate. Now reads as part of tldraw's chrome, not as foreign white surfaces against the canvas.

2. **Sign-out menu item.** Custom MainMenu wraps tldraw's `DefaultMainMenuContent` and appends a `vade-auth` group with a "Sign out" item. Closes #186 via Option 1 from the sub-issue body (SDK-conventional spot, top-left hamburger, high discoverability).

Closes #186. Refs #179.

## Implementation

**Panel tone:**
- `src/catalog/Sidebar.tsx`, `src/library/LibraryPanel.tsx`, `src/library/SaveDialog.tsx`, `src/shape-panel/SelectedShapePanel.tsx` — `'var(--tl-color-panel)'` → `'var(--tl-color-low)'` (replace_all).

**Sign-out wiring:**
- `src/shell/AuthContext.ts` — new context with `{ signOut: () => void }`. `useAuth()` hook for consumers.
- `src/components/MainMenu.tsx` — new. Wraps `DefaultMainMenu` + `DefaultMainMenuContent`; appends `<TldrawUiMenuGroup id="vade-auth">` containing `<TldrawUiMenuItem id="sign-out" label="Sign out" icon="exit" onSelect={…} />`. Action calls `useAuth().signOut()` after a `window.confirm` prompt.
- `src/App.tsx` — wraps the render tree in `<AuthContext.Provider value={{ signOut: clearToken }}>`; adds `MainMenu` to the `tldrawComponents` slot. `clearToken` already existed (localStorage purge + bridge disconnect + setToken(null)) — sign-out is a new trigger for it, not new logic.

**Type quirk:** tldraw's `TldrawUiMenuGroup` and `TldrawUiMenuItem` are typed against a React whose `ReactNode` includes `bigint`; React 18 in this project doesn't. Cast through `unknown` to a typed `FC<…>` alias to satisfy JSX type-check. Runtime contract unchanged. Comment in `MainMenu.tsx` explains.

## Test plan

- [x] `npm run build` clean (vite worker + client both pass).
- [ ] **Hosted-deploy visual check:** open https://vade-app.dev — Sidebar / LibraryPanel / SelectedShapePanel / SaveDialog now read as the same lightly grayish tone as tldraw's own toolbar/style-panel chrome (no longer near-white).
- [ ] **Sign-out flow:** open the top-left hamburger menu → "Sign out" appears at the bottom (in the new `vade-auth` group). Click → confirm prompt → returns to TokenGate. localStorage `vade-auth-token` is cleared. After re-paste, canvas content reappears (autosaved).
- [ ] iPad PWA install: same checks; no manual cache clear needed.

## Out of scope

- One sub-issue of #179 remains: #182 (chrome integration / TopPanel slot move). Independent of this PR.

## References

- Parent epic: #179
- Sub-issue closed: #186 (sign-out affordance) via Option 1 from the issue body.
- Predecessor merged this session: #185 (#181 retire), #187 (#183 push), #188 (#180 chips + #184 typography), #189 (panel-theme fix).
- Token reference: `--tl-color-low` is the surface tldraw uses for `tlui-button__low`, `tlui-menu-zone` open-state backdrop, and navigation-panel-a11y border.

https://claude.ai/code/session_01JNbNdxXHkP1avVeoTBmGUp