### PR TITLE
fix(shell): canvas-UI polish — MCP dot, stable Canvas label, lighter SaveDialog backdrop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { type TLUiComponents } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { VadeBridge, type BridgeStatus } from './bridge/ws-client'
@@ -8,16 +8,6 @@ import { createVadeAssetStore } from './assets/vade-asset-store'
 import { AppShell } from './shell/AppShell'
 import { AuthContext } from './shell/AuthContext'
 import { fontMono, size } from './shell/typography'
-
-// Custom MenuPanel hosts tldraw's default top-left menu group plus
-// the Catalog and Canvas (Library) toggles, so VADE's two primary
-// navigations read as first-class chrome (vade-core#182). MainMenu
-// adds a Sign-out item to tldraw's default menu (#186); it resolves
-// through the components context inside DefaultMenuPanel.
-const tldrawComponents: TLUiComponents = {
-  MenuPanel,
-  MainMenu,
-}
 
 const TOKEN_STORAGE_KEY = 'vade-auth-token'
 
@@ -35,6 +25,11 @@ function readStoredToken(): string | null {
 
 const COMMIT_SHA = import.meta.env.VITE_COMMIT_SHA
 
+// Status dot rendered into tldraw's SharePanel slot (top-right). Was
+// previously a fixed-position pill at bottom-right that overlapped
+// tldraw's StylePanel (canvas-ui skill landmine 6). Compresses to a
+// 10px dot; the BridgeStatus label and commit SHA move to the title
+// hover. Click-to-reauth is preserved when status is 'unauthorized'.
 function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onClearToken: () => void }) {
   const [status, setStatus] = useState<BridgeStatus>('disconnected')
 
@@ -51,50 +46,42 @@ function ConnectionIndicator({ bridge, onClearToken }: { bridge: VadeBridge; onC
   }
 
   const labels: Record<BridgeStatus, string> = {
-    connected: 'MCP',
-    connecting: 'connecting...',
-    disconnected: 'offline',
-    'no-bridge': 'no bridge',
-    unauthorized: 'bad token',
+    connected: 'MCP connected',
+    connecting: 'MCP connecting…',
+    disconnected: 'MCP offline',
+    'no-bridge': 'MCP: no bridge',
+    unauthorized: 'MCP: bad token (click to re-enter)',
   }
 
   const interactive = status === 'unauthorized'
+  const titleParts = [labels[status]]
+  if (COMMIT_SHA && COMMIT_SHA !== 'dev') titleParts.push(COMMIT_SHA)
 
   return (
     <div
-      onClick={interactive ? onClearToken : undefined}
       style={{
-        position: 'fixed',
-        bottom: 12,
-        right: 12,
-        zIndex: 1000,
         display: 'flex',
         alignItems: 'center',
-        gap: 6,
-        padding: '4px 10px',
-        borderRadius: 12,
-        background: 'var(--tl-color-panel-overlay)',
-        color: colors[status],
-        fontSize: size.sm,
-        fontFamily: fontMono,
-        pointerEvents: interactive ? 'auto' : 'none',
-        cursor: interactive ? 'pointer' : 'default',
-        backdropFilter: 'blur(8px)',
+        padding: '0 8px',
+        pointerEvents: 'all',
       }}
-      title={interactive ? 'Click to re-enter token' : undefined}
     >
-      <div
+      <button
+        type="button"
+        onClick={interactive ? onClearToken : undefined}
+        aria-label={labels[status]}
+        title={titleParts.join(' · ')}
+        disabled={!interactive}
         style={{
-          width: 6,
-          height: 6,
+          width: 10,
+          height: 10,
           borderRadius: '50%',
           background: colors[status],
+          border: 'none',
+          padding: 0,
+          cursor: interactive ? 'pointer' : 'default',
         }}
       />
-      {labels[status]}
-      {COMMIT_SHA && COMMIT_SHA !== 'dev' && (
-        <span style={{ color: '#6c7086' }}>· {COMMIT_SHA}</span>
-      )}
     </div>
   )
 }
@@ -186,6 +173,31 @@ export default function App() {
   // devices instead of dangling at the source device's local IndexedDB.
   const assetStore = useMemo(() => createVadeAssetStore(), [])
 
+  const clearToken = useCallback(() => {
+    try {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+    bridge.disconnect()
+    setToken(null)
+  }, [bridge])
+
+  // Custom MenuPanel hosts tldraw's default top-left menu group plus
+  // the Catalog and Canvas toggles (vade-core#182). MainMenu adds a
+  // Sign-out item to tldraw's default menu (#186). SharePanel hosts
+  // the connection-status dot in the top-right slot — moved off the
+  // bottom-right floating-pill spot that overlapped tldraw's
+  // StylePanel.
+  const tldrawComponents = useMemo<TLUiComponents>(
+    () => ({
+      MenuPanel,
+      MainMenu,
+      SharePanel: () => <ConnectionIndicator bridge={bridge} onClearToken={clearToken} />,
+    }),
+    [bridge, clearToken],
+  )
+
   if (requiresAuth && !token) {
     return (
       <TokenGate
@@ -201,16 +213,6 @@ export default function App() {
     )
   }
 
-  const clearToken = () => {
-    try {
-      window.localStorage.removeItem(TOKEN_STORAGE_KEY)
-    } catch {
-      // ignore
-    }
-    bridge.disconnect()
-    setToken(null)
-  }
-
   return (
     <AuthContext.Provider value={{ signOut: clearToken }}>
       <AppShell
@@ -221,7 +223,6 @@ export default function App() {
           bridgeRef.current.connect(editor)
         }}
       />
-      <ConnectionIndicator bridge={bridge} onClearToken={clearToken} />
     </AuthContext.Provider>
   )
 }

--- a/src/components/MenuPanel.tsx
+++ b/src/components/MenuPanel.tsx
@@ -16,11 +16,16 @@ const TldrawUiButton = _TldrawUiButton as unknown as FC<{
 const TldrawUiButtonLabel = _TldrawUiButtonLabel as unknown as FC<{ children?: ReactNode }>
 
 // Custom MenuPanel: tldraw's default top-left menu group (MainMenu +
-// PageMenu) with Catalog + Canvas (Library) toggles appended as
-// TldrawUiButton siblings, so VADE's two primary navigations read as
-// first-class chrome rather than auxiliary chips floating in the
-// SharePanel slot. Wired into tldrawComponents in App.tsx. Closes
-// vade-core#182 (Epic #179 §c).
+// PageMenu) with Catalog + Canvas toggles as discrete chrome buttons,
+// followed by a non-button readout of the active canvas name + dirty
+// indicator. A 1px divider separates the DefaultMenuPanel from the
+// VADE toggles so the three regions read as distinct.
+//
+// The Canvas toggle's label is fixed ('Canvas') — the active canvas
+// name is a separate readout, not the button label. (Earlier shape
+// rendered the active name as the button text, which read as the
+// button being renamed; the readout makes the name a state display
+// adjacent to a stable control.)
 //
 // DefaultMenuPanel resolves its inner MainMenu through the components
 // context, so our custom MainMenu (which adds the Sign-out item per
@@ -33,6 +38,7 @@ export function MenuPanel() {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 4, pointerEvents: 'all' }}>
       <DefaultMenuPanel />
+      <Divider />
       <TldrawUiButton
         type="menu"
         isActive={catalogOpen}
@@ -47,35 +53,62 @@ export function MenuPanel() {
         onClick={() => setLibrary(libraryOpen ? 'closed' : 'open')}
         title={libraryOpen ? 'Close library' : 'Open library (canvases + snapshots)'}
       >
-        <TldrawUiButtonLabel>
-          <span
-            style={{
-              display: 'inline-block',
-              maxWidth: 160,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              verticalAlign: 'bottom',
-            }}
-          >
-            {activeName ?? 'Canvas'}
-          </span>
-          {dirty && (
-            <span
-              aria-label="unsaved changes"
-              style={{
-                display: 'inline-block',
-                width: 6,
-                height: 6,
-                marginLeft: 6,
-                borderRadius: '50%',
-                background: 'var(--tl-color-warning)',
-                verticalAlign: 'middle',
-              }}
-            />
-          )}
-        </TldrawUiButtonLabel>
+        <TldrawUiButtonLabel>Canvas</TldrawUiButtonLabel>
       </TldrawUiButton>
+      {activeName && (
+        <>
+          <Divider />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '0 8px',
+              color: 'var(--tl-color-text-3)',
+              fontSize: 12,
+              maxWidth: 200,
+            }}
+            title={dirty ? `${activeName} (unsaved changes)` : activeName}
+          >
+            <span
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {activeName}
+            </span>
+            {dirty && (
+              <span
+                aria-label="unsaved changes"
+                style={{
+                  flexShrink: 0,
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  background: 'var(--tl-color-warning)',
+                }}
+              />
+            )}
+          </div>
+        </>
+      )}
     </div>
+  )
+}
+
+function Divider() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        width: 1,
+        height: 18,
+        margin: '0 4px',
+        background: 'var(--tl-color-divider)',
+        flexShrink: 0,
+      }}
+    />
   )
 }

--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -44,7 +44,7 @@ export function SaveDialog({
       style={{
         position: 'fixed',
         inset: 0,
-        background: 'rgba(0, 0, 0, 0.35)',
+        background: 'rgba(0, 0, 0, 0.15)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',


### PR DESCRIPTION
Closes: n/a

Three small canvas-UI fixes Ven flagged from a live iPad session:

1. **MCP indicator collided with tldraw StylePanel** — the bottom-right `position: fixed` pill sat on top of tldraw's stock chrome (canvas-ui skill landmine 6). Render through the `SharePanel` `TLUiComponents` slot so tldraw lays it out in the top-right chrome region. Compress to a 10px dot; status label + commit SHA move to title hover. Click-to-reauth preserved on `unauthorized`.

2. **Canvas toggle was being renamed to the active canvas name** — `<TldrawUiButtonLabel>{activeName ?? 'Canvas'}</TldrawUiButtonLabel>` made the toggle read as e.g. "coo-8-play". Restore stable "Canvas" label; surface the active canvas name as a separate non-button readout to the right. Add 1px vertical dividers between DefaultMenuPanel / Catalog / Canvas / readout so the regions read as discrete chrome rather than free-floating text.

3. **SaveDialog backdrop too dim** — `rgba(0,0,0,0.35)` made the library panel hard to read while a dialog was open. Drop to `0.15`.

## Test plan

- [ ] Verify on vade-app.dev that the MCP dot sits cleanly in the top-right SharePanel slot and doesn't overlap StylePanel when shapes are selected
- [ ] Hover the dot — title shows `MCP connected · <commit-sha>`
- [ ] Force `unauthorized` (e.g. invalid token) and confirm dot is still clickable to re-enter token
- [ ] Open Catalog + Library toggles; confirm "Canvas" label is stable and active-canvas-name readout updates correctly
- [ ] Open SaveDialog (Save…/+ New/Branch) and confirm library panel content stays legible behind the dim
- [ ] Build: `npm run build` clean (10s)

## Notes

- Browsing the canvas was not possible from this cloud session; verification is the build + diff. Visual confirmation needed on the device that surfaced the issue.
- Tangential: SaveDialog portals to document.body but does not call `editor.focus()` on close (canvas-ui skill landmine 5). Filing a separate issue rather than fixing inline.

https://claude.ai/code/session_01NP766mFZNdAHcDSkNmrPcB