### PR TITLE
auto-tag-issues + auto-add-prs-to-project: milestone classification (vade-core)

### DIFF
--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -1,0 +1,82 @@
+name: Auto-add new PRs to the VADE project
+
+# When a PR is opened or reopened on this repo, add it to the VADE
+# org project board with Status=In Progress. Pairs with
+# `auto-tag-issues.yml`'s project-add step (which only handles
+# issues, not PRs). See:
+#   - https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/project-board.md
+#   - MEMO-2026-05-20-pbrd — Status canonical; In Progress is the
+#     opened-PR-by-definition state.
+#   - MEMO-2026-05-21-qg65 — milestones uniform across active repos.
+#
+# When the VADE project is rebuilt or its fields change, batch-update
+# all 4 repos' workflows together.
+#
+# Prerequisites:
+#   - secrets.VADE_PROJECT_PAT — PAT with `project` scope for the
+#     vade-app org. If unset, the workflow logs a warning and skips
+#     (graceful no-op, mirrors the auto-tag-issues.yml pattern).
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-project-add-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  add:
+    # Skip dependabot + GitHub Actions auto-PRs; include vade-coo,
+    # claude[bot], and human authors.
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to VADE project, set Status=In Progress
+        env:
+          VADE_PROJECT_PAT: ${{ secrets.VADE_PROJECT_PAT }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VADE_PROJECT_PAT:-}" ]; then
+            echo "VADE_PROJECT_PAT not set — skipping project assignment for PR #$PR_NUMBER"
+            exit 0
+          fi
+
+          # Canonical IDs from coo/operations/project-board.md:
+          PROJECT_ID="PVT_kwDOEGdN_84BUV2r"
+          STATUS_FIELD_ID="PVTSSF_lADOEGdN_84BUV2rzhBesAw"
+          STATUS_IN_PROGRESS_OPT="47fc9ee4"
+
+          export GH_TOKEN="$VADE_PROJECT_PAT"
+
+          # addProjectV2ItemById is idempotent: returns the existing
+          # edge if the item is already on the project.
+          ITEM_ID=$(gh api graphql \
+            -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
+            -F p="$PROJECT_ID" \
+            -F c="$PR_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Failed to add PR #$PR_NUMBER to VADE project" >&2
+            exit 1
+          fi
+          echo "Added PR #$PR_NUMBER to VADE as item $ITEM_ID"
+
+          # Set Status=In Progress.
+          gh api graphql \
+            -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -F p="$PROJECT_ID" \
+            -F i="$ITEM_ID" \
+            -F f="$STATUS_FIELD_ID" \
+            -F o="$STATUS_IN_PROGRESS_OPT" >/dev/null
+
+          echo "Set Status=In Progress on item $ITEM_ID"

--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -43,7 +43,10 @@ jobs:
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
+          # Auto-add is opportunistic — graceful skip on any failure mode
+          # (missing secret, PAT scope insufficient for this repo, project
+          # field write denied). The CI run does NOT fail; the PR proceeds.
+          set -uo pipefail
 
           if [ -z "${VADE_PROJECT_PAT:-}" ]; then
             echo "VADE_PROJECT_PAT not set — skipping project assignment for PR #$PR_NUMBER"
@@ -59,24 +62,29 @@ jobs:
 
           # addProjectV2ItemById is idempotent: returns the existing
           # edge if the item is already on the project.
-          ITEM_ID=$(gh api graphql \
+          add_out=$(gh api graphql \
             -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
             -F p="$PROJECT_ID" \
-            -F c="$PR_NODE_ID" \
-            --jq '.data.addProjectV2ItemById.item.id')
+            -F c="$PR_NODE_ID" 2>&1)
+          add_rc=$?
+          ITEM_ID=$(printf '%s' "$add_out" | jq -r '.data.addProjectV2ItemById.item.id // empty' 2>/dev/null || true)
 
-          if [ -z "$ITEM_ID" ]; then
-            echo "Failed to add PR #$PR_NUMBER to VADE project" >&2
-            exit 1
+          if [ "$add_rc" -ne 0 ] || [ -z "$ITEM_ID" ]; then
+            echo "auto-add: PR #$PR_NUMBER could not be added to VADE project (likely VADE_PROJECT_PAT lacks Pull Requests: Read on this repo). Continuing — this is non-blocking." >&2
+            echo "auto-add: gh output was: $add_out" >&2
+            exit 0
           fi
           echo "Added PR #$PR_NUMBER to VADE as item $ITEM_ID"
 
-          # Set Status=In Progress.
-          gh api graphql \
+          # Set Status=In Progress. Best-effort — log and continue on failure.
+          if ! gh api graphql \
             -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
             -F p="$PROJECT_ID" \
             -F i="$ITEM_ID" \
             -F f="$STATUS_FIELD_ID" \
-            -F o="$STATUS_IN_PROGRESS_OPT" >/dev/null
+            -F o="$STATUS_IN_PROGRESS_OPT" >/dev/null 2>&1; then
+            echo "auto-add: Status field write failed on item $ITEM_ID — continuing" >&2
+            exit 0
+          fi
 
           echo "Set Status=In Progress on item $ITEM_ID"

--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -93,7 +93,8 @@ jobs:
                needs it. Do NOT request `authorAssociation` (not a
                valid `gh` JSON field).
 
-            2. Classify across all five dimensions. Canonical taxonomy:
+            2. Classify across the dimensions below (five label dimensions
+               plus one optional milestone). Canonical taxonomy:
                https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md
 
                - `type:*` — exactly one (mandatory):
@@ -139,31 +140,112 @@ jobs:
                    external-code — touches code outside this repo's
                      canonical ownership (vendored or cross-repo).
 
+               - `milestone` — zero or one (OPTIONAL; defaults to
+                 none). Use the GitHub UI title (e.g.,
+                 "Substrate Hygiene and Tooling"), NOT the M-prefix.
+                 Pick at most one per its scope-rule + test (canonical:
+                 https://github.com/vade-app/vade-coo-memory/blob/main/coo/audits/2026-05-20_milestone-taxonomy/README.md):
+                   "Decentering the Mind" — substantive edit / review /
+                     support for the "Decentering the Mind" essay or
+                     its peer-review atoms. Excludes the general
+                     publication pipeline ("The Published Record"),
+                     lineage events ("Lineage and Parallel Instances"),
+                     other foundations essays ("The Foundations Chain").
+                   "Boot and Environment Integrity" — agent's ability
+                     to start correctly + know its env state: boot
+                     pipeline, integrity probes, bootstrap, cloud /
+                     local env parity, harness secrets, boot CI.
+                     Excludes post-boot hooks ("Substrate Hygiene"),
+                     boot-time reads of identity / memory files.
+                   "Substrate Hygiene and Tooling" — operational
+                     primitives that make the agent work better
+                     session-to-session WITHOUT changing what it IS
+                     or CAN DO: hooks lifecycle, memo system plumbing,
+                     briefings integrity, label taxonomy, attribution
+                     mechanics, issue / PR hygiene, nightly automation,
+                     one-off refactors. Test: if removed, ops degrade
+                     silently without changing identity or capabilities.
+                   "The Published Record" — everything for
+                     read.vade-app.dev as public artifact: Quarto
+                     build, publish-site CI, publish-affordance, tier
+                     system, allowlist, IA, backlinks, deployment.
+                     Test: does this exist because the outside world
+                     should read something?
+                   "Memory Architecture" — design + implementation of
+                     the memory substrate: Mem0 model + SOP, memo
+                     system structure (index, IDs, semantic layer),
+                     transcript storage + schema, identity layer
+                     file, episodic memory cap. Excludes day-to-day
+                     memo writes; boot reads of memory files.
+                   "The Foundations Chain" — foundations essays +
+                     companions, disposition proposal, quorum records,
+                     F1-F6 watchdogs, the chain's open-question
+                     issues. Test: is this a primary artifact of the
+                     chain's self-record? Excludes Decentering and
+                     lineage.
+                   "Lineage and Parallel Instances" — issues whose
+                     primary subject is a documented lineage event
+                     (the-eight, laughing-davinci, socratic-126 / 209)
+                     OR the multi-instance phenomenon: deliberate
+                     fan-outs, society-of-selves auditor,
+                     lineage-interpreter agent. Test: is the primary
+                     subject the experience / record of co-existing
+                     instances, not the plumbing?
+                   "Skills and Agent Capabilities" — new capabilities
+                     added to the agent's vocabulary: slash commands,
+                     skills, sub-agent patterns, MCP integrations.
+                     Test: does this create or improve something the
+                     agent can INVOKE (vs configure / monitor)?
+                   "The Product Application" — vade-core as a
+                     product: tldraw canvas UI, MCP bridge, Fly.io,
+                     R2 / D1 storage, iPad-live, Shiffrin demo,
+                     auth / multi-tenant. Test: does this matter
+                     because end-users interact with the running app
+                     at vade-app.dev? Excludes read.vade-app.dev.
+                   "Outreach and Sustainability" — work extending
+                     reach, legitimacy, or material continuity beyond
+                     the current pair: Anthropic letter, funding
+                     instruments, philosopher contacts, conference
+                     prep, Shiffrin deck (outreach side).
+
+                 **Default to no milestone on ambiguity** (per
+                 MEMO-2026-05-20-mlst + MEMO-2026-05-21-qg65). If no
+                 milestone clearly applies per its scope-rule AND
+                 test, do NOT set one. Better empty than wrong.
+
                Expect 3–5 labels total on a typical issue (one each
                from type, readiness, prio; one or two area; zero or
                more qualifiers). If you find yourself applying fewer
                than 3, re-read the issue — you probably missed a
                dimension.
 
-            3. **Apply all labels.** This step is mandatory. Execute
-               exactly this `Bash` command (one `--add-label` flag per
-               label, every label from step 2):
+            3. **Apply all labels and milestone.** This step is
+               mandatory. Execute exactly this `Bash` command — one
+               `--add-label` flag per label from step 2, plus
+               `--milestone "<name>"` if (and only if) you selected
+               a milestone in step 2:
 
                    gh issue edit <NUMBER> --repo vade-app/vade-core \
-                     --add-label "<label1>" --add-label "<label2>" ...
+                     --add-label "<label1>" --add-label "<label2>" ... \
+                     [--milestone "<milestone-name>"]
 
                If `gh` reports a label does not exist in the repo,
                first create it with `gh label create "<label>" --repo
-               vade-app/vade-core` and retry. Keep going until
-               `gh issue edit` exits 0.
+               vade-app/vade-core` and retry. If `gh` reports
+               the milestone doesn't exist, drop the `--milestone`
+               flag and proceed (do NOT create milestones — only the
+               names listed in step 2 are valid; selection mistakes
+               are silenced this way). Keep going until `gh issue
+               edit` exits 0.
 
-            4. **Verify labels** by running:
+            4. **Verify labels and milestone** by running:
 
-                   gh issue view <NUMBER> --repo vade-app/vade-core --json labels
+                   gh issue view <NUMBER> --repo vade-app/vade-core --json labels,milestone
 
                and confirming `labels[*].name` contains every label
-               you intended to apply. If any are missing, retry step
-               3 for those.
+               you intended to apply, and (if you selected a milestone)
+               `milestone.title` matches it. If any are missing,
+               retry step 3 for those.
 
             5. **Add the issue to the VADE project.**
                Run this exact Bash block, replacing `<ISSUE_ID>` with
@@ -193,17 +275,18 @@ jobs:
 
             Do not stop until BOTH:
               - Step 4's verification shows every intended label on the
-                issue, AND
+                issue (and the milestone, if you selected one), AND
               - Step 6 confirms the VADE project item, OR step 5
                 logged the "VADE_PROJECT_PAT not set" warning.
 
             Merely declaring "applied" in text is not enough — the
             terminal state must be verified via `gh` output.
 
-            Side-effect budget: labels only, plus the one VADE project
-            item from step 5. Do not edit the
-            title or body, do not post a comment, do not assign, do
-            not close.
+            Side-effect budget: labels + at most one milestone + the
+            one VADE project item from step 5. Do not edit the title
+            or body, do not post a comment, do not assign, do not
+            close.
 
-            Final message: one line naming the labels now on the
-            issue, one line on project state (added / skipped / error).
+            Final message: one line naming the labels (and milestone,
+            if any) now on the issue, one line on project state
+            (added / skipped / error).


### PR DESCRIPTION
## Summary

Sibling of [vade-coo-memory#818](https://github.com/vade-app/vade-coo-memory/pull/818). Deploys the milestone-classification + PR-auto-add workflow files per [MEMO-2026-05-21-qg65](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-qg65.md). Deployment bundle at [`coo/operations/auto-milestone-pr-add/`](https://github.com/vade-app/vade-coo-memory/tree/main/coo/operations/auto-milestone-pr-add) in vade-coo-memory.

- `auto-tag-issues.yml`: Haiku prompt gains a sixth (optional) milestone dimension — all 10 themes with scope-rule + test, "default to no milestone on ambiguity" fallback per [MEMO-2026-05-20-mlst](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-20-mlst.md).
- `auto-add-prs-to-project.yml`: new — adds opened/reopened PRs to the VADE project with `Status=In Progress`. Skips `dependabot[bot]` + `github-actions[bot]`.

## Test plan

- [ ] YAML lint passes on both files.
- [ ] Post-merge: opening a probe PR triggers `auto-add-prs-to-project.yml` → item appears on the board with Status=In Progress.

Closes: n/a — sibling of vade-app/vade-coo-memory#818.

https://claude.ai/code/session_01GYJVHpazLzcKe93UFw3XVq