### PR TITLE
Cleanup coo-labs/coo-memory#1120 stale coo/X/ refs (vade-canvas)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-  Issue / PR hygiene checklist (Patterns A–D from coo/operations/issue-pr-hygiene.md).
+  Issue / PR hygiene checklist (Patterns A–D from operations/issue-pr-hygiene.md).
   The hygiene workflow validates this body on PR open/sync. Pattern B (closing
   keywords) is advisory in this repo (BLOCKING in coo-labs/coo-memory only,
   pending betterment-cadence promotion per briefing-014); A/C/D are advisory.
@@ -19,7 +19,7 @@
        Closes: n/a                         (no issue resolved)
 
      NEVER use `Closes coo-memory#N` (no `coo-labs/` prefix) — it
-     autolinks but does NOT auto-close. See coo/operations/issue-pr-hygiene.md.
+     autolinks but does NOT auto-close. See operations/issue-pr-hygiene.md.
 
      For multiple issues, ONE `Closes` LINE PER ISSUE — comma-lists
      silently fail (only the first ref auto-closes):


### PR DESCRIPTION
## Summary

Per-repo sweep of stale `coo/X/` path references for the cross-repo
wrapper-drop cleanup. Applies coo-labs/coo-memory#1120's manifest
([`bin/manifests/coo-wrapper.yaml`](https://github.com/coo-labs/coo-memory/blob/main/bin/manifests/coo-wrapper.yaml))
via the migration-sweep tool: mechanical prefix rewrites of
`coo/X/` → `X/` (directory promotions) and `coo/X.md` →
`identity/` or `operations/` (boot-promoted single-file moves).



## Scope-discipline

* `.github/workflows/*.yml` intentionally NOT modified — the COO PAT
  lacks workflow scope; the same residual class as F9, tracked under
  coo-labs/coo-memory#1114.
* `.github/ISSUE_TEMPLATE/*.yml` not edited here — those are synced
  from coo-labs/coo-harness via `sync-issue-templates.yml`; updating
  the canonical (coo-harness) propagates on its PR's merge.

Part of the 9-PR arc closing coo-labs/coo-memory#1120; the
issue-closing PR is coo-labs/coo-memory#1124 (where the manifest
lives).

Closes: n/a

https://claude.ai/code/session_01Msos7DB8mpqiGjgWAymzC4