### PR TITLE
ci(mcp-deploy): pin superfly/flyctl-actions to @v1, not @master

### DIFF
--- a/.github/workflows/mcp-deploy.yml
+++ b/.github/workflows/mcp-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Typecheck MCP server
         run: npm run typecheck:mcp
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
 
       - name: Deploy to Fly
         run: flyctl deploy --remote-only --app vade-mcp


### PR DESCRIPTION
## Summary

- Pin `superfly/flyctl-actions/setup-flyctl` from `@master` to `@v1` in `.github/workflows/mcp-deploy.yml`.
- One-line change; no behavior change today (`@v1` currently resolves to the same SHA as `1.6` / `ed8efb33`).

Closes: n/a

## Why

The action's own [README](https://github.com/superfly/flyctl-actions) cautions:

> For production deployments, pin flyctl to a specific version to avoid unexpected behavior in edge releases.

Our usage is exactly the production-deploy path the README warns about: on push to `main`, with `secrets.FLY_API_TOKEN` in env. The `@master` pin was carried in from the 2026-04-24 scaffold commit (PR #62) with no rationale recorded in the commit message.

`@v1` is a floating major maintained by superfly, matching the `@v<major>` convention we already use for `actions/checkout`, `actions/setup-node`, `peaceiris/actions-gh-pages`, `quarto-dev/quarto-actions/setup`, `anthropics/claude-code-action`, etc. across our workflows. This change removes `@master` as the lone outlier without introducing a new pin style.

## Context

Surfaced incidentally during the CVE-2026-31431 (Copy Fail) Linux-kernel vulnerability surface assessment requested by the BDFL. Copy Fail itself does not touch any infra we operate (production = Cloudflare Workers / V8 isolates, dev = Anthropic/GitHub-hosted ephemeral runners — all vendor-managed). The audit caught the dangling `@master` pin as a separate supply-chain hygiene item worth closing.

## Test plan

- [ ] CI passes (no workflow run is triggered by this branch — `mcp-deploy.yml` is `paths`-filtered to `mcp/**`, `Dockerfile`, `fly.toml`, etc., none of which are touched here).
- [ ] On next merge of an MCP-touching change to `main`, `mcp-deploy` job runs and `setup-flyctl@v1` resolves cleanly (same SHA as `master` today, so behavior is identical at merge time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)