### PR TITLE
F8 auto-merge: thin trigger for sync:* labeled PRs

### DIFF
--- a/.github/workflows/auto-merge-sync-pr.yml
+++ b/.github/workflows/auto-merge-sync-pr.yml
@@ -1,0 +1,23 @@
+name: Auto-merge sync PR
+
+# Thin trigger: on sync:* labeled PR, call vrt's reusable to enable
+# squash auto-merge. Implements the F8 acceptance row "Configure
+# auto-merge for sync-action PRs in consumer repos"
+# (vade-coo-memory#938) via the F7 centralization pattern
+# (vade-coo-memory#939).
+#
+# Canonical reusable: vade-app/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml
+# Ops doc row: vade-coo-memory/coo/operations/workflow-centralization.md.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: startsWith(github.event.label.name, 'sync:')
+    uses: vade-app/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml@main


### PR DESCRIPTION
F8 auto-merge thin trigger. Calls vade-runtime's reusable when a sync PR is opened (label-gated on `sync:*`). Implements the auto-merge acceptance row from [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938) — once this lands across all 8 consumers, future template syncs will auto-merge on green CI without per-PR clicks.

## Closing keywords

Closes: n/a

## Summary

- `.github/workflows/auto-merge-sync-pr.yml` — thin trigger on `pull_request: types: [labeled]`, calls `vade-app/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml@main` when label starts with `sync:`.

The reusable was added in [vade-runtime#322](https://github.com/vade-app/vade-runtime/pull/322); ops doc row in `coo/operations/workflow-centralization.md`. Auth uses the default `GITHUB_TOKEN` (no PAT) since the workflow runs in the consumer repo's context.

## Cross-repo references

- [vade-coo-memory#938](https://github.com/vade-app/vade-coo-memory/issues/938) — F8 epic
- [vade-runtime#322](https://github.com/vade-app/vade-runtime/pull/322) — reusable workflow (merged)

https://claude.ai/code/session_01M1XipbZh1gNg7rn6Tpkart