### PR TITLE
fix(shell): theme class on documentElement so portaled dialogs aren't transparent

### DIFF
--- a/src/shell/AppShell.tsx
+++ b/src/shell/AppShell.tsx
@@ -131,6 +131,22 @@ export function AppShell({ assetStore, licenseKey, components, onMount }: AppShe
   const isDark = useValue('isDark', () => editor?.user.getIsDarkMode() ?? false, [editor])
   const themeClass = isDark ? 'tl-theme__dark' : 'tl-theme__light'
 
+  // Mirror the theme class onto documentElement so portaled UI
+  // (SaveDialog and any future portal surface) sees tldraw's
+  // var(--tl-color-*) CSS custom properties. The flex-wrapper class
+  // below covers in-tree panels (Sidebar, LibraryPanel, FullPage),
+  // but createPortal targets document.body — outside that wrapper —
+  // and without the theme class on an ancestor, every var(--tl-*)
+  // falls back to its initial value and the dialog body renders
+  // transparent. Reported on PR #194 verification.
+  useEffect(() => {
+    const html = document.documentElement
+    html.classList.add(themeClass)
+    return () => {
+      html.classList.remove(themeClass)
+    }
+  }, [themeClass])
+
   return (
     <ShellContext.Provider value={shellState}>
       <>


### PR DESCRIPTION
Closes: n/a

Ven reported on PR #194 verification: the SaveDialog backdrop dim was lightened correctly, but the dialog **box itself** was see-through — you could see canvas content (memo cards, connector lines) through the dialog body.

## Root cause

\`SaveDialog\` uses \`createPortal(..., document.body)\` to escape tldraw's stacking context. The portal lands outside AppShell's flex wrapper that carries the \`.tl-theme__light/dark\` class. Tldraw's color tokens are scoped to those classes:

\`\`\`css
.tl-theme__light {
  --tl-color-low: hsl(204, 16%, 94%);
  --tl-color-panel: hsl(0, 0%, 99%);
  ...
}
\`\`\`

Inside the portal, no ancestor has the class, so every \`var(--tl-color-*)\` reference resolves to its initial value and the dialog body renders transparent.

PR #189 wrapped in-tree siblings (Sidebar / LibraryPanel / FullPage) with the theme class. Portals were the unclosed gap.

## Fix

Apply the theme class to \`document.documentElement\` via \`useEffect\` in AppShell. Cleanup removes it on theme change so the next class lands cleanly.

\`\`\`tsx
useEffect(() => {
  const html = document.documentElement
  html.classList.add(themeClass)
  return () => { html.classList.remove(themeClass) }
}, [themeClass])
\`\`\`

The flex-wrapper class stays for in-tree panels; documentElement covers portals (current SaveDialog and any future portal surface).

## Test plan

- [ ] Light mode: open + New / Save… / Branch dialog — dialog body is opaque, no canvas bleed-through
- [ ] Dark mode: same — dialog body is opaque in dark theme tokens
- [ ] Toggle dark mode while a dialog is open — dialog body re-themes correctly
- [ ] Build: \`npm run build\` clean (6.5s)

https://claude.ai/code/session_01NP766mFZNdAHcDSkNmrPcB