### PR TITLE
coo-on-assign: pre-fill all 9 vade-app/* repos (sync of #821)

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -91,9 +91,32 @@ jobs:
             // URLSearchParams handles percent-encoding (incl. multi-line
             // newlines as %0A) for both prompt and repositories. No
             // `environment` param at MVP — Ven's last-used env is sticky.
+            //
+            // Pre-select ALL nine vade-app/* repos the COO has scope on.
+            // The boot pass (coo-bootstrap.sh, integrity-check, identity
+            // layer reads) cross-references files across these repos; a
+            // session attached to only the assigning repo fails boot.
+            // The assigning repo goes first so it's the obvious primary
+            // in the form's repo selector.
+            const COO_SCOPE_REPOS = [
+              'vade-app/vade-coo-memory',
+              'vade-app/vade-core',
+              'vade-app/vade-runtime',
+              'vade-app/vade-agent-logs',
+              'vade-app/vade-governance',
+              'vade-app/skills',
+              'vade-app/coo4one',
+              'vade-app/vade-site',
+              'vade-app/coo-transcripts-analysis',
+            ];
+            const repositories = [
+              repoSlug,
+              ...COO_SCOPE_REPOS.filter(r => r !== repoSlug),
+            ].join(',');
+
             const params = new URLSearchParams({
               prompt,
-              repositories: repoSlug,
+              repositories,
             });
             const launchUrl = `https://claude.ai/code?${params.toString()}`;
 


### PR DESCRIPTION
## Summary

Syncs the JS hunk landed in vade-app/vade-coo-memory#821: pre-fill **all 9 `vade-app/*` repos** in the launch URL, not just the assigning one.

## What was broken

The MVP version of `coo-on-assign.yml` pre-filled only the assigning repo. But spawned COO sessions cross-read files across all nine `vade-app/*` repos — `coo-bootstrap.sh` lives in `vade-runtime`, identity layer in `vade-coo-memory`, etc. — so a session attached to only one repo fails boot. Caught live by Ven smoke-testing from vade-app/vade-coo-memory#810.

## Fix (byte-identical mirror of #821)

Hardcoded 9-repo list, assigning repo placed first as the form's primary.

## Test plan

- [x] Smoke-tested in vade-coo-memory: assigning repo first, all 9 included, round-trips through `URLSearchParams`.
- [ ] Post-merge: assign `vade-coo` to a throwaway issue, confirm the launch comment's link pre-fills all 9 repos.

Closes: n/a — sync of vade-app/vade-coo-memory#821.
