### PR TITLE
deploy(preview): add deploy:preview script + ACM cert step (refs #168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,20 @@ both `vade-app.dev` and `www.vade-app.dev` as `custom_domain` routes.
 
 A second `vade-core-preview` Worker (`wrangler.jsonc → env.preview`)
 serves per-PR builds at `pr-<N>.preview.vade-app.dev`. Cloudflare
-Workers Builds runs `wrangler deploy --env preview` on non-`main`
-pushes; the most recent preview push wins (single Worker — only one
-PR previewable at a time). Library bindings are deliberately omitted
+Workers Builds runs `npm run deploy:preview` on non-`main` pushes;
+the most recent preview push wins (single Worker — only one PR
+previewable at a time). Library bindings are deliberately omitted
 from the preview env, so `/library/*` fails loudly there until a
 follow-up provisions a separate `vade-library-preview` bucket / D1.
+
+The `deploy:preview` script invokes `wrangler deploy --config
+wrangler.jsonc --env preview --assets ./dist/client` rather than the
+plain `wrangler deploy` used for production. The `--config` /
+`--assets` flags bypass the `@cloudflare/vite-plugin` build-time
+config redirect (which produces a per-build wrangler.json that
+doesn't preserve the `env.preview` block), so the source config's
+env override is honored.
+
 Topology rationale: see issue #168 (subdomain over path-prefix to
 keep prod SPA state isolated from preview builds). Manual one-time
 provisioning lives in [docs/auth.md](docs/auth.md) → "Preview

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -241,23 +241,34 @@ echo "{\"operator\":[\"$PREVIEW_OPERATOR\"],\"agents\":[]}" | \
 
 ### One-time Cloudflare-side setup
 
-Done in the Cloudflare dashboard (Worker / DNS / Builds settings),
-not via `wrangler`:
+Done in the Cloudflare dashboard (Worker / DNS / Builds /
+SSL-TLS settings), not via `wrangler`:
 
-1. **Wildcard DNS.** Zone `vade-app.dev` → DNS → add a CNAME or
-   A record `*.preview` proxied (orange cloud). Universal SSL
-   covers `*.preview.vade-app.dev` provided the plan supports
-   wildcard certs.
-2. **Workers Builds production lock.** Workers & Pages →
+1. **Wildcard DNS.** Zone `vade-app.dev` → DNS → add an AAAA
+   record `*.preview` pointing at `100::` (Cloudflare's proxied-
+   only placeholder), proxied (orange cloud).
+2. **Advanced Certificate Manager (ACM).** Zone → SSL/TLS →
+   Edge Certificates → "Order Advanced Certificate" with hosts
+   `*.preview.vade-app.dev` and `preview.vade-app.dev`,
+   validation method `txt`, validity 365d. Required because the
+   Free-plan Universal SSL only covers `vade-app.dev` and
+   `*.vade-app.dev` (one level); the two-level wildcard
+   `*.preview.vade-app.dev` is an ACM cert (paid). Without this,
+   any `https://pr-<N>.preview.vade-app.dev/` returns 503 with a
+   TLS-handshake error from Cloudflare's edge.
+3. **Workers Builds production lock.** Workers & Pages →
    `vade-core` → Settings → Builds → set production-branch to
    `main` only. Without this, every PR-branch push redeploys
    production (the bug that surfaced in #167).
-3. **Workers Builds preview env.** On the same `vade-core` build
-   config, enable preview deployments for non-production branches
-   with the build command `wrangler deploy --env preview`.
-   Cloudflare provisions the `vade-core-preview` Worker on first
-   preview run.
-4. **Preview Worker secrets.** Once `vade-core-preview` exists in
+4. **Workers Builds preview env.** On the same `vade-core` build
+   config, enable preview deployments for non-production
+   branches with the build command **`npm run deploy:preview`**.
+   Cloudflare provisions the `vade-core-preview` Worker on the
+   first preview run. (The script invokes
+   `wrangler deploy --config wrangler.jsonc --env preview
+   --assets ./dist/client`; see README "Deploy" for why the
+   `--config`/`--assets` overrides are required.)
+5. **Preview Worker secrets.** Once `vade-core-preview` exists in
    the dashboard, set its operator token via
    `wrangler secret put OPERATOR_TOKENS --env preview` (separate
    value from production, per above).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mcp:sse": "VADE_MCP_TRANSPORT=sse VADE_MCP_HTTP_PORT=8080 tsx mcp/index.ts",
     "dev:all": "concurrently \"npm run dev\" \"npm run mcp\"",
     "deploy": "npm run build && wrangler deploy",
+    "deploy:preview": "npm run build && wrangler deploy --config wrangler.jsonc --env preview --assets ./dist/client",
     "migrate-library": "tsx scripts/migrate-library.ts",
     "typecheck:worker": "tsc -p tsconfig.worker.json",
     "typecheck:mcp": "tsc -p tsconfig.mcp.build.json"


### PR DESCRIPTION
## Summary

Operationalising the preview topology from #193 surfaced two gaps that #193's "BDFL manual steps" checklist either hand-waved or missed entirely. Patching them in code/docs so the issue can actually close.

### 1. Vite-plugin strips `env.preview` from the built config

`@cloudflare/vite-plugin` produces `dist/vade_core/wrangler.json` at build time and uses a `.wrangler/deploy/config.json` redirect to point `wrangler deploy` at it. That redirected config drops the `env.preview` block — `wrangler deploy --env preview` from the project root falls back to the top-level (production) config and ships to the `vade-core` Worker instead of `vade-core-preview`.

Fix: explicit `npm run deploy:preview` script that invokes the source config:

```
wrangler deploy --config wrangler.jsonc --env preview --assets ./dist/client
```

The `--config` bypasses the Vite redirect; `--assets` overrides the source's top-level `./dist` to ship only the SPA. Workers Builds non-main branch build command should be set to `npm run deploy:preview`. README + docs/auth.md updated.

### 2. Free-plan Universal SSL doesn't cover the two-level wildcard

`*.preview.vade-app.dev` is two subdomain levels deep. Cloudflare Free's Universal SSL covers `vade-app.dev` + `*.vade-app.dev` (one level). Curl on `pr-test.preview.vade-app.dev/` returns 503 with `TLS_error: SSL routines:OPENSSL_internal:` — the Worker is healthy and route is bound, but edge has no cert.

Fix: explicit Advanced Certificate Manager (ACM) step in docs/auth.md "One-time Cloudflare-side setup" with hosts (`*.preview.vade-app.dev` + `preview.vade-app.dev`) and cost context (~\$10/month, BDFL-authorised this session).

## What's already provisioned (under MEMO-2026-05-09-vwk2)

- `*.preview.vade-app.dev` AAAA `100::` proxied DNS record.
- `vade-core-preview` Worker, bound to `*.preview.vade-app.dev/*`, ASSETS-only.
- `OPERATOR_TOKENS` secret on the preview Worker, distinct from production.

## What's still BDFL-only

1. Order the ACM cert in the Cloudflare dashboard (or grant the COO token `SSL:Edit` + `Certificate Packs:Edit`).
2. Lock production-branch deploys to `main` in Workers Builds.
3. Set Workers Builds non-main branch build command to `npm run deploy:preview`.
4. Grant the COO 1Password service account write on the COO vault.

## Test plan

- [x] Manual `npm run deploy:preview` produces `vade-core-preview` Worker bound to `*.preview.vade-app.dev/*` with ASSETS-only bindings.
- [x] `wrangler secret put OPERATOR_TOKENS --env preview` succeeds.
- [ ] Post-ACM: `curl -fsS https://pr-<N>.preview.vade-app.dev/` returns 200.
- [ ] Post-ACM: `/library/canvases` returns 5xx (no R2; expected per #193 design).
- [ ] Post-Workers-Builds-config: non-main branch push auto-redeploys preview without touching prod.

Closes: n/a — partial implementation; #168 stays open until ACM + Workers Builds dashboard config land.

Refs vade-core#168

https://claude.ai/code/session_01SoLYu1gtDKrSMaCNPzyQd1