### PR TITLE
CLAUDE.md: reconcile push-failure prose with shim behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,21 +97,26 @@ for the authoritative list.
 ## Hitting an OAuth/scope wall on `git push` from a remote session
 
 Claude Code on the web sessions push through a scoped-down git
-proxy. The two recurring blockers are:
+proxy. Two failure shapes recur:
 
-- `git push` rejected with `refusing to allow an OAuth App to
-  create or update workflow ... without 'workflow' scope` (any
-  `.github/workflows/*` change).
-- GitHub MCP `create_or_update_file` / `push_files` returning
-  `404 Not Found` despite reads working.
+- **Proxy-class 403** (intermittent, often on the second push of a
+  session). `vade-runtime/scripts/git-shim.sh` +
+  `git-push-with-fallback.sh` handle this automatically — they
+  retry once via the direct github.com URL with the PAT selected
+  by remote owner (`GITHUB_MCP_PAT` for `vade-app/*`,
+  `GITHUB_PUBLIC_PAT` for everything else; MEMO-2026-05-12-22m9).
+  No manual intervention required; check the next try.
 
-Don't burn cycles retrying or asking for token swaps. Commit the
-work locally on the branch, then suggest the user `/teleport` the
-session to their local Claude Code and finish the push from there
-— typically with `git push git@github.com:OWNER/REPO.git BRANCH`.
-SSH key auth bypasses the OAuth-app scope restriction entirely.
-The unblock for vade-core PR #49 (workflow files) on 2026-04-20
-is the canonical example.
+- **OAuth-app `workflow` scope wall**: `refusing to allow an OAuth
+  App to create or update workflow ... without 'workflow' scope`
+  on any `.github/workflows/*` change. The PATs in env do not carry
+  the `workflow` scope, so the auto-fallback also fails. Commit the
+  work locally on the branch, then suggest the user `/teleport` the
+  session to their local Claude Code and finish the push from there
+  — typically with `git push git@github.com:OWNER/REPO.git BRANCH`.
+  SSH key auth bypasses the OAuth-app scope restriction entirely.
+  The unblock for vade-core PR #49 (workflow files) on 2026-04-20
+  is the canonical example.
 
 ## Current state
 


### PR DESCRIPTION
## Summary

The \"Hitting an OAuth/scope wall on \`git push\`\" section framed every push failure as \"don't burn cycles; teleport.\" That predates the \`git-shim\` + \`git-push-with-fallback\` shims that have been auto-retrying proxy-class 403s since April. The prose now splits cleanly:

- **Proxy-class 403** → shim auto-retries via direct URL with owner-routed PAT (vade-app/* → \`GITHUB_MCP_PAT\`, others → \`GITHUB_PUBLIC_PAT\` per MEMO-2026-05-12-22m9). No agent action required.
- **workflow-scope wall** → PATs lack the scope; \`/teleport\` is still the right answer for \`.github/workflows/*\` pushes.

## Test plan

- [x] Diff review (prose-only)

## Companion

Sibling to vade-app/vade-runtime#259 (the shim extensions) and the MEMO-2026-05-12-22m9 memo PR landing in vade-coo-memory this session.

Closes: n/a

https://claude.ai/code/session_01Kt4QUsK5CSs6y73DANpi43