### PR TITLE
coo-on-assign: sync workflow from vade-coo-memory

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -1,0 +1,120 @@
+name: COO on issue assign
+
+# Posts a pre-fill claude.ai/code launch URL on the assigned issue when
+# the new assignee is the COO's GitHub user (vade-coo). The launch URL
+# encodes a boot prompt + the issue's URL + the repository, so clicking
+# the link opens a Claude Code web form already populated with
+# everything needed to spawn a COO session on that issue.
+#
+# Architecture: vade-app/vade-coo-memory#801. claude.ai/code requires a
+# signed-in human to click "Start" — there is no headless API for
+# spawning a session from a server, so this workflow constructs the
+# link and surfaces it; the click-through is the spawn step. See
+# https://code.claude.com/docs/en/web-quickstart#pre-fill-sessions for
+# the pre-fill URL spec (parameters: prompt, repositories, environment).
+#
+# Operations doc: vade-coo-memory/coo/operations/coo-on-assign.md
+# Trigger:   gh issue edit <n> --add-assignee vade-coo
+# Suppress:  gh issue edit <n> --remove-assignee vade-coo
+#
+# Idempotency: none by design — every assigned event posts a fresh
+# comment. Re-assignment (remove + add) is the explicit re-launch
+# primitive (e.g. after a session ended or got stuck).
+#
+# This workflow file is byte-identical across all 9 vade-app/* repos
+# the COO has scope on. When the prompt or URL form changes, sync the
+# update across all 9 in one PR pass (workflow-sync convention; mirrors
+# the issue-pr-hygiene.yml rollout pattern from
+# coo/briefings/014-issue-pr-hygiene-rollout.md).
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  # Per (issue, assignee) — concurrent assigns of different users to the
+  # same issue don't serialize (the assignee gate filters anyway), but
+  # rapid re-assigns of vade-coo to the same issue queue.
+  group: coo-on-assign-${{ github.event.issue.number }}-${{ github.event.assignee.login }}
+  cancel-in-progress: false
+
+jobs:
+  post-launch-link:
+    # Gate: only fire when the user that was just assigned is vade-coo.
+    # `github.event.assignee` is the user added by THIS event (distinct
+    # from `github.event.issue.assignees`, the full current list).
+    if: ${{ github.event.assignee.login == 'vade-coo' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build pre-fill URL and post launch comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const repoSlug = `${owner}/${repo}`;
+
+            // --- Boot prompt template -------------------------------
+            // Refinement of the draft proposal in vade-app/vade-coo-memory#801.
+            // Notes:
+            //  - flat numbered/lettered list, no nested indentation —
+            //    template-literal preserves leading whitespace and YAML
+            //    indent stripping would otherwise leak spaces into the
+            //    prompt body.
+            //  - readiness:* branch (3a/3b/3c) replaces the body's
+            //    inline judgement-call so the instance routes on
+            //    labels (MEMO-2026-04-22-09) instead of re-deriving
+            //    scope per-issue.
+            //  - "Ven is not at the keyboard" framing is explicit so
+            //    the instance briefs instead of asking when it would
+            //    have asked interactively.
+            const prompt = [
+              `You are the VADE COO agent, opening a fresh cloud session by GitHub assignment, not by Ven sitting at the keyboard. Treat this as async.`,
+              ``,
+              `1. Boot first per CLAUDE.md (boot-integrity gate, identity layer, recent episodic, lineage events, memo digest). Greet briefly.`,
+              `2. Read the assigning issue: ${issue.html_url}. Read its comments, labels, milestone, and any cross-referenced issues / PRs.`,
+              `3. Branch by the issue's readiness:* label.`,
+              `3a. readiness:ready-to-pick-up (or absent label on a well-scoped body): implement autonomously. Open a PR when the change is complete and the verification steps in the issue (or your judgement of equivalent steps) have run green. Auto-subscribe per the PR-watch discipline in CLAUDE.md. Stand by for review.`,
+              `3b. readiness:needs-design / readiness:needs-research / readiness:needs-breakdown, or any clarification-shaped signal in the body: do preliminary reconnaissance, draft a plan, then post a brief comment on the issue (or open a discussion thread for larger scope) that names what you understood, what the design space is, which decisions Ven needs to make, and your recommendation. Stop after the brief — wait for Ven.`,
+              `3c. needs:bdfl-approval: never merge autonomously. Always brief, never autonomous, regardless of the readiness label.`,
+              `4. End-of-session discipline applies — episodic Mem0 entry, session log in vade-agent-logs, /memo-sync if a memo was issued.`,
+              ``,
+              `Ven is not currently at the keyboard. Don't expect interactive clarification mid-task; if you would have asked, brief instead.`,
+            ].join('\n');
+
+            // --- Compose the pre-fill URL ---------------------------
+            // URLSearchParams handles percent-encoding (incl. multi-line
+            // newlines as %0A) for both prompt and repositories. No
+            // `environment` param at MVP — Ven's last-used env is sticky.
+            const params = new URLSearchParams({
+              prompt,
+              repositories: repoSlug,
+            });
+            const launchUrl = `https://claude.ai/code?${params.toString()}`;
+
+            // --- Comment body ---------------------------------------
+            const body = [
+              `I've been assigned this issue. To launch a cloud COO session with the boot prompt + issue context pre-loaded:`,
+              ``,
+              `[**Launch COO session →**](${launchUrl})`,
+              ``,
+              `The session opens when you click — claude.ai/code needs a signed-in human (you) to spawn the container. Re-assign me to post a fresh link (e.g. after a session ends or gets stuck).`,
+              ``,
+              `---`,
+              `<sub>posted by \`coo-on-assign\` workflow · design: vade-app/vade-coo-memory#801 · [operations doc](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/coo-on-assign.md)</sub>`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body,
+            });
+
+            core.info(`Posted launch comment on ${repoSlug}#${issue.number}`);
+            core.info(`Launch URL length: ${launchUrl.length} chars`);


### PR DESCRIPTION
## Summary

Syncs `.github/workflows/coo-on-assign.yml` from [vade-app/vade-coo-memory#815](https://github.com/vade-app/vade-coo-memory/pull/815) (merged) into this repo. Byte-identical with the canonical source.

When `@vade-coo` is assigned to any issue in this repo, the workflow posts a comment with a `claude.ai/code?prompt=...&repositories=...` pre-fill URL. Click-through spawns a cloud COO session with the boot prompt + issue context pre-loaded.

## Canonical references

- Memo: [MEMO-2026-05-21-bh7h](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-bh7h.md) — the convention + architectural constraint (no headless session-spawn API; click-through is unavoidable).
- Operations doc: [coo/operations/coo-on-assign.md](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/coo-on-assign.md) — trigger, suppress, re-launch, failure modes, post-MVP futures.
- Original design issue: [vade-coo-memory#801](https://github.com/vade-app/vade-coo-memory/issues/801).

## Why this PR

The MVP affordance shipped in vade-coo-memory only. To make assignment-to-COO work uniformly across every repo the COO has GitHub scope on, the workflow lives in all nine `vade-app/*` repos. This is one of the eight follow-up rollout PRs.

## Test plan

- [ ] Workflow YAML lints (same `actions/github-script@v7` pattern used by `issue-pr-hygiene.yml` already in this repo or its siblings).
- [ ] After merge, open a throwaway issue in this repo, run `gh issue edit <n> --add-assignee vade-coo`, confirm the `coo-on-assign` workflow fires within ~30 s and posts a launch comment with a working `claude.ai/code?...` URL.
- [ ] Click the link, confirm the form pre-fills with the prompt + repo selector defaulting to this repo.

## Changes

Single new file: `.github/workflows/coo-on-assign.yml`. No other surface area touched.
Closes: n/a — this is a sync mirror of vade-app/vade-coo-memory#815 (which closed vade-app/vade-coo-memory#801).