### PR TITLE
Adopt /skill-name: title convention in skill.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill.yml
+++ b/.github/ISSUE_TEMPLATE/skill.yml
@@ -1,6 +1,6 @@
 name: Skill
 description: Skill lifecycle work (implement / review / revise / evaluate / idea).
-title: "Skill: <skill-name> — <phase>"
+title: "/<skill-name>: <short description>"
 type: Skill
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

Mirror of the vade-coo-memory PR. Template-only change:

- `.github/ISSUE_TEMPLATE/skill.yml` title default → `"/<skill-name>: <short description>"`.

## Test plan

- [x] Template title default updated

Refs vade-app/vade-coo-memory#802

Closes: n/a

https://claude.ai/code/session_015nu8GL4c1BdNerKhxFrq9o