### PR TITLE
sync(templates): auto-sync from canonical

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -13,7 +13,7 @@ body:
         each child issue (or use the GraphQL `addSubIssue` mutation).
 
         Native sub-issue linkage is **required** for Epic-type issues per
-        [`coo/operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-pr-hygiene.md) —
+        [`operations/issue-pr-hygiene.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-pr-hygiene.md) —
         markdown checklists of `#N` references in the epic body are insufficient
         because they're invisible to GraphQL queries and the project board's
         tracker UI.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -14,7 +14,7 @@ body:
 
         Native-field widgets at the bottom (Priority, Readiness) are
         bridged to the issue's native fields by a workflow on creation.
-        See [`coo/operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/coo/operations/issue-fields-and-types.md).
+        See [`operations/issue-fields-and-types.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/issue-fields-and-types.md).
 
   - type: textarea
     id: summary


### PR DESCRIPTION
Auto-synced from `coo-labs/coo-harness` canonical issue templates (F8).

**Edit the canonical**, not this PR: [`coo-harness/.github/ISSUE_TEMPLATE/`](https://github.com/coo-labs/coo-harness/tree/main/.github/ISSUE_TEMPLATE). Changes there auto-propagate here on next push to `main`.

- Canonical issue: [coo-memory#938](https://github.com/coo-labs/coo-memory/issues/938)
- Operations doc: [`operations/template-centralization.md`](https://github.com/coo-labs/coo-memory/blob/main/operations/template-centralization.md)
- Sync mechanism: [`coo-harness/scripts/sync-templates-to-consumers.sh`](https://github.com/coo-labs/coo-harness/blob/main/scripts/sync-templates-to-consumers.sh)

Orphan deletion is in effect — files deleted from the canonical are deleted here too.