### PR TITLE
feat(deploy): add env.preview block for per-PR canvas previews (refs #168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,21 @@ Two independent deploy targets, both driven off `main`:
 **Canvas SPA + library API** — Cloudflare Worker (`wrangler.jsonc`).
 The Worker serves Vite-built assets from `dist/client/` and owns the
 bearer-gated `/library/*` route, which reads/writes R2 (`LIBRARY_R2`)
-and D1 (`vade_library`). Deploys are triggered by Cloudflare's Git
-integration on push to `main`. `routes` attaches both `vade-app.dev`
-and `www.vade-app.dev` as `custom_domain` routes.
+and D1 (`vade_library`). Production deploys are triggered by
+Cloudflare's Git integration on push to `main`. `routes` attaches
+both `vade-app.dev` and `www.vade-app.dev` as `custom_domain` routes.
+
+A second `vade-core-preview` Worker (`wrangler.jsonc → env.preview`)
+serves per-PR builds at `pr-<N>.preview.vade-app.dev`. Cloudflare
+Workers Builds runs `wrangler deploy --env preview` on non-`main`
+pushes; the most recent preview push wins (single Worker — only one
+PR previewable at a time). Library bindings are deliberately omitted
+from the preview env, so `/library/*` fails loudly there until a
+follow-up provisions a separate `vade-library-preview` bucket / D1.
+Topology rationale: see issue #168 (subdomain over path-prefix to
+keep prod SPA state isolated from preview builds). Manual one-time
+provisioning lives in [docs/auth.md](docs/auth.md) → "Preview
+deployments".
 
 **MCP server** — Fly.io app `vade-mcp` at `mcp.vade-app.dev`
 (`Dockerfile` + `fly.toml`). The container runs the SSE MCP transport

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -217,6 +217,65 @@ echo "$NEW" | wrangler secret put LIBRARY_BEARER
 Both restart on secret change; brief library-API downtime is
 expected (~15s on Fly side).
 
+## Preview deployments
+
+The `vade-core-preview` Worker (one Worker, multiple subdomains via
+the `*.preview.vade-app.dev/*` wildcard route) carries its own
+secret slots, separate from the production `vade-core` Worker by
+virtue of distinct Worker names. **Use distinct token values** —
+sharing the prod operator token with preview widens the blast
+radius of a leaked preview build.
+
+```sh
+# Provision preview-only operator token (runs once, before first
+# preview deploy lands).
+PREVIEW_OPERATOR=$(openssl rand -hex 32)
+echo "{\"operator\":[\"$PREVIEW_OPERATOR\"],\"agents\":[]}" | \
+  wrangler secret put OPERATOR_TOKENS --env preview
+
+# Library bearer is unused on the preview Worker today (no R2 / D1
+# bindings under env.preview in wrangler.jsonc). When stateful
+# previews land, set a preview-only LIBRARY_BEARER on a separate
+# preview bucket + D1.
+```
+
+### One-time Cloudflare-side setup
+
+Done in the Cloudflare dashboard (Worker / DNS / Builds settings),
+not via `wrangler`:
+
+1. **Wildcard DNS.** Zone `vade-app.dev` → DNS → add a CNAME or
+   A record `*.preview` proxied (orange cloud). Universal SSL
+   covers `*.preview.vade-app.dev` provided the plan supports
+   wildcard certs.
+2. **Workers Builds production lock.** Workers & Pages →
+   `vade-core` → Settings → Builds → set production-branch to
+   `main` only. Without this, every PR-branch push redeploys
+   production (the bug that surfaced in #167).
+3. **Workers Builds preview env.** On the same `vade-core` build
+   config, enable preview deployments for non-production branches
+   with the build command `wrangler deploy --env preview`.
+   Cloudflare provisions the `vade-core-preview` Worker on first
+   preview run.
+4. **Preview Worker secrets.** Once `vade-core-preview` exists in
+   the dashboard, set its operator token via
+   `wrangler secret put OPERATOR_TOKENS --env preview` (separate
+   value from production, per above).
+
+### Verifying
+
+After the preview Worker is live:
+
+```sh
+curl -fsS "https://pr-<N>.preview.vade-app.dev/" -o /dev/null -w "%{http_code}\n"   # → 200 (SPA shell)
+curl -sS  "https://pr-<N>.preview.vade-app.dev/library/canvases" -o /dev/null -w "%{http_code}\n"   # → 500 (no R2 binding; expected)
+```
+
+The preview Worker is "demo the UI" only until `/library/*` is
+unwired with a separate bucket + database. Pasting the
+`PREVIEW_OPERATOR` token into the preview SPA gates past the
+TokenGate; canvas pan/zoom/shape-creation work; save/load fail.
+
 ## Threat model (M1)
 
 In-scope:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -38,7 +38,38 @@
 			"database_id": "9a3ff295-d190-40a5-be3b-1f2af0111d1d",
 			"remote": true
 		}
