### PR TITLE
coo-on-assign: drop truncating parenthetical from boot-step prompt

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -76,7 +76,7 @@ jobs:
             const prompt = [
               `You are the VADE COO agent, opening a fresh cloud session by GitHub assignment, not by Ven sitting at the keyboard. Treat this as async.`,
               ``,
-              `1. Boot first per CLAUDE.md (boot-integrity gate, identity layer, recent episodic, lineage events, memo digest). Greet briefly.`,
+              `1. Boot first per CLAUDE.md — read every numbered step in the session-start reading order, not just the ones that seem most relevant to the task below. The list includes integrity gate (1), persisted-output gate (1b), charter (2), governance (3), preferences (4), identity layer (5), episodic memory (6), memo digest (7), lineage events (7b), project board (8), mem0_sop (9), context README (12), operational Mem0 search (13), discussions digest (14). Skipping items because the parenthetical or this prompt seemed to enumerate a shorter set is the exact regression this language replaces. Greet briefly.`,
               `2. Read the assigning issue: ${issue.html_url}. Read its comments, labels, milestone, and any cross-referenced issues / PRs.`,
               `3. Branch by the issue's readiness:* label.`,
               `3a. readiness:ready-to-pick-up (or absent label on a well-scoped body): implement autonomously. Open a PR when the change is complete and the verification steps in the issue (or your judgement of equivalent steps) have run green. Auto-subscribe per the PR-watch discipline in CLAUDE.md. Stand by for review.`,


### PR DESCRIPTION
## Summary

Drops the truncating parenthetical from the `coo-on-assign.yml`
launch prompt step 1. Sync of the fix originally landed in
`vade-runtime` (companion PRs in vade-coo-memory, vade-core; each
repo holds a byte-identical copy of this workflow per the file's
header comment).

## Why

The previous wording — `Boot first per CLAUDE.md (boot-integrity
gate, identity layer, recent episodic, lineage events, memo
digest). Greet briefly.` — was being parsed by assignment-launched
agents as a *canonical boot list*, not illustrative shorthand for
the actual list in CLAUDE.md. Result: every assignment-launched
session was skipping CLAUDE.md steps 2–14 + 7b (`identity/charter`,
`identity/governance`, `identity/preferences`, `coo/mem0_sop`,
lineage event READMEs, `context/README`, operational Mem0 search).

Flagged live in
[vade-coo-memory#837](https://github.com/vade-app/vade-coo-memory/issues/837)
session today after the assigned COO instance skipped CB-005
because the identity layer wasn't fully loaded — symptom of the
broader regression, not the regression itself.

## Change

Replaces the parenthetical with explicit `every numbered step in
the session-start reading order, not just the ones that seem most
relevant to the task below` + a non-exhaustive enumeration that
names step IDs but defers to CLAUDE.md as canonical. The new
wording also names step 1b (persisted-output gate) added in
vade-coo-memory#842.

One-line change in the workflow's `prompt` template.

## Test plan

- [x] File modified byte-identically across all 9 repos this
      workflow lives in (rollout convention from the file's
      header comment).
- [ ] Next assignment-launched session reads CLAUDE.md fully,
      including the persisted-output gate (validated empirically
      on the next assignment).

Closes: n/a

https://claude.ai/code/session_01D38ph8uo4xaQJXujvrwABJ