### PR TITLE
fix(library): contain dialog input within parent padding

### DIFF
--- a/src/library/SaveDialog.tsx
+++ b/src/library/SaveDialog.tsx
@@ -78,12 +78,14 @@ export function SaveDialog({
           }}
           style={{
             width: '100%',
+            boxSizing: 'border-box',
             padding: '6px 8px',
             background: 'var(--tl-color-background)',
             border: '1px solid var(--tl-color-divider)',
             color: 'var(--tl-color-text)',
             borderRadius: 6,
             fontSize: size.lg,
+            outline: 'none',
           }}
         />
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>


### PR DESCRIPTION
Closes: n/a

Ven flagged on PR #198 verification: the text input still appeared to touch the dialog edges even after the padding bump from 16 to 20.

## Diagnosis

Two compounding causes:

1. **\`box-sizing\` mismatch.** tldraw resets to \`border-box\` only on its own \`.tl-container *\` subtree (tldraw.css:280-289). The portaled dialog lives outside that subtree and uses the default \`content-box\`. So \`width: 100%\` on the input sets only its content area to 100% of parent content width; its own 8px padding and 1px border extend OUTSIDE the 100%, eating ~9px from each side of the dialog's 20px padding margin. Effective gap was ~11px each side, not 20px.
2. **iOS Safari focus ring.** The default focus ring on a focused text input draws OUTSIDE the box and extends another 3-4px into the parent's padding, visually closing the gap to the dialog edge.

## Fix

\`\`\`diff
+ boxSizing: 'border-box',
  ...
+ outline: 'none',
\`\`\`

\`box-sizing: border-box\` makes \`width: 100%\` include the input's own padding+border, restoring the full 20px gap on each side. \`outline: none\` suppresses the iOS Safari outer focus ring.

## Focus indication trade-off

Without the browser's outer focus ring, focus is still indicated by:
- The cursor in the input
- The on-screen keyboard appearing on iPad
- The input's existing 1px border (\`var(--tl-color-divider)\`)

Acceptable for the dialog's narrow use case (a single text input that auto-focuses on open). If we later want a stronger focus indicator that doesn't break the layout, we'd add an inset \`box-shadow\` driven by React onFocus/onBlur state — out of scope here.

## Test plan

- [ ] Light mode: input has clear ~20px gap from dialog left/right edges
- [ ] Dark mode: same
- [ ] Type into the input — cursor and keyboard signal focus clearly
- [ ] Build: \`npm run build\` clean (12s)

https://claude.ai/code/session_01NP766mFZNdAHcDSkNmrPcB