-	]
+	],
+	// Preview environment for per-PR canvas builds.
+	//
+	// Topology — vade-core#168 recommended path: subdomain-per-PR. A single
+	// `vade-core-preview` Worker is bound to `*.preview.vade-app.dev/*`;
+	// Cloudflare Workers Builds runs `wrangler deploy --env preview` on
+	// non-`main` pushes. The most recent preview push wins (latest PR's
+	// bundle overwrites the Worker); only one PR can be previewed at a
+	// time. Sufficient for M1; revisit if parallel-PR preview is needed.
+	//
+	// Library bindings (R2 / D1) are deliberately omitted from the preview
+	// env. The preview Worker has no library access — `/library/*` fails
+	// loudly. Cleanest isolation pre-provisioning a `vade-library-preview`
+	// bucket + D1; tracked as follow-up if stateful previews are wanted.
+	//
+	// Operator + library secrets live on the preview Worker name (separate
+	// from production secrets by virtue of separate Worker name). See
+	// docs/auth.md → "Preview deployments".
+	"env": {
+		"preview": {
+			"name": "vade-core-preview",
+			"routes": [
+				{
+					"pattern": "*.preview.vade-app.dev/*",
+					"zone_name": "vade-app.dev"
+				}
+			],
+			"observability": {
+				"enabled": true
+			}
+		}
+	}
 	// Secrets (set via `wrangler secret put <NAME>`; not in this file):
 	//   LIBRARY_BEARER   — service-to-service secret shared with the Fly
 	//                      MCP container (`VADE_LIBRARY_BEARER`).
@@ -48,4 +79,7 @@
 	//                      /library/*, which is what the SPA CanvasSwitcher
 	//                      uses to talk to the library without a live MCP
 	//                      session. See docs/auth.md.
+	// Preview Worker (`vade-core-preview`) carries its own copies of these
+	// secrets. Use distinct values from production — separate bucket of
+	// blast-radius even though library access is currently unwired there.
 }


### PR DESCRIPTION
## Summary

Adds the `env.preview` block to `wrangler.jsonc` so per-PR canvas builds can deploy to a stable subdomain. Implements [vade-core#168](https://github.com/vade-app/vade-core/issues/168)'s recommended subdomain-per-PR topology.

The path-prefix pattern (`vade-app.dev/dev/pr-N/`) we use for the website wasn't transferable here: the website is static HTML, the canvas is a SPA with localStorage operator token + tldraw IndexedDB. Same-origin path-prefix would cross-bleed prod and preview state. Subdomain (`pr-N.preview.vade-app.dev`) gets origin isolation for free.

## Code changes

- **`wrangler.jsonc`** — new `env.preview` block: `name: "vade-core-preview"`, route `*.preview.vade-app.dev/*` (pattern + zone_name, since wildcards can't use `custom_domain: true`). `observability.enabled: true`. Library bindings (R2 / D1) deliberately omitted — `/library/*` will fail on the preview Worker until a follow-up provisions a separate `vade-library-preview` bucket + database. Worker bundle, assets, compatibility flags inherit from the top level.
- **`README.md`** — Deploy section describes the two-Worker topology and points at `docs/auth.md` for one-time setup.
- **`docs/auth.md`** — new "Preview deployments" section with: preview-only operator-token provisioning command, the four manual Cloudflare-side steps (wildcard DNS, prod-deploy lock, Workers Builds preview env, preview Worker secrets), and a `curl` verification recipe.

Validated: `npx wrangler types --env preview --config wrangler.jsonc` parses clean; `tsc -b`, `typecheck:worker`, `typecheck:mcp` all green.

## Manual steps for the BDFL

These can't be done from this repo or via `wrangler` alone — they need Cloudflare-dashboard access:

- [ ] **Wildcard DNS.** Cloudflare → `vade-app.dev` zone → DNS → add `*.preview` CNAME (or A) record, **proxied** (orange cloud). Verify Universal SSL covers `*.preview.vade-app.dev` (depends on the plan; Free covers a single-level wildcard).
- [ ] **Lock production deploys.** Cloudflare → Workers & Pages → `vade-core` → Settings → Builds → set production branch to `main` only. Without this, every PR-branch push redeploys *production* — the regression that surfaced in #167. **Do this before merging this PR.**
- [ ] **Enable preview deployments.** Same Builds config → enable preview deployments for non-production branches with build command `wrangler deploy --env preview`. Cloudflare provisions `vade-core-preview` on first preview run.
- [ ] **Provision preview operator token.** After the preview Worker exists:
  ```sh
  PREVIEW_OPERATOR=$(openssl rand -hex 32)
  echo "{\"operator\":[\"$PREVIEW_OPERATOR\"],\"agents\":[]}" | \
    wrangler secret put OPERATOR_TOKENS --env preview
  ```
  Use a value distinct from the production operator token. Save to 1Password.

## Verification

After the manual steps land, push any non-`main` branch and confirm:

```sh
curl -fsS "https://pr-<N>.preview.vade-app.dev/" -o /dev/null -w "%{http_code}\n"
# → 200 (SPA shell)
curl -sS  "https://pr-<N>.preview.vade-app.dev/library/canvases" -o /dev/null -w "%{http_code}\n"
# → 500 (no R2 binding; expected — library is unwired on preview)
```

Pasting the preview operator token into the SPA gates past `TokenGate`; canvas pan/zoom/shape-creation works; library save/load fail (expected).

## M1 trade-offs (worth being honest about)

- **Latest-wins.** Single preview Worker means only one PR is previewable at a time — most recent push to any non-main branch overwrites the preview. Sufficient for current cadence (1–2 active PRs); revisit if parallel-PR preview becomes useful.
- **Preview library is unwired.** Save/load will 500 on previews until follow-up issue provisions `vade-library-preview` R2 + D1 + migrations. Acceptable for "demo the UI" use case; not acceptable if previews need to round-trip canvas state.
- **Stale-preview GC.** Latest-wins is itself the GC mechanism — no per-PR Workers accumulate. When all PRs close, the preview Worker just holds the last bundle; no clean-up step needed.

Refs #168.

https://claude.ai/code/session_01TsJ55w6B64BMmGWKBaK64o

Closes: n/a — partial implementation of #168 (code/docs side); manual Cloudflare-dashboard steps remain, so #168 stays open until the four checklist items above are done and the acceptance criteria fully tick.