### PR TITLE
fix(library): SaveDialog padding + dark-mode panel contrast

### DIFF
--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -55,8 +55,8 @@ export function SaveDialog({
         onClick={(e) => e.stopPropagation()}
         style={{
           minWidth: 320,
-          padding: 16,
-          background: 'var(--tl-color-low)',
+          padding: 20,
+          background: 'var(--tl-color-panel)',
           color: 'var(--tl-color-text)',
           borderRadius: 12,
           border: '1px solid var(--tl-color-divider)',


### PR DESCRIPTION
Closes: n/a

Two issues from PR #197 verification on iPad:

## 1. Input field touched the dialog edge

Bump dialog padding from \`16\` to \`20\` so the input has consistent breathing room to all four edges.

## 2. Dark-mode dialog body indistinguishable from background

In dark mode, the tldraw token values are:

| Token | Lightness |
|---|---|
| \`--tl-color-background\` | 6.5% |
| \`--tl-color-low\` | 10.5% (post-#190 dialog body) |
| \`--tl-color-panel\` | 13.5% |

A 4-point lift (low → bg) flattened the dialog into the canvas; the dialog read as a continuation of the canvas with only the input's blue focus ring giving any indication of a surface. Switch the body to \`--tl-color-panel\` for a 7-point lift, which combined with the existing \`box-shadow\` gives a clearly elevated surface in dark mode.

This effectively reverts the dialog body to its post-#189 background. #190's \`--tl-color-low\` was the right "grayer tone" for the LibraryPanel sidebar (persistent chrome where a lower-priority tone reads as background-like) but the wrong choice for a modal dialog (transient surface that needs to lift off whatever's behind it). In light mode the contrast drops from 4-point (bg L=98 vs low L=94) to 1-point (bg L=98 vs panel L=99), but the box-shadow does the elevation work there.

## Test plan

- [ ] Light mode: open + New / Save… / Branch — input has clear margin to all four edges; dialog reads as elevated via shadow even though the bg-vs-panel contrast is small
- [ ] Dark mode: same — dialog body is visibly lighter than the canvas background; dialog feels lifted, not flush
- [ ] Build: \`npm run build\` clean (12s)

https://claude.ai/code/session_01NP766mFZNdAHcDSkNmrPcB