### PR TITLE
sync(templates): align with coo-harness canonical post-F13a

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -13,8 +13,8 @@ body:
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
         Native sub-issue linkage is **required** for Epic-type issues per
-        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/vade-coo-memory/blob/main/coo/operations/issue-pr-hygiene.md)
-        + [`coo/label_taxonomy.md`](https://github.com/coo-labs/vade-coo-memory/blob/main/coo/label_taxonomy.md) §6 —
+        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-pr-hygiene.md)
+        + [`coo/label_taxonomy.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/label_taxonomy.md) §6 —
         markdown checklists of `#N` references in the epic body are insufficient
         because they're invisible to GraphQL queries and the project board's
         tracker UI.
@@ -76,7 +76,7 @@ body:
         form `coo-labs/<repo>#N` for cross-repo references (NEVER bare `#N` —
         that autolinks to the wrong issue).
       placeholder: |
-        - coo-labs/vade-runtime#NNN — describe dependency
+        - coo-labs/coo-harness#NNN — describe dependency
         - coo-labs/vade-canvas#NNN — describe dependency
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -14,7 +14,7 @@ body:
 
         Native-field widgets at the bottom (Priority, Readiness) are
         bridged to the issue's native fields by a workflow on creation.
-        See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/vade-coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
+        See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
 
   - type: textarea
     id: summary


### PR DESCRIPTION
## Summary

Supersedes #259 (sync PR that conflicted with F13a's partial epic.yml edit and stalled on the same coo-labs/coo-harness#326 token issue as the other 7 consumers).

Takes canonical content from `coo-labs/coo-harness/.github/ISSUE_TEMPLATE/` directly:

- `epic.yml`: 4 lines (vade-coo-memory URL fields × 2 + vade-runtime ref)
- `task.yml`: 1 line (vade-coo-memory URL field)

F13a (#258) updated some refs (vade-core → vade-canvas) but missed these. The F11 source-side sync detected the diff and opened #259, but #259 conflicted with the merged F13a state.

## Test plan

- [ ] Diff against `coo-labs/coo-harness/.github/ISSUE_TEMPLATE/epic.yml` and `task.yml` is empty after merge

Surfaces step 13 (last remaining stale consumer) of the F10-F13 rename-wave fresh-build verification. Supersedes #259.

Closes: n/a — verification-cleanup follow-up, no tracked issue.

https://claude.ai/code/session_01Y3Tmx5L4cckhe1MqAjzHoi