### PR TITLE
coo-on-assign: flip thin trigger from assigned to field_added (PR3/4)

### DIFF
--- a/.github/workflows/coo-on-assign.yml
+++ b/.github/workflows/coo-on-assign.yml
@@ -1,18 +1,25 @@
 name: COO on issue assign
 
-# Thin trigger: fires on `issues.assigned` and delegates to the canonical
+# Thin trigger: fires on `issues.field_added` and delegates to the canonical
 # reusable workflow at coo-labs/coo-harness/.github/workflows/coo-on-assign-reusable.yml.
+# The reusable's gate filters down to the Readiness=Assigned transition;
+# field_added itself fires on ANY field value being set, so the wide trigger
+# is correct and the narrow filtering happens reusable-side.
 #
 # Centralization: coo-memory#939 (F7). Logic + COO_SCOPE_REPOS list
 # lives in the reusable; this file only carries the event trigger and
 # the per-repo opt-in. To opt OUT, delete this file.
 #
-# Trigger:   gh issue edit <n> --add-assignee vade-coo
-# Suppress:  gh issue edit <n> --remove-assignee vade-coo
+# Trigger:   gh api -X POST repos/<o>/<r>/issues/<n>/issue-field-values
+#            with [{"field_id":42387399,"value":"Assigned"}]  (Readiness)
+# Suppress:  set the field back to Ready (or any other value)
+#
+# Idempotency: none by design — every Readiness=Assigned transition posts
+# a fresh comment. Re-setting the field is the explicit re-launch primitive.
 
 on:
   issues:
-    types: [assigned]
+    types: [field_added]
 
 permissions:
   issues: write


### PR DESCRIPTION
PR3 of the 4-PR series rewiring the `coo-on-assign` workflow trigger from `issues.assigned` (assignee picker) to `issues.field_added` (Readiness field).

Mechanical thin-trigger flip — identical edit applied to this repo's `.github/workflows/coo-on-assign.yml`. The canonical reusable in [coo-harness](https://github.com/coo-labs/coo-harness/blob/main/.github/workflows/coo-on-assign-reusable.yml) was rewired in PR2 with a dual gate (assignee OR Readiness=Assigned) precisely so this rollout could be repo-by-repo without breaking the launch-link comment on assignment in the unflipped repos.

## What changed

`.github/workflows/coo-on-assign.yml`:

- `on: issues: types: [assigned]` → `on: issues: types: [field_added]`.
- Header comment refreshed: new Trigger / Suppress recipes reference the issue-field-values REST endpoint instead of `gh issue edit --add-assignee`.
- File content now matches the canonical post-rewire template; all 8 PR3 repos receive the identical edit.

## Why this is safe to merge

The dual gate in the reusable (shipped in [coo-harness#570](https://github.com/coo-labs/coo-harness/pull/570)) means:

- **After this PR merges**: setting `Readiness: Assigned` on a `<this repo>` issue fires field_added → reusable matches the second clause → comment posts.
- **Pre-merge** (current state): assigning vade-coo on a `<this repo>` issue still fires issues.assigned → reusable matches the first clause → comment posts. Nothing was broken during the window.

After all 8 PR3 PRs merge, PR4 strips the legacy assignee clause from the reusable.

## Canary evidence (already verified on coo-harness)

PR2's flip was canary-tested on [coo-harness#552](https://github.com/coo-labs/coo-harness/issues/552):
- Readiness=Assigned → run [`27091745002`](https://github.com/coo-labs/coo-harness/actions/runs/27091745002) success, comment posted.
- Readiness flipped back to Ready → run [`27091762331`](https://github.com/coo-labs/coo-harness/actions/runs/27091762331) skipped (gate filtered correctly).

## Series outline (recap)

- ✅ PR1 ([coo-memory#1326](https://github.com/coo-labs/coo-memory/pull/1326)) — Readiness field gains `Assigned` option.
- ✅ PR2 ([coo-harness#570](https://github.com/coo-labs/coo-harness/pull/570)) — Reusable dual gate + coo-harness canary.
- 🟢 PR3 (this PR, one of 8) — Flip remaining consumer thin trigger.
- ⏳ PR4 — Strip the legacy assignee clause from the reusable.

Closes n/a (in-flight design from this session; no separate tracker filed).

Closes: n/a

https://claude.ai/code/session_015io8MjjJ2eF2i3GiZz6MnM