### PR TITLE
fix: rename bridge secret to VADE_FIELDS_ADMIN_PAT (vade-coo-memory#811)

### DIFF
--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -35,4 +35,4 @@ jobs:
       repo-full-name: ${{ github.repository }}
       dry-run: ${{ inputs.dry_run || false }}
     secrets:
-      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.GITHUB_MCP_PAT }}
+      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}


### PR DESCRIPTION
## Summary

Mirror fixup. Canonical fix is in vade-coo-memory; this carries the same one-line change to this repo's caller workflow.

Closes: n/a — fixup for vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK