### PR TITLE
fix(library): refocus editor after dialog close + loadSnapshot

### DIFF
--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -96,6 +96,22 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
     [canvases],
   )
 
+  const [pendingBranchSnap, setPendingBranchSnap] = useState<string | null>(null)
+
+  // Close a dialog and return keyboard focus to the editor. SaveDialog
+  // portals to document.body so the dialog steals focus while open;
+  // tldraw's keyboard shortcuts (H, V, etc.) and wheel/pan stop firing
+  // until the editor regains focus. Likewise loadSnapshot restores the
+  // saved instance record carrying isFocused=false. Both failure paths
+  // are canvas-ui skill landmine 5; this helper is the canonical close
+  // for dialog-flow paths, and standalone loadSnapshot call sites
+  // (onLoad, onRestore) call editor.focus() inline. (#195)
+  const closeDialog = useCallback(() => {
+    setDialog(null)
+    setPendingBranchSnap(null)
+    editor.focus()
+  }, [editor])
+
   const onLoad = async (meta: CanvasMeta) => {
     setError(null)
     try {
@@ -106,6 +122,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
         return
       }
       loadSnapshot(editor.store, result.snapshot as Parameters<typeof loadSnapshot>[1])
+      editor.focus()
       onActiveChange({ slug, name: meta.name })
     } catch (err) {
       setError(surface(err))
@@ -123,7 +140,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
       await saveCanvas(active.name, snapshot, [], '')
       await saveSnapshot(active.slug, label)
       await Promise.all([refreshCanvases(), refreshSnapshots()])
-      setDialog(null)
+      closeDialog()
     } catch (err) {
       setError(surface(err))
     } finally {
@@ -144,7 +161,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
         onActiveChange({ slug: newSlug, name: meta.name })
       }
       await refreshCanvases()
-      setDialog(null)
+      closeDialog()
     } catch (err) {
       setError(surface(err))
     } finally {
@@ -163,7 +180,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
       const slug = slugify(name)
       onActiveChange({ slug, name })
       await refreshCanvases()
-      setDialog(null)
+      closeDialog()
     } catch (err) {
       setError(surface(err))
     } finally {
@@ -181,20 +198,19 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
         return
       }
       loadSnapshot(editor.store, result.snapshot as Parameters<typeof loadSnapshot>[1])
+      editor.focus()
       await refreshCanvases()
     } catch (err) {
       setError(surface(err))
     }
   }
 
-  const [pendingBranchSnap, setPendingBranchSnap] = useState<string | null>(null)
-
   const handleDialogSubmit = (value: string) => {
     if (dialog === 'snapshot') return onSaveSnapshot(value)
-    if (dialog === 'new') return value ? onNewCanvas(value) : setDialog(null)
+    if (dialog === 'new') return value ? onNewCanvas(value) : closeDialog()
     if (dialog === 'branch') {
       if (!value) {
-        setDialog(null)
+        closeDialog()
         return
       }
       return onBranchFromSnapshot(pendingBranchSnap, value)
@@ -389,10 +405,7 @@ export function LibraryPanel({ editor, active, onActiveChange, onClose }: Librar
           title={dialogConfig.title}
           placeholder={dialogConfig.placeholder}
           busy={busy}
-          onCancel={() => {
-            setDialog(null)
-            setPendingBranchSnap(null)
-          }}
+          onCancel={closeDialog}
           onSubmit={handleDialogSubmit}
         />
       )}


### PR DESCRIPTION
Closes #195

LibraryPanel triggered both halves of canvas-ui skill landmine 5:

1. **Modal portal steals focus** — SaveDialog portals to \`document.body\` to escape tldraw's stacking context. While open it holds focus, so tldraw keyboard shortcuts (H, V, etc.) and wheel/pan stop firing until the editor regains focus.
2. **\`loadSnapshot\` restores \`isFocused=false\`** — the saved instance record's \`isFocused\` flag survives \`loadSnapshot\`, so even a successful canvas load leaves the editor unfocused.

## Fix

- \`closeDialog()\` helper does \`setDialog(null)\` + \`setPendingBranchSnap(null)\` + \`editor.focus()\`. Route every dialog-close path through it: the four success paths in \`onSaveSnapshot\` / \`onBranchFromSnapshot\` / \`onNewCanvas\`, the two empty-value branches in \`handleDialogSubmit\`, and SaveDialog's \`onCancel\`.
- For standalone \`loadSnapshot\` call sites (\`onLoad\`, \`onRestore\` — no dialog involved), call \`editor.focus()\` inline after the load. \`onBranchFromSnapshot\` already routes through \`closeDialog()\` at the end so it picks up the focus there.

## Test plan

- [ ] Open the canvas, click a canvas in the library list — keyboard shortcut (e.g. \`V\` for select) works without an extra canvas click first
- [ ] Click + New, fill the dialog, Save — \`V\` works after dialog closes
- [ ] Click Branch on a snapshot, fill the dialog, Save — \`V\` works after
- [ ] Cancel any dialog (ESC or backdrop click) — \`V\` works after
- [ ] Restore a snapshot from the snapshot list — \`V\` works without an extra canvas click
- [ ] Build: \`npm run build\` clean (9s)

## Worked example

Canvas-ui skill §"The seven landmines" §5; PR #68 is the prior fix in the same family.

https://claude.ai/code/session_01NP766mFZNdAHcDSkNmrPcB