### PR TITLE
feat: per-type issue templates + bridge trigger (vade-coo-memory#811)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Bug
+description: A defect — existing behavior diverges from intended.
+title: "Bug: <short description>"
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Bug
+
+        Existing behavior diverges from what's intended. Use this template
+        for regressions, broken features, and unexpected outputs.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps to reproduce the bug. Be specific enough that someone else can hit the same state.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-observed
+    attributes:
+      label: Expected vs observed
+      description: What you expected to happen, and what actually happened.
+      placeholder: |
+        **Expected:** ...
+
+        **Observed:** ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Environment, recent changes, related issues. Use hyphenated MEMO
+        autolink form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,61 @@
+name: Chore
+description: Build, tooling, infra, housekeeping.
+title: "Chore: <short description>"
+type: Chore
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Chore
+
+        Housekeeping: build, tooling, infrastructure, dependency updates,
+        substrate hygiene. Use for work that doesn't ship user-facing
+        behavior but keeps the system running.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of what needs doing and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+description: Documentation-only change.
+title: "Docs: <short description>"
+type: Docs
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Docs
+
+        Documentation-only changes — new operations docs, foundation
+        essays, retrospective entries, README updates, or memo paired
+        files. For code changes that include incidental doc updates use
+        the corresponding code type instead.
+
+        Only the Priority widget bridges to a native field; Docs are not
+        pinned to a Readiness field (they ship when written).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What documentation needs writing / changing, and where it should live.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source-of-truth pointer
+      description: |
+        Is there an existing file this doc supersedes or paired with? If yes, name it.
+        For new memos / operations docs, list the memo IDs / paired artifacts.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,18 +1,18 @@
 name: Epic
 description: A parent issue that tracks multiple implementable child issues.
 title: "Epic: <short description>"
-labels: ["type:epic", "readiness:needs-breakdown"]
+type: Epic
 body:
   - type: markdown
     attributes:
       value: |
-        # Epic creation
+        # Epic
 
         Epics organize multi-issue work. After creating this issue, use the
         GitHub UI's **"Add sub-issue"** button on this issue to formally link
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
-        Native sub-issue linkage is **required** for `type:epic` issues per
+        Native sub-issue linkage is **required** for Epic-type issues per
         [`coo/operations/issue-pr-hygiene.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-pr-hygiene.md)
         + [`coo/label_taxonomy.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/label_taxonomy.md) §6 —
         markdown checklists of `#N` references in the epic body are insufficient
@@ -20,13 +20,21 @@ body:
         tracker UI.
 
         The hygiene workflow will emit an advisory comment if no native
-        sub-issues are linked once you label this issue `type:epic`.
+        sub-issues are linked once this issue is given the Epic type.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. Start date / Target date
+        are not pre-elicited here; set them in the issue's side panel
+        once the epic is scheduled.
 
   - type: textarea
     id: summary
     attributes:
       label: Summary
       description: One-paragraph description of what this epic is about and what shipping it looks like.
+      placeholder: |
+        e.g., "Migrate the five repos from `proj:*` labels to GitHub native
+        sub-issues so the project board's tracker UI reflects real progress."
     validations:
       required: true
 
@@ -35,6 +43,10 @@ body:
     attributes:
       label: Success criteria
       description: How we'll know this epic is done. Specific and falsifiable.
+      placeholder: |
+        - All 18 currently-non-compliant epics across the five repos have at
+          least one sub-issue linked via the native API.
+        - The project board's tracker column reflects native sub-issue counts.
     validations:
       required: true
 
@@ -45,8 +57,9 @@ body:
       description: |
         After creating this epic, click "Add sub-issue" on this issue's right-side
         panel to formally link each child. Use this textarea ONLY for a working
-        scratchpad of sub-issue candidates BEFORE they become real sub-issues.
-        Native sub-issues are the source-of-truth.
+        scratchpad of sub-issue candidates BEFORE they become real sub-issues
+        (e.g., "we'll need an issue for X"). Native sub-issues are the
+        source-of-truth.
       placeholder: |
         Working scratch — replace with native sub-issue links once filed:
           - [ ] Stream 1: <description>
@@ -63,7 +76,7 @@ body:
         form `vade-app/<repo>#N` for cross-repo references (NEVER bare `#N` —
         that autolinks to the wrong issue).
       placeholder: |
-        - vade-app/vade-coo-memory#NNN — describe dependency
+        - vade-app/vade-runtime#NNN — describe dependency
         - vade-app/vade-core#NNN — describe dependency
     validations:
       required: false
@@ -76,5 +89,48 @@ body:
         Background, prior memos, related epics. Use hyphenated MEMO autolink
         form (`MEMO-YYYY-MM-DD-<suffix>`) and dash form for non-issue IDs
         (`quorum-N`, `briefing-N`, `instance-N`).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Needs breakdown
+        - Ready
+        - Needs design
+        - Needs research
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - L
+        - XS
+        - S
+        - M
+        - XL
+      default: 0
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,71 @@
+name: Feature
+description: New user-facing capability.
+title: "Feature: <short description>"
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Feature
+
+        A new user-facing capability. For internal restructuring use
+        **Refactor**; for housekeeping use **Chore**.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: user-capability
+    attributes:
+      label: User capability
+      description: What can the user do after this ships that they couldn't do before? Frame from the user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Specific, falsifiable conditions for completion.
+      placeholder: |
+        - [ ] <condition 1>
+        - [ ] <condition 2>
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,76 @@
+name: Refactor
+description: Internal restructuring without behavior change.
+title: "Refactor: <short description>"
+type: Refactor
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Refactor
+
+        Internal restructuring that does not change observable behavior.
+        Pure code/data re-arrangement. If behavior changes — even
+        slightly — use **Feature** or **Bug** instead.
+
+        Native-field widgets at the bottom (Priority, Effort) are
+        bridged to the issue's native fields by a workflow on creation.
+        Refactor is not pinned to Readiness (it's typically picked up
+        opportunistically).
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What's being restructured. Files, modules, packages, or conceptual layers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior-unchanged
+    attributes:
+      label: Behavior-unchanged check
+      description: |
+        How you'll verify external behavior didn't change. Existing tests
+        passing is usually sufficient; for boundary cases, name the
+        specific behaviors you've confirmed remain equivalent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,0 +1,119 @@
+name: Research
+description: Spike, investigation, deep-dive — produces findings, not merged code.
+title: "Research: <short description>"
+type: Research
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Research
+
+        Spikes, investigations, deep-dives that produce findings (memos,
+        foundation essays, operations docs, briefings, or scoped
+        code-spikes). The deliverable is **understanding made durable**,
+        not a feature ship.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. The custom fields
+        `Research question` and `Output kind` are pinned to Research.
+
+  - type: textarea
+    id: research-question
+    attributes:
+      label: Research question
+      description: The specific question to investigate. One sentence; bridged to the native `Research question` field.
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach
+      description: How you plan to investigate. Sources to read, experiments to run, instances/agents to consult.
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected output
+      description: What artifact this will produce — memo, foundation essay, operations doc, briefing, or code-spike. Match the `Output kind` selection below.
+    validations:
+      required: false
+
+  - type: textarea
+    id: done-when
+    attributes:
+      label: Done when
+      description: Specific, falsifiable conditions for closing this issue. Research issues benefit from a clear close-when since they can drift.
+      placeholder: |
+        - [ ] <finding 1 reached>
+        - [ ] <artifact 1 published>
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: output-kind
+    attributes:
+      label: Output kind
+      description: Type of artifact this research will produce. Bridged to the native Output kind field.
+      options:
+        - memo
+        - foundation-essay
+        - operations-doc
+        - briefing
+        - code-spike
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill.yml
+++ b/.github/ISSUE_TEMPLATE/skill.yml
@@ -1,0 +1,109 @@
+name: Skill
+description: Skill lifecycle work (implement / review / revise / evaluate / idea).
+title: "Skill: <skill-name> — <phase>"
+type: Skill
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Skill
+
+        Skill lifecycle work — the new axis surfaced by issue fields.
+        Use this for any work on a `.claude/skills/<name>/` skill:
+        ideating, implementing, reviewing the SKILL.md, revising after
+        usage, or evaluating effectiveness.
+
+        Native-field widgets at the bottom are bridged to the issue's
+        native fields by a workflow on creation. The custom fields
+        `Skill kind` and `Skill name` are pinned to Skill.
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+      description: Canonical skill name (e.g. `memo-search`, `debug-mode`, `peer-review`). Matches the directory name under `.claude/skills/`. Bridged to the native `Skill name` field.
+      placeholder: <skill-name>
+    validations:
+      required: true
+
+  - type: dropdown
+    id: skill-kind
+    attributes:
+      label: Skill kind
+      description: Lifecycle phase. Bridged to the native `Skill kind` field.
+      options:
+        - idea
+        - implement
+        - review
+        - revise
+        - evaluate
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope of this phase
+      description: What this specific lifecycle step accomplishes. For `idea`, sketch the trigger and shape. For `implement`, the deliverable file path. For `review`/`revise`, what's being evaluated against what.
+    validations:
+      required: true
+
+  - type: textarea
+    id: adoption-test
+    attributes:
+      label: Adoption test
+      description: How will we know this skill is actually used? Or for `idea`-phase, what signals would trigger its use?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior skill versions, related issues. Use hyphenated MEMO
+        autolink form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      description: Estimated effort. XS → XL. Bridged to the native Effort field.
+      options:
+        - M
+        - XS
+        - S
+        - L
+        - XL
+      default: 0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,74 @@
+name: Task
+description: Default kind of implementable work that doesn't fit another type.
+title: "Task: <short description>"
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Task
+
+        Use this template for default implementable work. For multi-step
+        parent issues use the **Epic** template instead. For defects use
+        **Bug**; for new user-facing capabilities use **Feature**.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+        See [`coo/operations/issue-fields-and-types.md`](https://github.com/vade-app/vade-coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph description of what this task is and what shipping looks like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Specific, falsifiable conditions for completion.
+      placeholder: |
+        - [ ] <condition 1>
+        - [ ] <condition 2>
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form (`MEMO-YYYY-MM-DD-<suffix>`) and full cross-repo form
+        (`vade-app/<repo>#N`) for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,0 +1,72 @@
+name: Test
+description: Test coverage, fixtures, harness work.
+title: "Test: <short description>"
+type: Test
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Test
+
+        Test coverage additions, fixture management, harness work. For
+        the actual bug being tested use **Bug** with a linked Test issue,
+        not this template.
+
+        Native-field widgets at the bottom (Priority, Readiness) are
+        bridged to the issue's native fields by a workflow on creation.
+
+  - type: textarea
+    id: what-being-tested
+    attributes:
+      label: What's being tested
+      description: The component, behavior, regression, or boundary case this test covers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: linked-issue
+    attributes:
+      label: Linked issue
+      description: |
+        The bug or feature this test addresses. Use full cross-repo form
+        (`vade-app/<repo>#N`) for cross-repo references; bare `#N` resolves
+        wrong.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Background, prior memos, related issues. Use hyphenated MEMO autolink
+        form and full cross-repo form for issue references.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: P0 (urgent) → P3 (low). Bridged to the native Priority field.
+      options:
+        - P2
+        - P0
+        - P1
+        - P3
+      default: 0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: readiness
+    attributes:
+      label: Readiness
+      description: Pickup-readiness. Bridged to the native Readiness field.
+      options:
+        - Ready
+        - Needs design
+        - Needs research
+        - Needs breakdown
+    validations:
+      required: false

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -1,0 +1,38 @@
+name: Bridge issue-form widgets to native fields (trigger)
+
+# Triggers the bridge reusable workflow at
+# vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml
+# whenever an issue is opened in this repository.
+#
+# This file is hand-mirrored across vade-coo-memory / vade-runtime /
+# vade-core / vade-agent-logs. Edit canonical in vade-coo-memory and
+# port to siblings (workflow-sync convention; see
+# coo/operations/issue-pr-hygiene.md).
+#
+# Bridge design + script source: vade-app/vade-runtime#TBD.
+# Stage 2 design: vade-app/vade-coo-memory#811.
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to re-bridge.
+        required: true
+        type: number
+      dry_run:
+        description: Dry-run (print intended mutations without applying).
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  bridge:
+    uses: vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
+    with:
+      issue-number: ${{ github.event.issue.number || inputs.issue_number }}
+      repo-full-name: ${{ github.repository }}
+      dry-run: ${{ inputs.dry_run || false }}
+    secrets:
+      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.GITHUB_MCP_PAT }}


### PR DESCRIPTION
## Summary

Sibling PR to vade-app/vade-coo-memory#846 (Stage 2 of the issue-fields-and-types migration per [MEMO-2026-05-21-xfqh](https://github.com/vade-app/vade-coo-memory/blob/main/coo/memos/2026-05-21-xfqh.md)).

Mirrors the 10 per-type issue templates from vade-coo-memory (canonical) + the caller workflow that triggers vade-app/vade-runtime's reusable bridge workflow on `issues.opened`.

Hand-mirror per the workflow-sync convention. Edits to templates should land in vade-coo-memory first, then port here.

## Test plan

- [ ] Create a Task issue via the new template in this repo; verify native type + Priority + Readiness set via the bridge.

Closes: n/a — sub-deliverable of vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK