### PR TITLE
skills: backfill metadata: blocks per agentskills.io spec

### DIFF
--- a/.claude/skills/canvas-ui/SKILL.md
+++ b/.claude/skills/canvas-ui/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: canvas-ui
 description: Apply vade-core's canvas/tldraw frontend conventions and avoid the recurring landmines we've already learned about. Use this skill whenever you're working in vade-core on anything that touches the canvas — adding or modifying a custom shape under `src/shapes/`, wiring UI through `src/shell/AppShell.tsx`, mutating shapes through the MCP bridge in `src/bridge/`, the `vade-asset-store`, snapshot persistence, the library/catalog/shape-panel surfaces, or anywhere else `tldraw` or `@tldraw/*` is imported. Trigger even when the prompt only mentions "the canvas," "a shape," "AppShell," "persistenceKey," "asset store," "TLAssetStore," "ShapeUtil," "BindingUtil," "snapshot," "the editor," or "tldraw" without naming the skill — and especially trigger before opening a PR that changes any tldraw-touching file. This skill is the anti-patterns and conventions layer; for SDK reference / doc URLs, also consult the `tldraw-docs` skill (the two compose).
+metadata:
+  type: reference
+  vendoring: custom
 ---
 
 # canvas-ui

--- a/.claude/skills/tldraw-docs/SKILL.md
+++ b/.claude/skills/tldraw-docs/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: tldraw-docs
 description: Navigate the tldraw SDK documentation efficiently. Use this skill whenever a task involves the tldraw canvas SDK — including the Editor class, shape utils, custom shapes, bindings, tools, persistence, side effects, the store/signals system, sync, UI components, or any tldraw.dev reference. This includes any work in the vade-core repo, which is built on tldraw. tldraw publishes LLM-optimized markdown bundles at tldraw.dev/llms*.txt plus markdown-ready individual pages; this skill teaches which bundle to fetch and how to navigate so agents don't hallucinate API signatures, grab the full mega-bundle when a narrow fetch would do, or guess at topic names that don't exist. Trigger whenever the user mentions tldraw, canvas shapes, ShapeUtil, BindingUtil, tldraw editor, custom tool, snapshot, or is clearly working in a tldraw-based codebase even if they don't name "tldraw" explicitly.
+metadata:
+  type: documentation
+  vendoring: custom
 ---
 
 # tldraw-docs


### PR DESCRIPTION
Closes #264.

## Summary

Add a top-level \`metadata:\` block to each SKILL.md in this repo declaring
\`type\` and \`vendoring\` per the
[agentskills.io open standard](https://agentskills.io/specification) — the
standardized extension surface Claude Code defers to. The
\`coo-labs/skills\` inventory tool now reads declared metadata instead of
falling back to name/description heuristics.

Files patched (2):
- \`.claude/skills/canvas-ui/SKILL.md\`  → \`type: reference\`, \`vendoring: custom\`
- \`.claude/skills/tldraw-docs/SKILL.md\` → \`type: documentation\`, \`vendoring: custom\`

Existing frontmatter preserved exactly; the new block is inserted before
the closing \`---\`. Idempotent.

Generated by \`coo-labs/skills/tools/backfill-metadata.py\`.

## Test plan

- [x] Both files' YAML parses cleanly via \`yaml.safe_load\`
- [x] Cross-repo inventory shows \`type_source: declared\` and \`vendoring_source: declared\` for both entries

https://claude.ai/code/session_01U4Jp6cYD9dM16rDRT5q359