### PR TITLE
fix: trigger sync to canonical (vade-coo-memory#811)

### DIFF
--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -27,12 +27,14 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   bridge:
     uses: vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
     with:
       issue-number: ${{ github.event.issue.number || inputs.issue_number }}
       repo-full-name: ${{ github.repository }}
-      dry-run: ${{ inputs.dry_run || false }}
-    secrets:
-      ISSUE_FIELDS_ADMIN_PAT: ${{ secrets.VADE_FIELDS_ADMIN_PAT }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Sibling sync — brings this repo's bridge trigger workflow into parity with vade-coo-memory canonical (`secrets: inherit` + drop dry-run pass-through). Land alongside vade-runtime#TBD which fixes the underlying YAML parse error in the reusable workflow.

Closes: n/a — debug iteration for vade-app/vade-coo-memory#811.

https://claude.ai/code/session_013zXPvSRbF9Nf4F1H5S2zhK