### PR TITLE
chore: bump uses: refs to coo-labs after org rename (F9)

### DIFF
--- a/.github/workflows/auto-add-prs-to-project.yml
+++ b/.github/workflows/auto-add-prs-to-project.yml
@@ -1,7 +1,7 @@
 name: Auto-add new PRs to the VADE project
 
 # Thin trigger: fires on PR open/reopen and delegates to the canonical
-# reusable workflow at vade-app/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml.
+# reusable workflow at coo-labs/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml.
 #
 # Centralization: vade-coo-memory#939 (F7). Logic + project IDs live in
 # the reusable; this file only carries the event trigger and the
@@ -16,5 +16,5 @@ permissions:
 
 jobs:
   add:
-    uses: vade-app/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/auto-add-prs-to-project-reusable.yml@main
     secrets: inherit

--- a/.github/workflows/auto-merge-sync-pr.yml
+++ b/.github/workflows/auto-merge-sync-pr.yml
@@ -6,7 +6,7 @@ name: Auto-merge sync PR
 # (vade-coo-memory#938) via the F7 centralization pattern
 # (vade-coo-memory#939).
 #
-# Canonical reusable: vade-app/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml
+# Canonical reusable: coo-labs/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml
 # Ops doc row: vade-coo-memory/coo/operations/workflow-centralization.md.
 
 on:
@@ -20,4 +20,4 @@ permissions:
 jobs:
   auto-merge:
     if: startsWith(github.event.label.name, 'sync:')
-    uses: vade-app/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/auto-merge-sync-pr-reusable.yml@main

--- a/.github/workflows/auto-tag-issues.yml
+++ b/.github/workflows/auto-tag-issues.yml
@@ -2,7 +2,7 @@ name: Auto-tag new issues
 
 # Thin trigger: fires on issue open (gapfill mode) or workflow_dispatch
 # (full re-classify) and delegates to the canonical reusable workflow
-# at vade-app/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml.
+# at coo-labs/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml.
 #
 # Centralization: vade-coo-memory#939 (F7). Classification logic +
 # canonical taxonomy refs live in the reusable; this file only carries
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   tag:
-    uses: vade-app/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/auto-tag-issues-reusable.yml@main
     with:
       issue-number: ${{ github.event.issue.number || inputs.issue_number }}
       mode: ${{ github.event_name == 'workflow_dispatch' && 'full' || 'gapfill' }}

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -1,7 +1,7 @@
 name: Bridge issue-form widgets to native fields (trigger)
 
 # Triggers the bridge reusable workflow at
-# vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml
+# coo-labs/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml
 # whenever an issue is opened in this repository.
 #
 # This file is hand-mirrored across vade-coo-memory / vade-runtime /
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   bridge:
-    uses: vade-app/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/bridge-form-fields-to-natives.yml@main
     with:
       issue-number: ${{ github.event.issue.number || inputs.issue_number }}
       repo-full-name: ${{ github.repository }}

--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -1,7 +1,7 @@
 name: COO on issue assign
 
 # Thin trigger: fires on `issues.assigned` and delegates to the canonical
-# reusable workflow at vade-app/vade-runtime/.github/workflows/coo-on-assign-reusable.yml.
+# reusable workflow at coo-labs/vade-runtime/.github/workflows/coo-on-assign-reusable.yml.
 #
 # Centralization: vade-coo-memory#939 (F7). Logic + COO_SCOPE_REPOS list
 # lives in the reusable; this file only carries the event trigger and
@@ -20,5 +20,5 @@ permissions:
 
 jobs:
   post-launch-link:
-    uses: vade-app/vade-runtime/.github/workflows/coo-on-assign-reusable.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/coo-on-assign-reusable.yml@main
     secrets: inherit

--- a/.github/workflows/issue-pr-hygiene.yml
+++ b/.github/workflows/issue-pr-hygiene.yml
@@ -1,7 +1,7 @@
 name: Issue / PR hygiene
 
 # Thin trigger: fires on PR/issue events and delegates to the canonical
-# reusable workflow at vade-app/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml.
+# reusable workflow at coo-labs/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml.
 #
 # Centralization: vade-coo-memory#939 (F7), absorbs vade-coo-memory#767.
 # Per-repo behavior is one input: `pattern-b-mode`.
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   hygiene:
-    uses: vade-app/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml@main
+    uses: coo-labs/vade-runtime/.github/workflows/issue-pr-hygiene-reusable.yml@main
     with:
       pattern-b-mode: advisory
     secrets: inherit


### PR DESCRIPTION
## Summary
- Mechanical sed in `.github/workflows/*.yml` flipping `uses: vade-app/vade-runtime/...` → `uses: coo-labs/vade-runtime/...`
- F7 centralized reusables live in `coo-labs/vade-runtime`; GitHub does not redirect `uses:` paths after org rename
- Refs: [vade-coo-memory#951](https://github.com/vade-app/vade-coo-memory/issues/951) Section A

## Test plan
- [x] grep verifies zero remaining `vade-app/vade-runtime` refs in workflows dir
- [ ] CI passes (workflow load succeeds → ref resolves)
- [ ] Auto-merge on green

Closes: n/a

https://claude.ai/code/session_018xANPgimZf9xj4p6WRWkUB