### PR TITLE
sync(coo-on-assign): refresh COO_SCOPE_REPOS to current 10 repos

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -21,11 +21,16 @@ name: COO on issue assign
 # comment. Re-assignment (remove + add) is the explicit re-launch
 # primitive (e.g. after a session ended or got stuck).
 #
-# This workflow file is byte-identical across all 9 vade-app/* repos
-# the COO has scope on. When the prompt or URL form changes, sync the
-# update across all 9 in one PR pass (workflow-sync convention; mirrors
-# the issue-pr-hygiene.yml rollout pattern from
-# coo/briefings/014-issue-pr-hygiene-rollout.md).
+# This workflow file is byte-identical across all 10 vade-app/* repos
+# the COO has scope on. When the prompt, URL form, or COO_SCOPE_REPOS
+# list below changes, sync the update across all 10 in one PR pass
+# (workflow-sync convention; mirrors the issue-pr-hygiene.yml rollout
+# pattern from coo/briefings/014-issue-pr-hygiene-rollout.md).
+#
+# COO_SCOPE_REPOS maintenance: when a vade-app/* repo is created,
+# renamed, archived, or deleted, update the list in this workflow AND
+# sync to all 10 repos in scope. There is no runtime drift detection
+# yet — the list is the canonical declaration of scope.
 
 on:
   issues:
@@ -105,12 +110,15 @@ jobs:
             // newlines as %0A) for both prompt and repositories. No
             // `environment` param at MVP — Ven's last-used env is sticky.
             //
-            // Pre-select ALL nine vade-app/* repos the COO has scope on.
+            // Pre-select ALL ten vade-app/* repos the COO has scope on.
             // The boot pass (coo-bootstrap.sh, integrity-check, identity
             // layer reads) cross-references files across these repos; a
             // session attached to only the assigning repo fails boot.
             // The assigning repo goes first so it's the obvious primary
             // in the form's repo selector.
+            //
+            // When a vade-app/* repo is added/renamed/archived/deleted,
+            // update this list AND sync the change to all 10 repos.
             const COO_SCOPE_REPOS = [
               'vade-app/vade-coo-memory',
               'vade-app/vade-core',
@@ -120,7 +128,8 @@ jobs:
               'vade-app/skills',
               'vade-app/coo4one',
               'vade-app/vade-site',
-              'vade-app/coo-transcripts-analysis',
+              'vade-app/tjsonl',
+              'vade-app/vade-console',
             ];
             const repositories = [
               repoSlug,


### PR DESCRIPTION
## Summary

Sync the `coo-on-assign` workflow with the canonical copy in `vade-app/vade-coo-memory` (the authoritative source for this byte-identical-across-repos workflow). The diff:

- **Add**: `vade-app/tjsonl`, `vade-app/vade-console`
- **Remove**: `vade-app/coo-transcripts-analysis` (repo no longer exists)

Plus the maintenance comments are updated (9 → 10) and an explicit "when a vade-app/\* repo is added/renamed/archived/deleted, sync the list" hint is added near `COO_SCOPE_REPOS`.

One of 10 companion PRs across the vade-app/* repos in COO scope; canonical source + operations-doc update is at [vade-app/vade-coo-memory#895](https://github.com/vade-app/vade-coo-memory/pull/895).

## Test plan

- [x] Workflow file is byte-identical to the canonical copy in `vade-app/vade-coo-memory`
- [ ] Once merged + all 10 PRs synced: assigning `@vade-coo` to a test issue in any of the 10 scoped repos pre-fills a URL whose `repositories=` lists all 10

Closes vade-app/vade-coo-memory#892

https://claude.ai/code/session_012erGfLLRAT89k7mkQHyywJ