### PR TITLE
fix: correct stale refs in CLAUDE.md + workflows (F40-F44; Worker names preserved)

### DIFF
--- a/.github/workflows/auto-merge-sync-pr.yml
+++ b/.github/workflows/auto-merge-sync-pr.yml
@@ -7,7 +7,7 @@ name: Auto-merge sync PR
 # (coo-memory#939).
 #
 # Canonical reusable: coo-labs/coo-harness/.github/workflows/auto-merge-sync-pr-reusable.yml
-# Ops doc row: vade-coo-memory/coo/operations/workflow-centralization.md.
+# Ops doc row: coo-memory/operations/workflow-centralization.md.
 
 on:
   pull_request:

--- a/.github/workflows/bridge-form-fields-trigger.yml
+++ b/.github/workflows/bridge-form-fields-trigger.yml
@@ -4,10 +4,10 @@ name: Bridge issue-form widgets to native fields (trigger)
 # coo-labs/coo-harness/.github/workflows/bridge-form-fields-to-natives.yml
 # whenever an issue is opened in this repository.
 #
-# This file is hand-mirrored across vade-coo-memory / vade-runtime /
-# vade-canvas / vade-agent-logs. Edit canonical in vade-coo-memory and
+# This file is hand-mirrored across coo-memory / coo-harness /
+# vade-canvas / coo-logs. Edit canonical in coo-memory and
 # port to siblings (workflow-sync convention; see
-# coo/operations/issue-pr-hygiene.md).
+# operations/issue-pr-hygiene.md).
 #
 # Bridge design + script source: coo-labs/coo-harness#TBD.
 # Stage 2 design: coo-labs/coo-memory#811.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Claude Code on the web sessions push through a scoped-down git
 proxy. Two failure shapes recur:
 
 - **Proxy-class 403** (intermittent, often on the second push of a
-  session). `vade-runtime/scripts/git-shim.sh` +
+  session). `coo-harness/scripts/git-shim.sh` +
   `git-push-with-fallback.sh` handle this automatically — they
   retry once via the direct github.com URL with the PAT selected
   by remote owner (`GITHUB_MCP_PAT` for `coo-labs/*`,
@@ -115,7 +115,7 @@ proxy. Two failure shapes recur:
   session to their local Claude Code and finish the push from there
   — typically with `git push git@github.com:OWNER/REPO.git BRANCH`.
   SSH key auth bypasses the OAuth-app scope restriction entirely.
-  The unblock for vade-core PR #49 (workflow files) on 2026-04-20
+  The unblock for vade-canvas#49 (workflow files) on 2026-04-20
   is the canonical example.
 
 ## Current state


### PR DESCRIPTION
## Substrate drift audit — vade-canvas fixes

Per-line judgment heavy: most `vade-core` refs in this repo are Worker names (not repo refs) and stay. Three actionable fixes.

## CLAUDE.md (2 real fixes)

- L103: `vade-runtime/scripts/git-shim.sh` → `coo-harness/scripts/git-shim.sh`
- L118: `vade-core PR #49` → `vade-canvas#49` (cross-repo autolink form; GitHub redirect resolves either form)

## Intentional KEEPs (briefing 038 KEEP list — Worker names + historical rename-redirect docs)

These refs are NOT drift:
- CLAUDE.md L180 / README.md L120 / docs/auth.md L6 — Worker (`vade-core`, name unchanged) — Cloudflare Worker binding is immutable
- README.md L68 / L77 — `vade-core-preview` Worker (same rationale)
- README.md L80 — historical rename-redirect documentation note
- docs/auth.md L28 — comment "Worker (vade-core; run from this repo)"
- docs/auth.md L222, L224, L260, L263, L266, L271 — all `vade-core[-preview]` Worker names

## Workflows (5 fixes across 2 files)

### `bridge-form-fields-trigger.yml`

Hand-mirror list update + flatten retired `coo/` subdir prefix:
- L7-8: `vade-coo-memory / vade-runtime` → `coo-memory / coo-harness`; `vade-canvas / vade-agent-logs` → `vade-canvas / coo-logs`
- L8: `canonical in vade-coo-memory` → `canonical in coo-memory`
- L10: `coo/operations/issue-pr-hygiene` → `operations/issue-pr-hygiene`

### `auto-merge-sync-pr.yml`

- L10: same sync-pattern as coo4one#19, site#20, coo-logs#612, tjsonl#35, coo-console#30

## Three-commit pattern

CLAUDE.md via git push; workflows via API PUT (workflow scope wall).

## References

- coo-labs/coo-memory#1212 — audit record (F40-F44)
- MEMO-2026-05-12-22m9 — referenced in CLAUDE.md L107 (still current)
- MEMO-2026-05-24-q3tk — org/repo rename
- briefing 038 — KEEP list (vade-core Worker name carve-out)

Closes: n/a

https://claude.ai/code/session_017hSom1HxwbstPu9qBNwZSQ